### PR TITLE
docs(m11): T6.9 L3 component diagrams for CLI Dispatcher + Core Lib

### DIFF
--- a/bin/verify-diagrams.js
+++ b/bin/verify-diagrams.js
@@ -168,7 +168,7 @@ const C4_FUNCTIONS = [
   'Container', 'Container_Ext', 'ContainerDb', 'ContainerDb_Ext', 'ContainerQueue', 'ContainerQueue_Ext',
   'Component', 'Component_Ext', 'ComponentDb', 'ComponentDb_Ext', 'ComponentQueue', 'ComponentQueue_Ext',
   // Boundaries
-  'Boundary', 'Enterprise_Boundary', 'System_Boundary', 'Container_Boundary',
+  'Boundary', 'Enterprise_Boundary', 'System_Boundary', 'Container_Boundary', 'Component_Boundary',
   // Relationships
   'Rel', 'Rel_Back', 'Rel_Neighbor', 'Rel_Back_Neighbor',
   'Rel_D', 'Rel_Down', 'Rel_U', 'Rel_Up', 'Rel_L', 'Rel_Left', 'Rel_R', 'Rel_Right',

--- a/specs/architecture-l3-cli-dispatcher.md
+++ b/specs/architecture-l3-cli-dispatcher.md
@@ -1,0 +1,106 @@
+# Level-3 Component Diagram — CLI Dispatcher
+
+**Container under decomposition:** `CLI Dispatcher` (from `specs/architecture.md` §Component Interaction Diagram, Level 2).
+
+**Source tree:** `src/cli/`
+
+This diagram lists the components inside the `CLI Dispatcher` container and their relationships at strict-C4 Level 3 — the granularity the implementation plan's sprint allocation reasons about. The Level-2 diagram in `architecture.md` rendered `Deps Injection Seam` and `Error Hierarchy` as containers for narrative convenience; here they appear as components nested inside the CLI Dispatcher boundary, which is their actual scope.
+
+> **Turn-2 commitment.** This file fulfills the Architect Turn-2 promise (`architecture.md` §Component Interaction Diagram diagram-level note: *"a separate Level-3 Component Diagram per container WILL be produced in Turn 2 for at least `CLI Dispatcher` and `Core Lib`"*). The companion file is [`architecture-l3-core-lib.md`](./architecture-l3-core-lib.md). Implementation tracker: T6.9.
+
+## Diagram
+
+```mermaid
+C4Component
+    title Component Diagram — CLI Dispatcher (src/cli/)
+
+    Person(dev, "Developer", "Runs jumpstart-mode <subcommand>")
+    Person(aiAgent, "AI Coding Assistant", "Spawns the CLI as a subprocess for tool calls")
+
+    Container_Boundary(cli, "CLI Dispatcher (src/cli/)") {
+        Component(bin, "bin.ts", "TypeScript / ESM entry", "npm-bin entry point. Carries the shebang. Awaits runMain() and translates JumpstartError subclasses to exit codes via redactSecrets-wrapped stderr (ADR-006 + ADR-012). One of two allowlisted process.exit sites.")
+        Component(main, "main.ts", "TypeScript / citty", "Root citty defineCommand. Owns the lazy subCommands map (147 entries → 14 cluster modules). Reads FRAMEWORK_VERSION from package.json via createRequire(import.meta.url).")
+        Component(deps, "deps.ts", "TypeScript", "Deps injection seam. Exports createRealDeps() and createTestDeps(). The CliProcess shape deliberately omits `exit` so commands cannot bypass the bin.ts catch.")
+
+        Component_Boundary(commands, "commands/ (14 cluster files, 147 leaf commands)") {
+            Component(specVal, "spec-validation.ts", "12 commands", "validate, spec-drift, hash, graph, simplicity, scan-wrappers, invariants, template-check, freshness-audit, shard, checklist, smells")
+            Component(handoff, "handoff.ts", "12 commands", "handoff-check, coverage, consistency, lint, contracts, regulatory, boundaries, task-deps, diff (async), modules, validate-module, handoff")
+            Component(lifecycle, "lifecycle.ts", "11 commands", "approve, reject, checkpoint, agent-checkpoint, focus, …")
+            Component(cleanup, "cleanup.ts", "57 commands", "Largest cluster — adr (async), revert (async), timestamp, semantic-diff, sla-slo, … built via thinWrapper factory.")
+            Component(otherClusters, "10 other clusters", "marketplace · runners · spec-quality · llm · governance · collaboration · enterprise · deferred · version-tag · _helpers")
+            Component(helpers, "_helpers.ts", "TypeScript", "Shared utilities: legacyRequire (sync, .js only), legacyImport (async, tries .mjs then .js), safeJoin (assertInsideRoot-gated), assertUserPath (path-safety boundary). PACKAGE_ROOT anchored at fileURLToPath(import.meta.url) — NOT cwd (post-M9 Pit Crew B3 fix).")
+        }
+    }
+
+    Container_Boundary(libCore, "Core Lib (src/lib/)") {
+        Component(errors, "errors.ts", "JumpstartError hierarchy", "Base + ValidationError(2) + LLMError(3). Throw site for every command failure mode.")
+        Component(secretScanner, "secret-scanner.ts", "redactSecrets()", "Imported by bin.ts to scrub stderr lines before emit (ADR-012).")
+        Component(libModules, "*.ts", "111 leaf modules", "Domain logic — see architecture-l3-core-lib.md for the L3 decomposition.")
+    }
+
+    Container_Boundary(legacyTail, "Legacy Strangler Tail (bin/lib/, M11 cleanup)") {
+        Component(legacyMjs, "*.mjs", "38 ESM legacy modules", "handoff, next-phase, dashboard, install, locks, timestamps, diff, complexity, … — loaded via legacyImport()")
+        Component(legacyJs, "*.js", "155 CJS legacy modules", "io, ai-evaluation, fitness-functions, … — loaded via legacyRequire()")
+    }
+
+    Rel(dev, bin, "Invokes", "shell pipe / npx")
+    Rel(aiAgent, bin, "Spawns subprocess", "child_process.spawn")
+    Rel(bin, main, "Calls runMain()", "ESM import")
+    Rel(bin, errors, "Branches on JumpstartError subclass for exitCode", "instanceof")
+    Rel(bin, secretScanner, "Wraps stderr lines", "ESM import")
+    Rel(main, deps, "Constructs Deps", "createRealDeps()")
+
+    Rel(main, specVal, "Lazy-loads on dispatch", "dynamic import")
+    Rel(main, handoff, "Lazy-loads on dispatch", "dynamic import")
+    Rel(main, lifecycle, "Lazy-loads on dispatch", "dynamic import")
+    Rel(main, cleanup, "Lazy-loads on dispatch", "dynamic import")
+    Rel(main, otherClusters, "Lazy-loads on dispatch", "dynamic import")
+
+    Rel(specVal, libModules, "Calls library functions", "ESM import")
+    Rel(handoff, libModules, "Calls library functions", "ESM import")
+    Rel(lifecycle, libModules, "Calls library functions", "ESM import")
+    Rel(cleanup, helpers, "Uses safeJoin / legacyImport", "ESM import")
+    Rel(cleanup, libModules, "Calls library functions", "ESM import")
+    Rel(otherClusters, libModules, "Calls library functions", "ESM import")
+
+    Rel(helpers, legacyMjs, "legacyImport(name) → await import('.../bin/lib/<name>.mjs')", "dynamic import")
+    Rel(helpers, legacyJs, "legacyRequire(name) → require('.../bin/lib/<name>.js')", "createRequire")
+    Rel(specVal, errors, "Throws ValidationError on bad input", "throw")
+    Rel(handoff, errors, "Throws ValidationError on bad input", "throw")
+    Rel(cleanup, errors, "Throws ValidationError on bad input", "throw")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+## Key invariants
+
+| Invariant | Enforced by | Notes |
+|---|---|---|
+| `process.exit` is called from exactly two sites | `scripts/check-process-exit.mjs` allowlist | `src/cli/bin.ts` (CLI path) + `src/lib/ipc.ts` `runIpc()` (subprocess path) |
+| Every command's `Impl` is a pure function | `tests/test-cli-*.test.ts` per-cluster smoke tests | Returns `CommandResult{exitCode, message?}`; the citty `run()` wrapper translates the result into a throw |
+| `legacyImport` and `legacyRequire` resolve from the package root, not cwd | `tests/test-m9-pitcrew-regressions.test.ts` B3 cases | Anchored at `fileURLToPath(import.meta.url)` — defends against attacker-cwd RCE |
+| `subCommands` is lazy | `src/cli/main.ts` `lazy()` thunk wrapper | `node dist/cli/bin.mjs --version` imports zero command modules |
+| Stderr is redaction-wrapped | `src/cli/bin.ts` `emitErrorLine` | Prevents env-var-shaped LLM error payloads + absolute filesystem paths from leaking (ADR-012) |
+
+## Strangler-tail timeline
+
+The legacy boundary on the right of the diagram (`bin/lib/*.{js,mjs}`) is **transitional**. Three of the deepest-used legacy modules already have TS ports in `src/lib/` that the dashboard cluster could call directly; doing so retires the corresponding `legacyImport`/`legacyRequire` callsite. M11 cleanup completes the retirement and deletes the entire `bin/lib/` boundary:
+
+| Module group | Status post-M9 | Retired in |
+|---|---|---|
+| `bin/lib-ts/*` (the 1.x strangler staging area) | **deleted** at M9 cutover (`git mv` to `src/lib/`) | M9 |
+| `bin/lib/*.mjs` (38 ESM legacy) | **retained** under `bin/package.json {"type": "commonjs"}` scope | M11 |
+| `bin/lib/*.js` (155 CJS legacy) | **retained** for the RC soak window | M11 |
+| `bin/cli.js` (5,359-line monolith) | **retained as dead code** in the published package | M11 |
+| 82 obsolete `tests/*.test.js` | **retained** until target modules go | M11 |
+
+Once M11 deletes the legacy tail, the right-hand `Container_Boundary` in this diagram disappears and the `_helpers.ts` component shrinks to just `safeJoin` + `assertUserPath` (the two path-safety helpers stay).
+
+## See also
+
+- `specs/architecture.md` §Component Interaction Diagram — the parent L2 container view
+- [`specs/architecture-l3-core-lib.md`](./architecture-l3-core-lib.md) — companion L3 decomposition for the `Core Lib` container
+- `specs/decisions/adr-002-cli-framework.md` — citty selection + lazy `subCommands` rationale
+- `specs/decisions/adr-006-error-model.md` — typed-error → exitCode contract pinned by the bin.ts catch
+- `specs/decisions/adr-009-ipc-stdin-path-traversal.md` — path-safety boundary shared with `_helpers.safeJoin`
+- `specs/decisions/adr-012-secrets-redaction.md` — stderr-redaction contract pinned in `bin.ts`

--- a/specs/architecture-l3-core-lib.md
+++ b/specs/architecture-l3-core-lib.md
@@ -1,0 +1,136 @@
+# Level-3 Component Diagram — Core Lib
+
+**Container under decomposition:** `Core Lib (Ports of bin/lib/*)` (from `specs/architecture.md` §Component Interaction Diagram, Level 2).
+
+**Source tree:** `src/lib/` (111 modules post-M9 cutover).
+
+This diagram lists the Core Lib's components grouped by cluster — the same clusters Scout identified in the legacy `bin/lib/` codebase and that the implementation plan's port stages (Stage 4.1 through 4.7) tracked individually. Showing every one of the 111 modules would defeat the diagram's purpose; the components below are **cluster anchors** — the module that the rest of the cluster depends on. The full module list per cluster lives in `specs/architecture.md` §System Components.
+
+> **Turn-2 commitment.** This file (alongside [`architecture-l3-cli-dispatcher.md`](./architecture-l3-cli-dispatcher.md)) fulfills the Architect Turn-2 promise from `architecture.md` §Component Interaction Diagram. Implementation tracker: T6.9.
+
+## Diagram
+
+```mermaid
+C4Component
+    title Component Diagram — Core Lib (src/lib/, 111 modules grouped by cluster)
+
+    Container(cli, "CLI Dispatcher", "TypeScript / citty", "src/cli/* — invokes Core Lib functions per dispatched command")
+    Container(testing, "Testing + E2E Infra", "TypeScript / vitest + bespoke", "Holodeck e2e + headless runner subprocesses")
+    System_Ext(liteLLM, "LiteLLM Proxy", "Local OpenAI-compatible gateway")
+    System_Ext(userRepo, "User project files", ".jumpstart/ + specs/")
+
+    Container_Boundary(libCore, "Core Lib (src/lib/)") {
+
+        Component_Boundary(foundation, "Foundation cluster (8 modules)") {
+            Component(errors, "errors.ts", "JumpstartError hierarchy", "Base error class + ValidationError(2) + LLMError(3). Every cluster throws subclasses; bin.ts catches.")
+            Component(ipc, "ipc.ts", "isDirectRun + runIpc", "Dual-mode subprocess shim. Second of two allowlisted process.exit sites.")
+            Component(pathSafety, "path-safety.ts", "assertInsideRoot", "Trust-boundary guard — every user-supplied path goes through it (ADR-009).")
+            Component(io, "io.ts", "writeResult + wrapTool", "Throw-based contract — wrapTool catches and shapes IPC envelopes.")
+            Component(hashing, "hashing.ts", "hashContent + hashFile", "SHA-256 helpers; pinned binary-vs-utf8 semantics.")
+            Component(otherFoundation, "locks · timestamps · diff · secret-scanner", "4 leaves", "Locks (file-locks); timestamps (ISO_UTC + audit); diff (unified-diff); secret-scanner (redactSecrets — used by bin.ts via ADR-012).")
+        }
+
+        Component_Boundary(config, "Config cluster (5 modules)") {
+            Component(configLoader, "config-loader.ts", "loadConfig", "Project + global merge with profile expansion via dynamic import.")
+            Component(otherConfig, "config-yaml · config-merge · framework-manifest", "3 leaves", "YAML round-trip; three-way-merge for upgrade safety; framework-owned manifest for upgrade-time conflict detection.")
+        }
+
+        Component_Boundary(specVal, "Spec validation cluster (~12 modules)") {
+            Component(validator, "validator.ts", "validate + validateArtifact", "Zod-primary + JSON-Schema-walker fallback. MODULE_DIR = path.dirname(fileURLToPath(import.meta.url)) for schemas dir lookup.")
+            Component(otherSpecVal, "ambiguity-heatmap · complexity · context-chunker · invariants · template-watcher · smell-detector · spec-drift · simplicity-gate · scanner · proactive-validator", "10 leaves")
+        }
+
+        Component_Boundary(specGraph, "Spec graph + traceability (6 modules)") {
+            Component(graph, "graph.ts", "buildFromSpecs + getCoverage", "Story↔task dependency graph used by handoff coverage + dashboard.")
+            Component(otherGraph, "traceability · bidirectional-trace · impact-analysis · adr-index · repo-graph", "5 leaves")
+        }
+
+        Component_Boundary(state, "State + lifecycle (~10 modules)") {
+            Component(stateStore, "state-store.ts", "loadState + updateState", "ESM module — `.jumpstart/state/state.json` r/w.")
+            Component(dashboard, "dashboard.ts", "gatherDashboardData (async)", "Aggregates state + timeline + coverage. Loads handoff + next-phase legacy siblings via async dynamic import (post-M9 Pit Crew B1 fix).")
+            Component(otherState, "timeline · usage · governance-dashboard · approve · checkpoint · focus · next-phase · …", "rest of cluster")
+        }
+
+        Component_Boundary(llm, "LLM cluster (~6 modules)") {
+            Component(llmProvider, "llm-provider.ts", "createLLMProvider", "openai SDK against LITELLM_BASE_URL with HTTPS-or-localhost allowlist (ADR-011). Lazy-loads `openai` via createRequire so mock-only consumers don't pay the import cost.")
+            Component(otherLlm, "model-router · cost-router · mock-responses · model-governance · prompt-governance", "5 leaves")
+        }
+
+        Component_Boundary(marketplace, "Marketplace cluster (4 modules)") {
+            Component(install, "install.ts", "installItem + uninstallItem", "ZIP fetch + SHA-256 verify + ZIP-slip-safe extract (ADR-010). Uses redactSecrets when logging response bodies.")
+            Component(otherMkt, "integrate · registry · upgrade", "3 leaves")
+        }
+
+        Component_Boundary(governance, "Governance + enterprise + collaboration (~70 modules)") {
+            Component(complexClusters, "compliance-packs · risk-register · waiver-workflow · evidence-collector · policy-engine · …", "Largest cluster aggregate", "~70 mostly-self-contained modules across the governance/enterprise/collaboration roll-ups. Most are thin wrappers around state files; a handful (data-contracts, contract-checker, regulatory-gate) cross into spec-validation.")
+        }
+
+        Component_Boundary(testInfra, "Testing/e2e helpers (8 modules)") {
+            Component(holodeck, "holodeck.ts", "runScenario", "Library port; the bin/holodeck.mjs runner imports it for E2E scenario execution.")
+            Component(otherTest, "headless-runner · simulation-tracer · smoke-tester · regression · verify-diagrams · context7-setup · tool-bridge · tool-schemas", "7 leaves")
+        }
+    }
+
+    Rel(cli, errors, "Throws + catches typed errors", "throw / instanceof")
+    Rel(cli, pathSafety, "Gates every user-supplied path", "assertInsideRoot")
+    Rel(cli, io, "Writes IPC-shaped JSON results", "writeResult")
+    Rel(cli, configLoader, "Loads project + global config", "ESM import")
+    Rel(cli, validator, "Validates artifacts on demand", "ESM import")
+    Rel(cli, graph, "Builds spec graph", "ESM import")
+    Rel(cli, stateStore, "Reads/writes phase state", "ESM import")
+    Rel(cli, dashboard, "Renders progress + governance dashboards", "ESM import")
+    Rel(cli, llmProvider, "Creates LLM provider", "ESM import")
+    Rel(cli, install, "Installs marketplace items", "ESM import")
+
+    Rel(dashboard, stateStore, "Loads state.json", "ESM import")
+    Rel(dashboard, graph, "Pulls coverage", "ESM import")
+    Rel(validator, errors, "Throws ValidationError on schema mismatch", "throw")
+    Rel(install, errors, "Throws ValidationError on ZIP-slip + LLMError on registry HTTP", "throw")
+    Rel(install, pathSafety, "Gates each ZIP entry's resolved path", "assertInsideRoot")
+    Rel(llmProvider, liteLLM, "Chat completions", "HTTPS via openai SDK")
+    Rel(install, userRepo, "Writes installed items into .jumpstart/skills/", "fs")
+    Rel(stateStore, userRepo, "Reads/writes .jumpstart/state/state.json", "fs")
+    Rel(dashboard, userRepo, "Reads .jumpstart/usage-log.json + specs/", "fs")
+    Rel(testing, holodeck, "Runs E2E scenarios", "ESM import")
+    Rel(ipc, errors, "Catches JumpstartError → exitCode", "instanceof")
+    Rel(complexClusters, stateStore, "Reads/writes governance state files", "ESM import")
+    Rel(complexClusters, errors, "Throws on policy violations + missing inputs", "throw")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+## Cluster overview
+
+| Cluster | Module count | Anchor | Cross-cluster deps | Notes |
+|---|---|---|---|---|
+| **Foundation** | 8 | `errors.ts`, `path-safety.ts`, `ipc.ts` | None — cluster is the foundation | Every other cluster imports from here. `errors.ts` defines the typed-error contract; `ipc.ts` is the dual-mode subprocess shim. |
+| **Config** | 5 | `config-loader.ts` | Foundation (errors + path-safety) | Three-way-merge logic preserves user customizations across framework upgrades. |
+| **Spec validation** | ~12 | `validator.ts` | Foundation, Schemas (in `src/schemas/`) | Zod-primary; JSON-Schema-walker fallback for inline schemas in tests. `MODULE_DIR` resolves via `import.meta.url`. |
+| **Spec graph** | 6 | `graph.ts` | Foundation, Spec validation | Story↔task graph drives handoff coverage + dashboard summary. |
+| **State + lifecycle** | ~10 | `state-store.ts`, `dashboard.ts` | Foundation, Config, Graph | `dashboard.ts` is async post-M9 (B1 fix) so its handoff/next-phase ESM legacy siblings load correctly. |
+| **LLM** | ~6 | `llm-provider.ts` | Foundation | `LITELLM_BASE_URL` validated at startup per ADR-011. `openai` SDK lazy-loaded via `createRequire`. |
+| **Marketplace** | 4 | `install.ts` | Foundation, Path safety, Errors | ZIP-slip prevention per ADR-010. SHA-256 + manifest hashing + IDE-canonical remap. |
+| **Governance + enterprise + collaboration** | ~70 | (no single anchor — distributed) | State, Spec validation | Largest aggregate cluster. Most modules are thin wrappers around `.jumpstart/state/*.json` files; some cross into spec-validation (data contracts, regulatory gate). |
+| **Testing/e2e helpers** | 8 | `holodeck.ts` | All clusters (it exercises them) | Library ports of the runners. The `bin/holodeck.mjs` runner imports `holodeck.ts` + state-store + usage. |
+
+Total: **8 + 5 + 12 + 6 + 10 + 6 + 4 + 70 + 8 ≈ 129** named modules. The discrepancy with the 111-file count comes from one-module-per-row vs. one-module-per-`.ts`-file: a few clusters double-count (e.g. `simulation-tracer.ts` is in both Foundation/io and Testing). The on-disk file count is the load-bearing one.
+
+## Key invariants
+
+| Invariant | Enforced by | Notes |
+|---|---|---|
+| Foundation modules have no cross-cluster imports | Static analysis via `scripts/extract-public-surface.mjs` | The cluster is the foundation; cycles surface immediately. |
+| Every module is dual-mode (library + subprocess) | The IPC entry-block at the bottom of each module + `tests/fixtures/ipc/` | Either `await runIpc(handler, schema)` if `isDirectRun(import.meta.url)` (subprocess path) or normal ESM exports (library path). |
+| `process.exit` is forbidden in cluster code | `scripts/check-process-exit.mjs` allowlist of `[src/cli/bin.ts, src/lib/ipc.ts]` | Library functions throw `JumpstartError` subclasses; the IPC adapter or the CLI bin does the exit translation. |
+| Path-safety guards every user input | `assertInsideRoot` from `path-safety.ts` is the canonical gate | Documented in ADR-009; pinned by `tests/test-m8-pitcrew-regressions.test.ts` + `tests/test-m9-pitcrew-regressions.test.ts`. |
+| Dashboard's lazy sibling-loaders degrade to `null` (never throw) | `try/catch` with debug-only error logging | Post-M9 the loaders are async to handle ESM legacy modules correctly; the silent-degrade contract is preserved. |
+
+## See also
+
+- [`specs/architecture.md`](./architecture.md) §Component Interaction Diagram — parent L2 container view
+- [`specs/architecture-l3-cli-dispatcher.md`](./architecture-l3-cli-dispatcher.md) — companion L3 for the CLI Dispatcher container
+- [`specs/decisions/adr-006-error-model.md`](./decisions/adr-006-error-model.md) — typed-error contract that constrains the cluster boundary
+- [`specs/decisions/adr-009-ipc-stdin-path-traversal.md`](./decisions/adr-009-ipc-stdin-path-traversal.md) — path-safety boundary
+- [`specs/decisions/adr-010-zipslip-prevention.md`](./decisions/adr-010-zipslip-prevention.md) — install.ts ZIP-slip contract
+- [`specs/decisions/adr-011-llm-endpoint-validation.md`](./decisions/adr-011-llm-endpoint-validation.md) — LLM provider startup gate
+- [`specs/decisions/adr-012-secrets-redaction.md`](./decisions/adr-012-secrets-redaction.md) — secret-scanner redaction contract

--- a/src/lib/verify-diagrams.ts
+++ b/src/lib/verify-diagrams.ts
@@ -290,6 +290,7 @@ const C4_FUNCTIONS = [
   'Enterprise_Boundary',
   'System_Boundary',
   'Container_Boundary',
+  'Component_Boundary',
   // Relationships
   'Rel',
   'Rel_Back',


### PR DESCRIPTION
## Summary

Closes T6.9 — the architecture-spec Turn-2 commitment to author Level-3 component diagrams for the two largest containers (CLI Dispatcher + Core Lib). Each is a strict-C4 decomposition with cluster boundaries, anchor modules per cluster, and cross-cluster relations.

## Files

- `specs/architecture-l3-cli-dispatcher.md` — 5 components inside the CLI Dispatcher boundary (bin.ts, main.ts, deps.ts, the 14 commands/* clusters, _helpers.ts) plus the legacy strangler boundary that M11 cleanup retires. Documents the invariants the bin.ts catch + legacyImport/legacyRequire pin (`process.exit` allowlist, `redactSecrets`-wrapped stderr, package-anchored PACKAGE_ROOT per the M9 Pit Crew B3 fix).
- `specs/architecture-l3-core-lib.md` — the 111 Core Lib modules grouped into 9 clusters (Foundation, Config, Spec validation, Spec graph, State + lifecycle, LLM, Marketplace, Governance + enterprise + collaboration, Testing/e2e). Anchor module called out per cluster; cross-cluster deps + invariants tabulated.

Both files include `mermaid C4Component` blocks and pass `node bin/verify-diagrams.js --file …` with zero warnings.

## Side fix

`bin/verify-diagrams.js` and `src/lib/verify-diagrams.ts` didn't recognise `Component_Boundary` (the C4-PlantUML keyword for grouping components inside a Container_Boundary). The new diagrams use it; pre-fix it emitted a warning. Added `Component_Boundary` to the C4 functions allowlist in both the runtime + the TS port.

## Test plan

- [x] `node bin/verify-diagrams.js --file specs/architecture-l3-cli-dispatcher.md` — passes
- [x] `node bin/verify-diagrams.js --file specs/architecture-l3-core-lib.md` — passes
- [x] `npm run verify-baseline` — 12/12 green (pure docs + verifier patch; no behavioral change)
- [x] Both files cross-link correctly to architecture.md and the relevant ADRs

## Refs

- T6.9 (M11 housekeeping milestone)
- `specs/architecture.md` §Component Interaction Diagram diagram-level note — the Turn-2 commitment this PR fulfills