### PR TITLE
feat(m8-batch3): marketplace cluster — 6 commands + 10 tests

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"3f6989f7-a511-4759-95d7-6d6161cb734f","pid":87401,"procStart":"Tue Apr 28 23:03:40 2026","acquiredAt":1777419289236}
+{"sessionId":"3f6989f7-a511-4759-95d7-6d6161cb734f","pid":99843,"procStart":"Wed Apr 29 10:15:24 2026","acquiredAt":1777457809027}

--- a/src/cli/commands/marketplace.ts
+++ b/src/cli/commands/marketplace.ts
@@ -1,0 +1,536 @@
+/**
+ * marketplace.ts — Marketplace cluster (T4.7.2 batch 3).
+ *
+ * Ports the following bin/cli.js subcommands into citty `defineCommand`s:
+ *   - install            (lib-ts: install + searchItems + fetchRegistryIndex
+ *                          + normalizeItemId + detectIDE)
+ *   - uninstall          (lib-ts: uninstallItem + normalizeItemId)
+ *   - status             (lib-ts: getStatus — the marketplace-status branch
+ *                          batch 2 deliberately skipped, see lifecycle.ts)
+ *   - integrate          (lib-ts: applyIntegration + cleanIntegration +
+ *                          readIntegrationLog)
+ *   - update             (lib-ts: updateItems + checkUpdates +
+ *                          fetchRegistryIndex + normalizeItemId)
+ *   - upgrade            (lib-ts: upgrade + restore + listUpgradeBackups)
+ *
+ * Pattern: each leaf command is a `defineCommand` exported as
+ * `<name>Command`. Pure logic lives in `<name>Impl(deps, args)`. All
+ * lib-ts imports are TOP-LEVEL ES imports — the inline-`require`
+ * pattern from earlier batches (spec-validation.ts, handoff.ts) silently
+ * dies at runtime when the lib-ts file is .ts-only. lifecycle.ts is the
+ * canonical example.
+ *
+ * **No `registry` subcommand**: the spec called for one but `bin/cli.js`
+ * has no `subcommand === 'registry'` branch. Skipped — the registry
+ * functions in `bin/lib-ts/registry.ts` are invoked indirectly via
+ * `validate-module` (already in spec-validation.ts batch 1).
+ *
+ * @see bin/cli.js (lines 1350-1732 — legacy reference)
+ * @see bin/lib-ts/install.ts (install/uninstallItem/getStatus/checkUpdates/...)
+ * @see bin/lib-ts/integrate.ts (applyIntegration/cleanIntegration/readIntegrationLog)
+ * @see bin/lib-ts/upgrade.ts  (upgrade/restore/listUpgradeBackups)
+ * @see specs/implementation-plan.md T4.7.2
+ */
+
+import { defineCommand } from 'citty';
+import {
+  checkUpdates,
+  detectIDE,
+  fetchRegistryIndex,
+  getStatus,
+  install,
+  normalizeItemId,
+  searchItems,
+  uninstallItem,
+  updateItems,
+} from '../../../bin/lib-ts/install.js';
+import {
+  applyIntegration,
+  cleanIntegration,
+  readIntegrationLog,
+} from '../../../bin/lib-ts/integrate.js';
+import { listUpgradeBackups, restore, upgrade } from '../../../bin/lib-ts/upgrade.js';
+import { type CommandResult, createRealDeps, type Deps } from '../deps.js';
+
+// ─────────────────────────────────────────────────────────────────────────
+// install
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface InstallArgs {
+  /** Either a fully-qualified id like `skill.ignition`, OR the
+   *  category half of a `<type> <name>` invocation. */
+  itemId?: string;
+  /** Optional second positional — when present, combines with `itemId`
+   *  to form `<itemId>.<name>` per `normalizeItemId`. */
+  name?: string;
+  /** `--registry <url>` override. The lib-ts callee runs the URL
+   *  through its internal `validateMarketplaceUrl`, so we don't have
+   *  to gate it here. */
+  registry?: string;
+  /** `--search <query>` switches the command into search mode. */
+  search?: string;
+  /** `--dry-run` — preview without writing. */
+  dryRun?: boolean;
+  /** `--force` — re-install even if already present. */
+  force?: boolean;
+}
+
+export async function installImpl(deps: Deps, args: InstallArgs): Promise<CommandResult> {
+  // Search mode short-circuits positional parsing.
+  if (args.search !== undefined) {
+    try {
+      const index = await fetchRegistryIndex(args.registry);
+      const results = searchItems(index, args.search);
+      if (results.length === 0) {
+        deps.logger.warn(`No items found matching "${args.search}".`);
+      } else {
+        deps.logger.info(`Found ${results.length} item(s):`);
+        for (const r of results) {
+          deps.logger.info(`  ${r.id} — ${r.displayName} [${r.category}] (${r.version})`);
+          if (r.description) deps.logger.info(`    ${r.description}`);
+        }
+      }
+      return { exitCode: 0 };
+    } catch (err) {
+      deps.logger.error(`Search failed: ${(err as Error).message}`);
+      return { exitCode: 1, message: (err as Error).message };
+    }
+  }
+
+  if (!args.itemId) {
+    deps.logger.error('Usage: jumpstart-mode install <item-id> [options]');
+    deps.logger.error('       jumpstart-mode install <type> <name> [options]');
+    deps.logger.error('       jumpstart-mode install --search <query>');
+    return { exitCode: 1 };
+  }
+
+  const itemId = normalizeItemId(args.itemId, args.name);
+  if (!itemId) {
+    deps.logger.error(
+      `Cannot resolve item from "${args.itemId}". Try: jumpstart-mode install --search ${args.itemId}`
+    );
+    return { exitCode: 1 };
+  }
+
+  try {
+    const ide = detectIDE(deps.projectRoot);
+    if (args.dryRun) {
+      deps.logger.info(`[dry-run] Would install ${itemId}`);
+      deps.logger.info(`  IDE detected: ${ide.ide}`);
+      deps.logger.info(`  Agents → ${ide.agentDir}/`);
+      deps.logger.info(`  Prompts → ${ide.promptDir}/`);
+    }
+
+    deps.logger.info(`Installing ${itemId}...`);
+    const result = await install(itemId, {
+      registryUrl: args.registry,
+      projectRoot: deps.projectRoot,
+      force: Boolean(args.force),
+      dryRun: Boolean(args.dryRun),
+      onProgress: (msg) => deps.logger.info(msg),
+    });
+
+    if ('bundleId' in result) {
+      deps.logger.success(`Bundle ${result.bundleId} installed:`);
+      for (const r of result.installed) {
+        if ('error' in r) {
+          deps.logger.error(`  ${r.item.id}: ${r.error}`);
+        } else {
+          deps.logger.success(`  ${r.item.id} → ${(r.installed || []).join(', ')}`);
+          if (r.remappedFiles && r.remappedFiles.length > 0) {
+            deps.logger.info(`    Remapped: ${r.remappedFiles.join(', ')}`);
+          }
+        }
+      }
+    } else if (result.skipped) {
+      deps.logger.warn(`${result.item.id} v${result.item.version} already installed.`);
+    } else {
+      deps.logger.success(`${result.item.id} v${result.item.version} installed`);
+      deps.logger.info(`  Location: ${(result.installed || []).join(', ')}`);
+      deps.logger.info(`  Files: ${result.fileCount}`);
+      deps.logger.info(`  IDE: ${result.ide || 'unknown'}`);
+      if (result.remappedFiles && result.remappedFiles.length > 0) {
+        deps.logger.info(`  Remapped: ${result.remappedFiles.join(', ')}`);
+      }
+      if (result.dependenciesInstalled && result.dependenciesInstalled.length > 0) {
+        deps.logger.info(`  Dependencies: ${result.dependenciesInstalled.join(', ')}`);
+      }
+    }
+    return { exitCode: 0 };
+  } catch (err) {
+    deps.logger.error(`Install failed: ${(err as Error).message}`);
+    return { exitCode: 1, message: (err as Error).message };
+  }
+}
+
+export const installCommand = defineCommand({
+  meta: { name: 'install', description: 'Install a marketplace item (skill/agent/prompt/bundle)' },
+  args: {
+    itemId: {
+      type: 'positional',
+      description: 'Item id (e.g. skill.ignition) or category (with name)',
+      required: false,
+    },
+    name: {
+      type: 'positional',
+      description: 'Item name (when itemId is the category)',
+      required: false,
+    },
+    registry: { type: 'string', description: 'Registry URL override', required: false },
+    search: { type: 'string', description: 'Search registry for matching items', required: false },
+    'dry-run': { type: 'boolean', description: 'Preview without writing', required: false },
+    force: { type: 'boolean', description: 'Re-install even if present', required: false },
+  },
+  async run({ args }) {
+    const r = await installImpl(createRealDeps(), {
+      itemId: args.itemId,
+      name: args.name,
+      registry: args.registry,
+      search: args.search,
+      dryRun: Boolean(args['dry-run']),
+      force: Boolean(args.force),
+    });
+    if (r.exitCode !== 0) throw new Error(r.message ?? 'install failed');
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// uninstall
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface UninstallArgs {
+  itemId?: string;
+  name?: string;
+}
+
+export function uninstallImpl(deps: Deps, args: UninstallArgs): CommandResult {
+  if (!args.itemId) {
+    deps.logger.error('Usage: jumpstart-mode uninstall <item-id>');
+    deps.logger.error('       jumpstart-mode uninstall <type> <name>');
+    return { exitCode: 1 };
+  }
+  const itemId = normalizeItemId(args.itemId, args.name);
+  if (!itemId) {
+    deps.logger.error(`Cannot resolve item from "${args.itemId}".`);
+    return { exitCode: 1 };
+  }
+  try {
+    const result = uninstallItem(itemId, deps.projectRoot);
+    deps.logger.success(`Uninstalled ${itemId}`);
+    if (result.removed.length > 0) {
+      deps.logger.info(`  Removed: ${result.removed.join(', ')}`);
+    }
+    return { exitCode: 0 };
+  } catch (err) {
+    deps.logger.error(`Uninstall failed: ${(err as Error).message}`);
+    return { exitCode: 1, message: (err as Error).message };
+  }
+}
+
+export const uninstallCommand = defineCommand({
+  meta: { name: 'uninstall', description: 'Uninstall a marketplace item' },
+  args: {
+    itemId: { type: 'positional', description: 'Item id or category', required: false },
+    name: { type: 'positional', description: 'Item name (with category)', required: false },
+  },
+  run({ args }) {
+    const r = uninstallImpl(createRealDeps(), { itemId: args.itemId, name: args.name });
+    if (r.exitCode !== 0) throw new Error(r.message ?? 'uninstall failed');
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// status — marketplace status (the one batch 2 skipped)
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface StatusArgs {
+  // No args today; reserved for future filters (e.g. --type=skill).
+  _placeholder?: never;
+}
+
+export function statusImpl(deps: Deps, _args: StatusArgs): CommandResult {
+  const status = getStatus(deps.projectRoot);
+
+  if (status.count === 0) {
+    deps.logger.warn('No marketplace items installed.');
+    deps.logger.info('Install with: jumpstart-mode install skill ignition');
+    return { exitCode: 0 };
+  }
+
+  deps.logger.info(`${status.count} marketplace item(s) installed:`);
+  for (const [id, entry] of Object.entries(status.items)) {
+    const typeLabel = (entry.type ?? 'item').padEnd(6);
+    deps.logger.info(`  ${typeLabel} ${id} v${entry.version}`);
+    deps.logger.info(`         Installed: ${entry.installedAt}`);
+    if (entry.remappedFiles && entry.remappedFiles.length > 0) {
+      deps.logger.info(`         Remapped:  ${entry.remappedFiles.join(', ')}`);
+    }
+  }
+  return { exitCode: 0 };
+}
+
+export const statusCommand = defineCommand({
+  meta: { name: 'status', description: 'List installed marketplace items' },
+  args: {},
+  run() {
+    const r = statusImpl(createRealDeps(), {});
+    if (r.exitCode !== 0) throw new Error(r.message ?? 'status failed');
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// integrate
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface IntegrateArgs {
+  clean?: boolean;
+  status?: boolean;
+}
+
+export function integrateImpl(deps: Deps, args: IntegrateArgs): CommandResult {
+  if (args.status) {
+    const log = readIntegrationLog(deps.projectRoot);
+    const fileCount = Object.keys(log.files || {}).length;
+    const skillCount = Object.keys(log.skillContributions || {}).length;
+    if (fileCount === 0) {
+      deps.logger.warn('No integration files generated.');
+      deps.logger.info('Run: jumpstart-mode integrate');
+      return { exitCode: 0 };
+    }
+    deps.logger.info(`Integration state (${log.generatedAt}):`);
+    deps.logger.info(`  Skills integrated: ${skillCount}`);
+    deps.logger.info(`  Files generated:   ${fileCount}`);
+    for (const [fp, meta] of Object.entries(log.files)) {
+      deps.logger.info(`    ${fp} ${meta.hash.slice(0, 18)}...`);
+    }
+    return { exitCode: 0 };
+  }
+
+  try {
+    if (args.clean) {
+      const { filesRemoved } = cleanIntegration(deps.projectRoot, {
+        onProgress: (m) => deps.logger.info(m),
+      });
+      deps.logger.success(`Clean complete: removed ${filesRemoved.length} file(s).`);
+    } else {
+      const { filesWritten, filesRemoved, skillCount } = applyIntegration(deps.projectRoot, {
+        onProgress: (m) => deps.logger.info(m),
+      });
+      deps.logger.success(
+        `Integration rebuilt: ${skillCount} skill(s), ${filesWritten.length} file(s) generated.`
+      );
+      if (filesRemoved.length > 0) {
+        deps.logger.info(`  Removed ${filesRemoved.length} stale file(s).`);
+      }
+    }
+    return { exitCode: 0 };
+  } catch (err) {
+    deps.logger.error(`Integration failed: ${(err as Error).message}`);
+    return { exitCode: 1, message: (err as Error).message };
+  }
+}
+
+export const integrateCommand = defineCommand({
+  meta: {
+    name: 'integrate',
+    description: 'Rebuild skill integration files from installed skills',
+  },
+  args: {
+    clean: { type: 'boolean', description: 'Remove all integration files', required: false },
+    status: { type: 'boolean', description: 'Show current integration state', required: false },
+  },
+  run({ args }) {
+    const r = integrateImpl(createRealDeps(), {
+      clean: Boolean(args.clean),
+      status: Boolean(args.status),
+    });
+    if (r.exitCode !== 0) throw new Error(r.message ?? 'integrate failed');
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// update
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface UpdateArgs {
+  itemId?: string;
+  name?: string;
+  registry?: string;
+}
+
+export async function updateImpl(deps: Deps, args: UpdateArgs): Promise<CommandResult> {
+  const itemId =
+    args.itemId && !args.itemId.startsWith('--') ? normalizeItemId(args.itemId, args.name) : null;
+
+  try {
+    const index = await fetchRegistryIndex(args.registry);
+    const { updates } = checkUpdates(deps.projectRoot, index);
+
+    if (updates.length === 0) {
+      deps.logger.success('All installed items are up to date.');
+      return { exitCode: 0 };
+    }
+
+    deps.logger.info(`${updates.length} update(s) available:`);
+    for (const u of updates) {
+      deps.logger.info(`  ${u.id}: ${u.localVersion} → ${u.registryVersion}`);
+    }
+
+    const results = await updateItems(itemId, {
+      registryUrl: args.registry,
+      projectRoot: deps.projectRoot,
+      index,
+      onProgress: (msg) => deps.logger.info(msg),
+    });
+
+    deps.logger.success(`Updated ${results.length} item(s).`);
+    return { exitCode: 0 };
+  } catch (err) {
+    deps.logger.error(`Update failed: ${(err as Error).message}`);
+    return { exitCode: 1, message: (err as Error).message };
+  }
+}
+
+export const updateCommand = defineCommand({
+  meta: {
+    name: 'update',
+    description: 'Update installed marketplace items to latest registry version',
+  },
+  args: {
+    itemId: {
+      type: 'positional',
+      description: 'Item id (omit to update all)',
+      required: false,
+    },
+    name: {
+      type: 'positional',
+      description: 'Item name (when itemId is category)',
+      required: false,
+    },
+    registry: { type: 'string', description: 'Registry URL override', required: false },
+  },
+  async run({ args }) {
+    const r = await updateImpl(createRealDeps(), {
+      itemId: args.itemId,
+      name: args.name,
+      registry: args.registry,
+    });
+    if (r.exitCode !== 0) throw new Error(r.message ?? 'update failed');
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// upgrade
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface UpgradeArgs {
+  dryRun?: boolean;
+  yes?: boolean;
+  doRestore?: boolean;
+}
+
+/** Confirmation hook — uses the legacy `prompts` package for parity
+ *  with `bin/cli.js`. Resolves to `false` if prompts isn't available
+ *  (e.g. test environments) so the upgrade aborts cleanly rather than
+ *  hanging. */
+async function defaultConfirm(message: string): Promise<boolean> {
+  try {
+    // Strangler-phase: bare require() is the M4-M8 norm for optional
+    // CJS deps (matches deps.ts, lifecycle.ts). M9 ESM cutover swaps
+    // to dynamic `import()`.
+    const prompts = require('prompts') as (q: {
+      type: string;
+      name: string;
+      message: string;
+      initial?: boolean;
+    }) => Promise<{ confirmed?: boolean }>;
+    const { confirmed } = await prompts({
+      type: 'confirm',
+      name: 'confirmed',
+      message,
+      initial: true,
+    });
+    return Boolean(confirmed);
+  } catch {
+    return false;
+  }
+}
+
+export async function upgradeImpl(deps: Deps, args: UpgradeArgs): Promise<CommandResult> {
+  const dryRun = Boolean(args.dryRun);
+  const yes = Boolean(args.yes);
+
+  // --restore branch
+  if (args.doRestore) {
+    const backups = listUpgradeBackups(deps.projectRoot);
+    if (backups.length === 0) {
+      deps.logger.warn('No upgrade backups found.');
+      return { exitCode: 0 };
+    }
+
+    deps.logger.info(`Upgrade backups (${backups.length} file(s)):`);
+    for (const b of backups) {
+      deps.logger.info(`  ${b.originalPath}`);
+      deps.logger.info(`    Archived: ${b.archivedAt}`);
+      deps.logger.info(`    Upgrade: ${b.fromVersion} → ${b.toVersion}`);
+      deps.logger.info(`    File: ${b.file}`);
+    }
+
+    if (!dryRun) {
+      const confirmed = await defaultConfirm(`Restore all ${backups.length} backed-up file(s)?`);
+      if (!confirmed) {
+        deps.logger.warn('Restore cancelled.');
+        return { exitCode: 0 };
+      }
+    }
+
+    const result = restore(deps.projectRoot, { dryRun });
+    if (!result.success) {
+      // RestoreResult does not currently carry a `message` field; emit
+      // a generic failure note. (The RestoreResult shape exposed by
+      // bin/lib-ts/upgrade.ts is `{ success, restored, skipped }`.)
+      deps.logger.error('Restore failed.');
+      return { exitCode: 1 };
+    }
+    return { exitCode: 0 };
+  }
+
+  // Normal upgrade
+  try {
+    const result = await upgrade(deps.projectRoot, {
+      packageRoot: deps.projectRoot,
+      dryRun,
+      yes,
+      confirm: yes ? undefined : defaultConfirm,
+      log: (msg) => deps.logger.info(msg),
+    });
+
+    if (!result.success) {
+      if (result.message !== 'Cancelled by user.') {
+        deps.logger.error(result.message ?? 'upgrade failed');
+        return { exitCode: 1, message: result.message };
+      }
+    }
+    return { exitCode: 0 };
+  } catch (err) {
+    deps.logger.error(`Upgrade failed: ${(err as Error).message}`);
+    return { exitCode: 1, message: (err as Error).message };
+  }
+}
+
+export const upgradeCommand = defineCommand({
+  meta: { name: 'upgrade', description: 'Safely upgrade framework files' },
+  args: {
+    'dry-run': { type: 'boolean', description: 'Preview without writing', required: false },
+    yes: { type: 'boolean', description: 'Skip confirmation prompt', required: false },
+    restore: { type: 'boolean', description: 'Restore from upgrade backups', required: false },
+  },
+  async run({ args }) {
+    const r = await upgradeImpl(createRealDeps(), {
+      dryRun: Boolean(args['dry-run']),
+      yes: Boolean(args.yes),
+      doRestore: Boolean(args.restore),
+    });
+    if (r.exitCode !== 0) throw new Error(r.message ?? 'upgrade failed');
+  },
+});

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -148,6 +148,14 @@ const subCommands: Record<string, () => Promise<CommandDef>> = {
   rewind: lazy(() => import('./commands/lifecycle.js').then((m) => m.rewindCommand)),
   next: lazy(() => import('./commands/lifecycle.js').then((m) => m.nextCommand)),
   'plan-executor': lazy(() => import('./commands/lifecycle.js').then((m) => m.planExecutorCommand)),
+
+  // Marketplace cluster (T4.7.2 batch 3 — bin/cli.js lines 1350-1732)
+  install: lazy(() => import('./commands/marketplace.js').then((m) => m.installCommand)),
+  uninstall: lazy(() => import('./commands/marketplace.js').then((m) => m.uninstallCommand)),
+  status: lazy(() => import('./commands/marketplace.js').then((m) => m.statusCommand)),
+  integrate: lazy(() => import('./commands/marketplace.js').then((m) => m.integrateCommand)),
+  update: lazy(() => import('./commands/marketplace.js').then((m) => m.updateCommand)),
+  upgrade: lazy(() => import('./commands/marketplace.js').then((m) => m.upgradeCommand)),
 };
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/tests/test-cli-marketplace.test.ts
+++ b/tests/test-cli-marketplace.test.ts
@@ -1,0 +1,94 @@
+/**
+ * test-cli-marketplace.test.ts — T4.7.2 batch 3 (marketplace cluster).
+ *
+ * Smoke + dispatcher coverage for the six `src/cli/commands/marketplace.ts`
+ * commands. Per the seed pattern in `test-cli-lifecycle.test.ts`, this
+ * file only validates:
+ *
+ *   1. Each `<name>Command` has the expected `meta.name`.
+ *   2. Each `<name>Impl(testDeps, {})` returns `exitCode: 1` when called
+ *      with empty/missing-required args (smoke test only — full coverage
+ *      lives with the underlying lib in tests/test-install.test.ts,
+ *      tests/test-integrate.test.ts, tests/test-upgrade.test.ts).
+ *   3. `main.subCommands` exposes the new lazy thunks.
+ *
+ * @see src/cli/commands/marketplace.ts
+ * @see specs/implementation-plan.md T4.7.2
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  installCommand,
+  installImpl,
+  integrateCommand,
+  statusCommand,
+  uninstallCommand,
+  uninstallImpl,
+  updateCommand,
+  upgradeCommand,
+} from '../src/cli/commands/marketplace.js';
+import { createTestDeps } from '../src/cli/deps.js';
+import { main } from '../src/cli/main.js';
+
+// citty's CommandDef is heavily generic-parameterized; we narrow to a
+// minimal "has meta" shape via `unknown` cast for the tabular test.
+async function metaName(cmd: { meta?: unknown }): Promise<string | undefined> {
+  const m = cmd.meta;
+  const resolved =
+    typeof m === 'function'
+      ? await (m as () => Promise<{ name?: string } | undefined>)()
+      : await (m as Promise<{ name?: string } | undefined> | { name?: string } | undefined);
+  return resolved?.name;
+}
+
+describe('marketplace cluster — defineCommand meta.name', () => {
+  const cases: [string, { meta?: unknown }][] = [
+    ['install', installCommand],
+    ['uninstall', uninstallCommand],
+    ['status', statusCommand],
+    ['integrate', integrateCommand],
+    ['update', updateCommand],
+    ['upgrade', upgradeCommand],
+  ];
+  for (const [expected, cmd] of cases) {
+    it(`${expected}Command.meta.name === '${expected}'`, async () => {
+      expect(await metaName(cmd)).toBe(expected);
+    });
+  }
+});
+
+describe('marketplace cluster — Impl missing-required-args smoke', () => {
+  it('installImpl returns exitCode=1 when itemId and search are absent', async () => {
+    const deps = createTestDeps();
+    const r = await installImpl(deps, {});
+    expect(r.exitCode).toBe(1);
+  });
+
+  it('uninstallImpl returns exitCode=1 when itemId is absent', () => {
+    const deps = createTestDeps();
+    const r = uninstallImpl(deps, {});
+    expect(r.exitCode).toBe(1);
+  });
+
+  it('uninstallImpl returns exitCode=1 when itemId cannot be normalized', () => {
+    // Empty string + undefined name → normalizeItemId returns null.
+    const deps = createTestDeps();
+    const r = uninstallImpl(deps, { itemId: '..' });
+    // `..` is rejected by normalizeItemId (see install.ts) → null →
+    // we surface exitCode=1.
+    expect(r.exitCode).toBe(1);
+  });
+});
+
+describe('marketplace cluster — main.subCommands wiring', () => {
+  it('main.subCommands contains every marketplace command name', async () => {
+    const subs =
+      typeof main.subCommands === 'function' ? await main.subCommands() : await main.subCommands;
+    expect(subs).toBeDefined();
+    if (!subs) return;
+    const expected = ['install', 'uninstall', 'status', 'integrate', 'update', 'upgrade'];
+    for (const name of expected) {
+      expect(name in subs).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Refs #16

## Summary
Marketplace cluster: install, uninstall, status, integrate, update, upgrade.

Skipped: `registry` — no `subcommand === 'registry'` branch in bin/cli.js (registry functions reach via validate-module from batch 1).

## Verification
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean
- [x] `npx vitest run` — 3114 tests pass (was 3104, +10)
- [x] `node scripts/verify-baseline.mjs` — 12/12 PASS

## Pattern
Top-level ES imports per lifecycle.ts canonical (avoids inline-require footgun from batches 1).

## Deviations
- chalk colors → deps.logger
- `process.exit` → CommandResult{exitCode} per ADR-006
- `--search` simplified to string flag

Remaining for #16: 105 of 147 commands across ~7 cluster files.