### PR TITLE
chore(m11): foundation-cluster defensive fixes for noUncheckedIndexedAccess

### DIFF
--- a/src/lib/io.ts
+++ b/src/lib/io.ts
@@ -216,7 +216,7 @@ export function parseToolArgs(argv: string[]): ToolArgs {
   const args: ToolArgs = {};
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
-    if (!arg.startsWith('--')) continue;
+    if (arg === undefined || !arg.startsWith('--')) continue;
     const key = arg.slice(2);
     const next = argv[i + 1];
     if (next !== undefined && !next.startsWith('--')) {

--- a/src/lib/secret-scanner.ts
+++ b/src/lib/secret-scanner.ts
@@ -286,6 +286,7 @@ export function scanFile(filePath: string, patterns: SecretPattern[]): SecretFin
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
+    if (line === undefined) continue;
     // Pit Crew M3 Reviewer M4 (DEFERRED): the legacy skip-line regex
     // `^\s*(#|\/\/)\s*(example|TODO|FIXME|NOTE)` allows `// TODO
     // actualSecret = "ghp_..."` to bypass the scanner. Tightening it

--- a/src/lib/timestamps.ts
+++ b/src/lib/timestamps.ts
@@ -179,8 +179,10 @@ export function audit(filePath: string): AuditResult {
   const lines = content.split('\n');
 
   for (let idx = 0; idx < lines.length; idx++) {
-    const match = lines[idx].match(TIMESTAMP_LINE_REGEX);
-    if (!match) continue;
+    const line = lines[idx];
+    if (line === undefined) continue;
+    const match = line.match(TIMESTAMP_LINE_REGEX);
+    if (!match || match[1] === undefined) continue;
 
     result.entries++;
     const value = match[1].trim();
@@ -201,12 +203,12 @@ export function audit(filePath: string): AuditResult {
   }
 
   const fmMatch = content.match(FRONTMATTER_BLOCK_REGEX);
-  if (fmMatch) {
+  if (fmMatch && fmMatch[1] !== undefined) {
     const fm = fmMatch[1];
     for (const field of FRONTMATTER_DATE_FIELDS) {
       const fieldRegex = new RegExp(`^${field}:\\s*"?(.+?)"?$`, 'm');
       const fieldMatch = fm.match(fieldRegex);
-      if (!fieldMatch) continue;
+      if (!fieldMatch || fieldMatch[1] === undefined) continue;
 
       const value = fieldMatch[1].trim();
       if (value === '' || value.startsWith('{{') || value === 'Pending' || value === 'N/A') {


### PR DESCRIPTION
## Summary

Phase 2a of [#31](https://github.com/scombey/JumpStart-AutoNav/issues/31). The full `noUncheckedIndexedAccess` flip (533 errors across many clusters) is too big for one autonomous PR; this PR closes the 9 errors in the **Foundation cluster** (`src/lib/{io,secret-scanner,timestamps}.ts`) without enabling the flag globally. When the eventual final flip lands, those files don't contribute errors.

The fixes are pure defensive guards. Runtime behavior is unchanged.

## Changes

- `io.ts:215 parseToolArgs` — `argv[i]` becomes `string | undefined` under the strict flag; guard with `arg === undefined` before `arg.startsWith('--')`.
- `timestamps.ts:181 audit` — guard `lines[idx]` and assert `match[1] !== undefined` before `.trim()`.
- `timestamps.ts:204 audit` — same for `fmMatch[1]` and `fieldMatch[1]` regex captures.
- `secret-scanner.ts:288 scanFile` — guard `lines[i]` before passing to the skip-line regex.

## Test plan

- [x] `npx tsc --noEmit` — clean (flag stays OFF)
- [x] `npm run verify-baseline` — 12/12 green
- [x] 3,421 tests pass

## Note on flake

A transient `tests/test-m9-pitcrew-regressions.test.ts` failure was observed when `dist/` is stale (the M9 cluster-files smoke checks depend on `tsdown` having run). `rm -rf dist && verify-baseline` clears it. Same flake batch-1 (PR #36) reported. Independent of this PR's changes; tracked for the M9 smoke test to do its own fresh build.

## What's next

Phase 2b: Config cluster (`config-yaml`, `config-loader`, `config-merge`, `framework-manifest`). Same pattern — fix defensive errors, flag stays off until every cluster's PR lands.

## Refs

- T6.6 / issue #31 phase 2a (Foundation cluster)