### PR TITLE
chore(m11): spec-validation + graph cluster defensive fixes for noUncheckedIndexedAccess

### DIFF
--- a/src/lib/adr-index.ts
+++ b/src/lib/adr-index.ts
@@ -75,30 +75,32 @@ export function parseADR(filePath: string): ADREntry | null {
     const name = path.basename(filePath, '.md');
 
     const titleMatch = content.match(/^#{1,2}\s+(.+)$/m);
-    const title = titleMatch ? titleMatch[1].trim() : name;
+    const title = titleMatch?.[1] !== undefined ? titleMatch[1].trim() : name;
 
     const statusMatch =
       content.match(/\*\*Status:\*\*\s*(.+)/i) || content.match(/Status:\s*(.+)/i);
-    const status = statusMatch ? statusMatch[1].trim() : 'unknown';
+    const status = statusMatch?.[1] !== undefined ? statusMatch[1].trim() : 'unknown';
 
     const dateMatch =
       content.match(/\*\*Date:\*\*\s*(.+)/i) ||
       content.match(/Date:\s*(.+)/i) ||
       content.match(/(\d{4}-\d{2}-\d{2})/);
-    const date = dateMatch ? dateMatch[1].trim() : null;
+    const date = dateMatch?.[1] !== undefined ? dateMatch[1].trim() : null;
 
     const tagMatch = content.match(/\*\*Tags:\*\*\s*(.+)/i) || content.match(/Tags:\s*(.+)/i);
-    const tags = tagMatch ? tagMatch[1].split(',').map((t) => t.trim().toLowerCase()) : [];
+    const tags =
+      tagMatch?.[1] !== undefined ? tagMatch[1].split(',').map((t) => t.trim().toLowerCase()) : [];
 
     const componentMatch =
       content.match(/\*\*Components?:\*\*\s*(.+)/i) || content.match(/Components?:\s*(.+)/i);
-    const components = componentMatch ? componentMatch[1].split(',').map((c) => c.trim()) : [];
+    const components =
+      componentMatch?.[1] !== undefined ? componentMatch[1].split(',').map((c) => c.trim()) : [];
 
     const decisionMatch = content.match(/##\s+Decision\s*\n+([\s\S]*?)(?=\n##|\n---|$)/i);
-    const decision = decisionMatch ? decisionMatch[1].trim().slice(0, 500) : '';
+    const decision = decisionMatch?.[1] !== undefined ? decisionMatch[1].trim().slice(0, 500) : '';
 
     const contextMatch = content.match(/##\s+Context\s*\n+([\s\S]*?)(?=\n##|\n---|$)/i);
-    const context = contextMatch ? contextMatch[1].trim().slice(0, 500) : '';
+    const context = contextMatch?.[1] !== undefined ? contextMatch[1].trim().slice(0, 500) : '';
 
     return {
       id: name,

--- a/src/lib/ambiguity-heatmap.ts
+++ b/src/lib/ambiguity-heatmap.ts
@@ -114,6 +114,7 @@ export function scanAmbiguity(text: string, options: ScanOptions = {}): ScanResu
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
+    if (line === undefined) continue;
     const lineNum = i + 1;
 
     for (const term of VAGUE_TERMS) {
@@ -203,7 +204,7 @@ export function generateHeatmap(root: string, options: ScanOptions = {}): Heatma
     results,
     overall: {
       total_findings: results.reduce((s, r) => s + r.total_findings, 0),
-      highest_density_file: results.length > 0 ? results[0].file : null,
+      highest_density_file: results[0]?.file ?? null,
     },
   };
 }

--- a/src/lib/analyzer.ts
+++ b/src/lib/analyzer.ts
@@ -91,6 +91,7 @@ export function extractTerms(content: string): Map<string, string> {
   const terms = new Map<string, string>();
 
   for (const m of content.matchAll(/\*\*([A-Z][a-zA-Z\s]+)\*\*/g)) {
+    if (m[1] === undefined) continue;
     const term = m[1].trim();
     if (term.length > 2 && term.length < 50) {
       terms.set(term.toLowerCase(), term);
@@ -98,6 +99,7 @@ export function extractTerms(content: string): Map<string, string> {
   }
 
   for (const m of content.matchAll(/^#{1,4}\s+(?:.*?:\s*)?(.+)$/gm)) {
+    if (m[1] === undefined) continue;
     const term = m[1].trim();
     if (term.length > 2 && term.length < 60) {
       terms.set(term.toLowerCase(), term);
@@ -260,11 +262,15 @@ export function analyze(input: AnalyzeInput): AnalysisResult {
   if (sourceNames.length >= 2) {
     for (let i = 0; i < sourceNames.length; i++) {
       const srcA = sourceNames[i];
+      if (srcA === undefined) continue;
       const termsA = allTermsBySource[srcA];
+      if (termsA === undefined) continue;
       for (const [keyA, termA] of termsA) {
         for (let j = i + 1; j < sourceNames.length; j++) {
           const srcB = sourceNames[j];
+          if (srcB === undefined) continue;
           const termsB = allTermsBySource[srcB];
+          if (termsB === undefined) continue;
           for (const [keyB, termB] of termsB) {
             if (
               keyA !== keyB &&
@@ -290,7 +296,7 @@ export function analyze(input: AnalyzeInput): AnalysisResult {
   if (artifacts.contracts && artifacts.dataModel) {
     const entities: string[] = [];
     for (const m of artifacts.dataModel.matchAll(/###\s+Entity:\s+(\w+)/g)) {
-      entities.push(m[1]);
+      if (m[1] !== undefined) entities.push(m[1]);
     }
     for (const entity of entities) {
       if (!artifacts.contracts.toLowerCase().includes(entity.toLowerCase())) {

--- a/src/lib/context-chunker.ts
+++ b/src/lib/context-chunker.ts
@@ -112,7 +112,8 @@ export function estimateTokens(text: string): number {
  */
 export function chunkContent(content: string, options: ChunkOptions = {}): ChunkResult {
   const model = options.model || 'default';
-  const limits = MODEL_CONTEXT_LIMITS[model] || MODEL_CONTEXT_LIMITS.default;
+  const limits = MODEL_CONTEXT_LIMITS[model] ?? MODEL_CONTEXT_LIMITS.default;
+  if (limits === undefined) throw new Error('MODEL_CONTEXT_LIMITS.default is missing');
   const maxTokens = options.max_tokens || Math.floor(limits.tokens * 0.8);
   const overlapTokens = options.overlap || Math.floor(maxTokens * 0.05);
 
@@ -184,7 +185,7 @@ export function chunkImplementationPlan(root: string, _options: ChunkOptions = {
 
   const packets: PlanPacket[] = sections.map((section, i) => ({
     index: i,
-    title: section.split('\n')[0].trim(),
+    title: (section.split('\n')[0] ?? '').trim(),
     estimated_tokens: estimateTokens(section),
     lines: section.split('\n').length,
   }));

--- a/src/lib/crossref.ts
+++ b/src/lib/crossref.ts
@@ -76,11 +76,15 @@ export function extractLinks(content: string): MarkdownLink[] {
     const matches = line.matchAll(linkPattern);
     for (const m of matches) {
       const raw = m[2];
+      const text = m[1];
+      if (raw === undefined || text === undefined) continue;
       if (/^https?:|^mailto:|^#/.test(raw)) continue;
       const parts = raw.split('#');
+      const target = parts[0];
+      if (target === undefined) continue;
       links.push({
-        text: m[1],
-        target: parts[0],
+        text,
+        target,
         anchor: parts[1] || null,
         line: idx + 1,
       });
@@ -102,6 +106,7 @@ export function extractAnchors(content: string): string[] {
   const anchors: string[] = [];
   const headings = content.matchAll(/^#+\s+(.+)$/gm);
   for (const m of headings) {
+    if (m[1] === undefined) continue;
     const slug = m[1]
       .toLowerCase()
       .replace(/[^\w\s-]/g, '')
@@ -163,6 +168,7 @@ export function validateCrossRefs(specsDir: string, root: string): CrossRefRepor
   for (const file of specFiles) {
     const rel = path.relative(root, file).replace(/\\/g, '/');
     const content = contentMap[rel];
+    if (content === undefined) continue;
     const links = extractLinks(content);
     linkGraph[rel] = links;
 

--- a/src/lib/graph.ts
+++ b/src/lib/graph.ts
@@ -241,13 +241,19 @@ export function buildFromSpecs(specsDir: string): SpecGraph {
     const prdContent = readFileSync(prdPath, 'utf8');
 
     for (const m of prdContent.matchAll(/### Epic (E\d+):\s*(.+)/g)) {
-      addNode(graph, m[1], 'epic', { name: m[2].trim() });
+      const epicId = m[1];
+      const epicName = m[2];
+      if (epicId === undefined || epicName === undefined) continue;
+      addNode(graph, epicId, 'epic', { name: epicName.trim() });
     }
 
     for (const m of prdContent.matchAll(/#### Story (E\d+-S\d+):\s*(.+)/g)) {
       const storyId = m[1];
+      const storyName = m[2];
+      if (storyId === undefined || storyName === undefined) continue;
       const epicId = storyId.split('-')[0];
-      addNode(graph, storyId, 'story', { name: m[2].trim() });
+      if (epicId === undefined) continue;
+      addNode(graph, storyId, 'story', { name: storyName.trim() });
       addEdge(graph, epicId, storyId, 'contains');
     }
   }
@@ -259,7 +265,9 @@ export function buildFromSpecs(specsDir: string): SpecGraph {
     const taskMatches = Array.from(planContent.matchAll(/### Task (M\d+-T\d+):\s*(.+)/g));
     for (const taskMatch of taskMatches) {
       const taskId = taskMatch[1];
-      const cleanedName = taskMatch[2].replace(/\s*`\[.*?\]`\s*/, '').trim();
+      const taskName = taskMatch[2];
+      if (taskId === undefined || taskName === undefined) continue;
+      const cleanedName = taskName.replace(/\s*`\[.*?\]`\s*/, '').trim();
       addNode(graph, taskId, 'task', { name: cleanedName });
 
       const blockStart = taskMatch.index ?? 0;
@@ -267,12 +275,12 @@ export function buildFromSpecs(specsDir: string): SpecGraph {
       const block = planContent.substring(blockStart, blockEnd === -1 ? undefined : blockEnd);
 
       const storyRefMatch = block.match(/\*\*Story Reference\*\*\s*\|\s*(E\d+-S\d+)/);
-      if (storyRefMatch) {
+      if (storyRefMatch?.[1] !== undefined) {
         addEdge(graph, taskId, storyRefMatch[1], 'implements');
       }
 
       const filesMatch = block.match(/\*\*Files\*\*\s*\|\s*(.+)/);
-      if (filesMatch) {
+      if (filesMatch?.[1] !== undefined) {
         const files = filesMatch[1].split(',').map((f) => f.trim().replace(/`/g, ''));
         for (const file of files) {
           if (file && file !== '-' && file !== 'None') {
@@ -332,8 +340,9 @@ export function auditTaskDependencies(graph: {
     inDeg[t.id] = 0;
   }
   for (const e of taskEdges) {
-    if (adj[e.from]) adj[e.from].push(e.to);
-    if (inDeg[e.to] !== undefined) inDeg[e.to]++;
+    const fromAdj = adj[e.from];
+    if (fromAdj) fromAdj.push(e.to);
+    if (inDeg[e.to] !== undefined) inDeg[e.to] = (inDeg[e.to] ?? 0) + 1;
   }
 
   // Detect cycles via DFS
@@ -380,8 +389,9 @@ export function auditTaskDependencies(graph: {
     remaining = [];
     for (const node of currentLevel) {
       for (const neighbor of adj[node] || []) {
-        inDeg[neighbor]--;
-        if (inDeg[neighbor] === 0) remaining.push(neighbor);
+        const remaining_count = (inDeg[neighbor] ?? 0) - 1;
+        inDeg[neighbor] = remaining_count;
+        if (remaining_count === 0) remaining.push(neighbor);
       }
     }
     level++;
@@ -396,7 +406,7 @@ export function auditTaskDependencies(graph: {
   for (const e of taskEdges) {
     const fromMatch = e.from.match(/M(\d+)-T/);
     const toMatch = e.to.match(/M(\d+)-T/);
-    if (fromMatch && toMatch) {
+    if (fromMatch?.[1] !== undefined && toMatch?.[1] !== undefined) {
       const fromMilestone = Number.parseInt(fromMatch[1], 10);
       const toMilestone = Number.parseInt(toMatch[1], 10);
       if (toMilestone > fromMilestone) {

--- a/src/lib/repo-graph.ts
+++ b/src/lib/repo-graph.ts
@@ -270,7 +270,7 @@ export function buildRepoGraph(
         try {
           const content = readFileSync(adrPath, 'utf8');
           const titleMatch = content.match(/^# (.+)/m);
-          if (titleMatch) title = titleMatch[1];
+          if (titleMatch?.[1] !== undefined) title = titleMatch[1];
         } catch {
           // use filename as title
         }

--- a/src/lib/safe-rename.ts
+++ b/src/lib/safe-rename.ts
@@ -120,11 +120,13 @@ export function findReferences(
               if (content.includes(term)) {
                 const lines = content.split('\n');
                 for (let i = 0; i < lines.length; i++) {
-                  if (lines[i].includes(term)) {
+                  const line = lines[i];
+                  if (line === undefined) continue;
+                  if (line.includes(term)) {
                     references.push({
                       file: relFile,
                       line: i + 1,
-                      content: lines[i].trim().substring(0, 150),
+                      content: line.trim().substring(0, 150),
                       match: term,
                     });
                   }

--- a/src/lib/smell-detector.ts
+++ b/src/lib/smell-detector.ts
@@ -201,6 +201,7 @@ export function detectSmells(content: string): SmellDetectionResult {
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
+    if (line === undefined) continue;
 
     if (line.startsWith('```')) {
       inCodeBlock = !inCodeBlock;
@@ -220,6 +221,7 @@ export function detectSmells(content: string): SmellDetectionResult {
     if (line.startsWith('#') || line.match(/^\|[-\s|]+\|$/)) continue;
 
     for (const [type, config] of Object.entries(SMELL_PATTERNS)) {
+      if (config === undefined) continue;
       for (const pattern of config.patterns) {
         // matchAll is stateless across invocations (unlike legacy's
         // stateful regex iteration which had to reset lastIndex
@@ -259,7 +261,9 @@ export function scoreSmellDensity(content: string): SmellDensityResult {
   let inFrontmatter = false;
 
   for (let i = 0; i < lines.length; i++) {
-    const line = lines[i].trim();
+    const rawLine = lines[i];
+    if (rawLine === undefined) continue;
+    const line = rawLine.trim();
     if (line.startsWith('```')) {
       inCodeBlock = !inCodeBlock;
       continue;
@@ -338,12 +342,14 @@ export function generateSmellReport(filePath: string): string {
 
   const grouped: Record<string, SmellEntry[]> = {};
   for (const smell of result.smells) {
-    if (!grouped[smell.type]) grouped[smell.type] = [];
-    grouped[smell.type].push(smell);
+    const bucket = grouped[smell.type] ?? [];
+    bucket.push(smell);
+    grouped[smell.type] = bucket;
   }
 
   for (const [type, smells] of Object.entries(grouped)) {
     const config = SMELL_PATTERNS[type];
+    if (config === undefined) continue;
     report += `## ${type} (${smells.length}) — ${config.severity}\n\n`;
     report += `*${config.description}*\n\n`;
     report += '| Line | Text |\n|------|------|\n';

--- a/src/lib/traceability.ts
+++ b/src/lib/traceability.ts
@@ -164,7 +164,9 @@ export function buildTraceabilityChain(root: string): TraceabilityResult {
     const relatedTasks = tasks.filter((t) => {
       const lines = implContent.split('\n');
       for (let i = 0; i < lines.length; i++) {
-        if (lines[i].includes(t)) {
+        const line = lines[i];
+        if (line === undefined) continue;
+        if (line.includes(t)) {
           const context = lines.slice(Math.max(0, i - 5), i + 5).join('\n');
           if (context.includes(storyId)) return true;
         }

--- a/src/lib/validator.ts
+++ b/src/lib/validator.ts
@@ -122,7 +122,7 @@ function buildIdToZodMap(): Map<string, ZodMapEntry> {
     const stem = filename.replace(/\.schema\.json$/, '');
     const pascal = stem
       .split(/[-_]/)
-      .map((p) => (p.length === 0 ? '' : p[0].toUpperCase() + p.slice(1)))
+      .map((p) => (p.length === 0 ? '' : (p[0] ?? '').toUpperCase() + p.slice(1)))
       .join('');
     const exportName = `${pascal}Schema`;
     const zodSchema = (generated as Record<string, unknown>)[exportName];
@@ -206,7 +206,8 @@ export function extractFrontmatter(content: string): Record<string, unknown> | n
   if (!match) return null;
 
   const frontmatter: Record<string, unknown> = {};
-  const lines = match[1].split(/\r?\n/);
+  const fmBody = match[1] ?? '';
+  const lines = fmBody.split(/\r?\n/);
   let currentKey: string | null = null;
   let currentList: string[] | null = null;
 
@@ -227,18 +228,21 @@ export function extractFrontmatter(content: string): Record<string, unknown> | n
     // Key-value pair
     const kvMatch = trimmed.match(/^(\w[\w_-]*)\s*:\s*(.*)/);
     if (kvMatch) {
+      const matchedKey = kvMatch[1];
+      const matchedValue = kvMatch[2];
+      if (matchedKey === undefined || matchedValue === undefined) continue;
       // Pit Crew M3 Adversary F9: skip __proto__/constructor/prototype.
       // These are not legal frontmatter keys for jumpstart artifacts;
       // accepting them creates a prototype-pollution vector for any
       // downstream consumer that does `Object.entries(frontmatter)` or
       // shape-based lookups.
-      if (FORBIDDEN_FRONTMATTER_KEYS.has(kvMatch[1])) {
+      if (FORBIDDEN_FRONTMATTER_KEYS.has(matchedKey)) {
         currentKey = null;
         currentList = null;
         continue;
       }
-      currentKey = kvMatch[1];
-      const value = kvMatch[2].trim();
+      currentKey = matchedKey;
+      const value = matchedValue.trim();
       currentList = null;
 
       if (value === '' || value === '[]') {
@@ -641,11 +645,11 @@ export function checkApproval(filePath: string): ApprovalCheckOutcome {
 
   // Approver
   const approverMatch = gateSection.match(/\*\*Approved by:\*\*\s*(.+)/);
-  const approver = approverMatch ? approverMatch[1].trim() : null;
+  const approver = approverMatch?.[1] !== undefined ? approverMatch[1].trim() : null;
 
   // Date
   const dateMatch = gateSection.match(/\*\*Approval date:\*\*\s*(.+)/);
-  const date = dateMatch ? dateMatch[1].trim() : null;
+  const date = dateMatch?.[1] !== undefined ? dateMatch[1].trim() : null;
 
   const approved = Boolean(
     !unchecked &&


### PR DESCRIPTION
## Summary

Phase 2c of [#31](https://github.com/scombey/JumpStart-AutoNav/issues/31). Closes the 68 errors across 11 files in the spec-validation + graph cluster that surface under `noUncheckedIndexedAccess`. Pure defensive guards; no runtime behavior change. Flag stays OFF until every cluster's defensive code has landed (final flip = phase 3).

## Files touched

| File | Errors closed |
|---|---|
| `graph.ts` | 16 (regex-captures + record-index guards in `buildFromSpecs`, `getCoverage`'s topological-sort + Kahn's level assignment, milestone-inversion detection) |
| `validator.ts` | 13 (split-array first-char in pascal-case; frontmatter parser kvMatch guards; gateSection approver/date) |
| `smell-detector.ts` | 8 (line guard in `detectSmells` + `scoreSmellDensity`; SMELL_PATTERNS config narrowing; bucket upsert) |
| `analyzer.ts` | 7 (regex-captures in extractTerms; cross-source drift sourceNames + termsBy guards) |
| `adr-index.ts` | 7 (every regex-capture in `parseADR`) |
| `crossref.ts` | 6 (extractLinks raw/text/parts; extractAnchors slug; validateCrossRefs contentMap) |
| `ambiguity-heatmap.ts` | 5 (detectFile line guard; overall.highest_density_file) |
| `safe-rename.ts` | 2 (textual-reference scan line guard) |
| `context-chunker.ts` | 2 (MODEL_CONTEXT_LIMITS guard; section-split title) |
| `traceability.ts` | 1 (story-task association scan) |
| `repo-graph.ts` | 1 (titleMatch regex-capture) |

## Test plan

- [x] `npx tsc --noEmit` — clean (flag stays OFF)
- [x] `npm run verify-baseline` — 12/12 green
- [x] `npm run lint` — clean
- [x] 3,421 tests pass

## Cluster progression

- phase 1   `exactOptionalPropertyTypes` ON         → #35 (`ed3aab2`)
- phase 2a  Foundation cluster                      → #37 (`5e93076`)
- phase 2b  Config cluster                          → #38 (`9b79a07`)
- phase 2c  Spec validation + graph cluster         → **this PR**
- phase 2d  State + LLM + marketplace               → next
- phase 2e  Governance + enterprise + collab        → largest cluster
- phase 2f  CLI commands                            → last per-cluster
- phase 3   Final flag-flip                         → tiny once all clusters done

## Refs

- T6.6 / issue #31 phase 2c (spec-validation + graph cluster)