### PR TITLE
chore(m11): state+LLM+marketplace cluster defensive fixes for noUncheckedIndexedAccess

### DIFF
--- a/src/lib/ceremony.ts
+++ b/src/lib/ceremony.ts
@@ -208,12 +208,16 @@ export function expandDotNotation(flat: Record<string, unknown>): Record<string,
     let current = result;
     for (let i = 0; i < keys.length - 1; i++) {
       const k = keys[i];
+      if (k === undefined) continue;
       if (!(k in current) || typeof current[k] !== 'object') {
         current[k] = {};
       }
       current = current[k] as Record<string, unknown>;
     }
-    current[keys[keys.length - 1]] = value;
+    const lastKey = keys[keys.length - 1];
+    if (lastKey !== undefined) {
+      current[lastKey] = value;
+    }
   }
   return result;
 }
@@ -289,11 +293,17 @@ export function compareProfiles(profileA: string, profileB: string): ProfileDiff
 /** Summary of all profiles and their light↔rigorous diffs. */
 export function getProfileSummary(): ProfileSummary {
   return {
-    profiles: VALID_PROFILES.map((name) => ({
-      name,
-      description: PROFILES[name].description,
-      setting_count: Object.keys(PROFILES[name].settings).length,
-    })),
+    profiles: VALID_PROFILES.map((name) => {
+      const profile = PROFILES[name];
+      if (profile === undefined) {
+        throw new Error(`PROFILES catalog out of sync — missing entry for ${name}`);
+      }
+      return {
+        name,
+        description: profile.description,
+        setting_count: Object.keys(profile.settings).length,
+      };
+    }),
     key_differences: compareProfiles('light', 'rigorous'),
   };
 }

--- a/src/lib/cost-router.ts
+++ b/src/lib/cost-router.ts
@@ -150,7 +150,10 @@ export function saveConfig(config: CostRouterConfig, configFile?: string): void 
 export function routeByCost(task: RouteTask, options: RouteOptions = {}): RouteResult {
   const configFile = options.configFile || DEFAULT_CONFIG_FILE;
   const config = loadConfig(configFile);
-  const profile = BUDGET_PROFILES[config.budget_profile] || BUDGET_PROFILES.balanced;
+  const profile = BUDGET_PROFILES[config.budget_profile] ?? BUDGET_PROFILES.balanced;
+  if (profile === undefined) {
+    throw new Error('BUDGET_PROFILES.balanced missing — catalog out of sync');
+  }
   // Pit Crew M4 Reviewer M1: legacy used `||` not `??`. For a caller
   // who passes `min_quality: 0` (i.e. "no minimum"), `??` keeps the 0
   // and accepts any quality; `||` falls through to profile default.

--- a/src/lib/dashboard.ts
+++ b/src/lib/dashboard.ts
@@ -253,7 +253,9 @@ export function findClarifications(specsDir: string): Clarification[] {
     const content = readFileSync(filePath, 'utf8');
     const lines = content.split('\n');
     for (let i = 0; i < lines.length; i++) {
-      for (const match of lines[i].matchAll(TAG_RE)) {
+      const line = lines[i];
+      if (line === undefined) continue;
+      for (const match of line.matchAll(TAG_RE)) {
         results.push({
           file: `specs/${file}`,
           line: i + 1,
@@ -348,7 +350,7 @@ export async function gatherDashboardData(
     try {
       const raw = readFileSync(configPath, 'utf8');
       const typeMatch = raw.match(/^\s*type:\s*(\S+)/m);
-      if (typeMatch) projectType = typeMatch[1];
+      if (typeMatch?.[1] !== undefined) projectType = typeMatch[1];
     } catch {
       /* default greenfield */
     }
@@ -409,9 +411,10 @@ export async function gatherDashboardData(
     qualityScores.length > 0
       ? Math.round(qualityScores.reduce((sum, q) => sum + q.score, 0) / qualityScores.length)
       : null;
+  const firstScore = qualityScores[0];
   const lowestPhase =
-    qualityScores.length > 0
-      ? qualityScores.reduce((min, q) => (q.score < min.score ? q : min), qualityScores[0])
+    firstScore !== undefined
+      ? qualityScores.reduce((min, q) => (q.score < min.score ? q : min), firstScore)
       : null;
 
   const quality: QualitySummary = {

--- a/src/lib/focus.ts
+++ b/src/lib/focus.ts
@@ -174,14 +174,20 @@ export function getPreset(presetName: string): Preset {
 }
 
 export function listPresets(): PresetSummary[] {
-  return VALID_PRESETS.map((name) => ({
-    name,
-    description: PRESETS[name].description,
-    start_phase: PRESETS[name].start_phase,
-    end_phase: PRESETS[name].end_phase,
-    role: PRESETS[name].role,
-    phases: PRESETS[name].phases,
-  }));
+  return VALID_PRESETS.map((name) => {
+    const preset = PRESETS[name];
+    if (preset === undefined) {
+      throw new Error(`PRESETS catalog out of sync — missing entry for ${name}`);
+    }
+    return {
+      name,
+      description: preset.description,
+      start_phase: preset.start_phase,
+      end_phase: preset.end_phase,
+      role: preset.role,
+      phases: preset.phases,
+    };
+  });
 }
 
 export function validatePhaseRange(startPhase: number, endPhase: number): ValidationResult {
@@ -227,8 +233,8 @@ export function getPhasesInRange(startPhase: number, endPhase: number): PhaseEnt
     if (p >= startPhase && p <= endPhase) {
       phases.push({
         phase: p,
-        name: PHASE_NAMES[String(p)],
-        command: AGENT_COMMANDS[String(p)],
+        name: PHASE_NAMES[String(p)] ?? '',
+        command: AGENT_COMMANDS[String(p)] ?? '',
       });
     }
   }
@@ -262,7 +268,7 @@ export function buildFocusConfig(options: FocusBuildOptions): FocusConfig {
     preset: null,
     start_phase: start,
     end_phase: end,
-    description: `Custom focus: Phase ${start} (${PHASE_NAMES[String(start)]}) through Phase ${end} (${PHASE_NAMES[String(end)]})`,
+    description: `Custom focus: Phase ${start} (${PHASE_NAMES[String(start)] ?? ''}) through Phase ${end} (${PHASE_NAMES[String(end)] ?? ''})`,
     role: 'Custom',
     phases,
   };
@@ -299,9 +305,9 @@ export function readFocusFromConfig(configPath: string): FocusConfig | null {
     const startMatch = section.match(/^\s+start_phase:\s*(-?\d+)/m);
     const endMatch = section.match(/^\s+end_phase:\s*(-?\d+)/m);
 
-    const preset = presetMatch ? presetMatch[1] : null;
-    const startPhase = startMatch ? Number.parseInt(startMatch[1], 10) : null;
-    const endPhase = endMatch ? Number.parseInt(endMatch[1], 10) : null;
+    const preset = presetMatch?.[1] ?? null;
+    const startPhase = startMatch?.[1] !== undefined ? Number.parseInt(startMatch[1], 10) : null;
+    const endPhase = endMatch?.[1] !== undefined ? Number.parseInt(endMatch[1], 10) : null;
 
     if (preset && preset !== 'null') {
       try {

--- a/src/lib/handoff-validator.ts
+++ b/src/lib/handoff-validator.ts
@@ -250,9 +250,12 @@ function extractPmToArchitect(
   let match: RegExpExecArray | null;
   // biome-ignore lint/suspicious/noAssignInExpressions: standard regex.exec idiom
   while ((match = storyRegex.exec(content)) !== null) {
+    const storyId = match[1];
+    const storyTitle = match[2];
+    if (storyId === undefined || storyTitle === undefined) continue;
     const story: UserStory = {
-      id: match[1],
-      title: match[2].trim(),
+      id: storyId,
+      title: storyTitle.trim(),
       acceptance_criteria: [],
     };
 
@@ -286,6 +289,9 @@ function extractPmToArchitect(
   const nfrRegex = /###\s+NFR-(\d+):\s*(.+)/g;
   // biome-ignore lint/suspicious/noAssignInExpressions: standard regex.exec idiom
   while ((match = nfrRegex.exec(content)) !== null) {
+    const nfrId = match[1];
+    const nfrTitle = match[2];
+    if (nfrId === undefined || nfrTitle === undefined) continue;
     const nfrStart = match.index + match[0].length;
     const nextSection = content.indexOf('\n### ', nfrStart);
     const nfrBody = content
@@ -293,16 +299,16 @@ function extractPmToArchitect(
       .trim();
 
     payload.non_functional_requirements.push({
-      id: `NFR-${match[1]}`,
-      category: inferNfrCategory(match[2]),
-      description: match[2].trim(),
+      id: `NFR-${nfrId}`,
+      category: inferNfrCategory(nfrTitle),
+      description: nfrTitle.trim(),
       metric: extractMetric(nfrBody) ?? 'To be defined',
     });
   }
 
   // Extract problem statement from Product Overview
   const overviewMatch = content.match(/## Product Overview\s*\n([\s\S]*?)(?=\n## )/);
-  if (overviewMatch) {
+  if (overviewMatch?.[1] !== undefined) {
     payload.domain_context.problem_statement = overviewMatch[1].trim().substring(0, 500);
   }
   if (
@@ -339,13 +345,16 @@ function extractArchitectToDev(
       .filter((c) => c.trim())
       .map((c) => c.trim());
     if (cols.length >= 3) {
-      const layer = cols[0].toLowerCase();
+      const layer = cols[0]?.toLowerCase();
+      const colName = cols[1];
+      const colVer = cols[2];
+      if (layer === undefined || colName === undefined || colVer === undefined) continue;
       if (layer === 'runtime') {
-        payload.technology_stack.runtime = { name: cols[1], version: cols[2] };
+        payload.technology_stack.runtime = { name: colName, version: colVer };
       } else if (layer === 'framework') {
-        payload.technology_stack.framework = { name: cols[1], version: cols[2] };
+        payload.technology_stack.framework = { name: colName, version: colVer };
       } else if (layer === 'database') {
-        payload.technology_stack.database = { name: cols[1], version: cols[2] };
+        payload.technology_stack.database = { name: colName, version: colVer };
       }
     }
   }
@@ -361,11 +370,13 @@ function extractArchitectToDev(
 
     const purposeMatch = compBody.match(/\*\*Purpose:\*\*\s*(.+)/);
     const interfaceMatch = compBody.match(/\*\*Interface:\*\*\s*(.+)/);
+    const compName = match[1];
+    if (compName === undefined) continue;
 
     payload.components.push({
-      name: match[1].trim(),
-      purpose: purposeMatch ? purposeMatch[1].trim() : 'Not specified',
-      interface: interfaceMatch ? interfaceMatch[1].trim() : 'Not specified',
+      name: compName.trim(),
+      purpose: purposeMatch?.[1] !== undefined ? purposeMatch[1].trim() : 'Not specified',
+      interface: interfaceMatch?.[1] !== undefined ? interfaceMatch[1].trim() : 'Not specified',
     });
   }
 
@@ -373,19 +384,25 @@ function extractArchitectToDev(
   const taskRegex = /(M\d+-T\d+)\s*[:-]\s*(.+)/g;
   // biome-ignore lint/suspicious/noAssignInExpressions: standard regex.exec idiom
   while ((match = taskRegex.exec(content)) !== null) {
+    const taskId = match[1];
+    const taskTitle = match[2];
+    if (taskId === undefined || taskTitle === undefined) continue;
+    const milestone = taskId.split('-')[0];
+    if (milestone === undefined) continue;
     payload.task_list.push({
-      id: match[1],
-      title: match[2].trim(),
-      milestone: match[1].split('-')[0],
+      id: taskId,
+      title: taskTitle.trim(),
+      milestone,
     });
   }
 
   // Extract deployment info
   const deployMatch = content.match(/## Deployment\s*\n([\s\S]*?)(?=\n## |$)/);
-  if (deployMatch) {
+  if (deployMatch?.[1] !== undefined) {
     const body = deployMatch[1];
     const envMatch = body.match(/\*\*Environment:\*\*\s*(.+)/);
-    payload.deployment_strategy.environment = envMatch ? envMatch[1].trim() : 'production';
+    payload.deployment_strategy.environment =
+      envMatch?.[1] !== undefined ? envMatch[1].trim() : 'production';
   }
 
   return payload;
@@ -409,10 +426,12 @@ function extractDevToQa(content: string, _frontmatter: Record<string, unknown>):
   let match: RegExpExecArray | null;
   // biome-ignore lint/suspicious/noAssignInExpressions: standard regex.exec idiom
   while ((match = taskPattern.exec(content)) !== null) {
-    if (!seenTasks.has(match[1])) {
-      seenTasks.add(match[1]);
+    const tid = match[1];
+    if (tid === undefined) continue;
+    if (!seenTasks.has(tid)) {
+      seenTasks.add(tid);
       payload.implemented_tasks.push({
-        id: match[1],
+        id: tid,
         status: 'completed',
         files_changed: ['src/'],
       });
@@ -562,7 +581,7 @@ export function checkPhantomRequirements(
     let m: RegExpExecArray | null;
     // biome-ignore lint/suspicious/noAssignInExpressions: standard regex.exec idiom
     while ((m = pattern.exec(downstreamContent)) !== null) {
-      downstreamIds.add(m[1]);
+      if (m[1] !== undefined) downstreamIds.add(m[1]);
     }
   }
 
@@ -656,7 +675,7 @@ function extractMetric(text: string): string | null {
 
 function extractPriority(text: string): string | null {
   const m = text.match(/\*\*Priority:\*\*\s*(.+)/i);
-  if (!m) return null;
+  if (!m || m[1] === undefined) return null;
   const p = m[1].trim().toLowerCase();
   if (p.includes('must')) return 'must-have';
   if (p.includes('should')) return 'should-have';

--- a/src/lib/install.ts
+++ b/src/lib/install.ts
@@ -510,7 +510,7 @@ export function checkCompatibility(item: Item): CompatibilityResult {
   if (compat.jumpstartMode) {
     const range = compat.jumpstartMode;
     const match = range.match(/^>=\s*(\d+\.\d+\.\d+)$/);
-    if (match) {
+    if (match?.[1] !== undefined) {
       const minVersion = match[1];
       if (compareSemver(FRAMEWORK_VERSION, minVersion) < 0) {
         warnings.push(`Requires jumpstart-mode ${range} but found ${FRAMEWORK_VERSION}.`);
@@ -1185,7 +1185,7 @@ function installFromStaging(
 
   let contentRoot = stagingDir;
   const stagingEntries = readdirSync(stagingDir, { withFileTypes: true });
-  if (stagingEntries.length === 1 && stagingEntries[0].isDirectory()) {
+  if (stagingEntries.length === 1 && stagingEntries[0]?.isDirectory()) {
     contentRoot = path.join(stagingDir, stagingEntries[0].name);
   }
 
@@ -1535,8 +1535,11 @@ export async function install(
     }
 
     const primaryResult =
-      allResults.find((r) => r.item?.id === item.id) || allResults[allResults.length - 1];
-    if (primaryResult && allResults.length > 1) {
+      allResults.find((r) => r.item?.id === item.id) ?? allResults[allResults.length - 1];
+    if (primaryResult === undefined) {
+      throw new Error('Bundle install produced no results');
+    }
+    if (allResults.length > 1) {
       primaryResult.dependenciesInstalled = allResults
         .filter((r) => r.item?.id !== item.id)
         .map((r) => r.item?.id)

--- a/src/lib/integrate.ts
+++ b/src/lib/integrate.ts
@@ -197,10 +197,10 @@ export function parseSkillFrontmatter(content: string): SkillFrontmatter {
   const skillFenceMatch = content.match(/^```skill\s*\n---\n([\s\S]*?)\n---\s*\n/m);
   const standardFenceMatch = content.match(/^---\n([\s\S]*?)\n---\s*\n/m);
 
-  if (skillFenceMatch) {
+  if (skillFenceMatch?.[1] !== undefined) {
     yamlBlock = skillFenceMatch[1];
     result.body = content.slice(skillFenceMatch[0].length);
-  } else if (standardFenceMatch) {
+  } else if (standardFenceMatch?.[1] !== undefined) {
     yamlBlock = standardFenceMatch[1];
     result.body = content.slice(standardFenceMatch[0].length);
   }
@@ -208,13 +208,13 @@ export function parseSkillFrontmatter(content: string): SkillFrontmatter {
   for (const line of yamlBlock.split('\n')) {
     const nameMatch = line.match(/^name:\s*(.+)/);
     const descMatch = line.match(/^description:\s*['"]?([\s\S]+?)['"]?\s*$/);
-    if (nameMatch) result.name = nameMatch[1].trim();
-    if (descMatch) result.description = descMatch[1].trim();
+    if (nameMatch?.[1] !== undefined) result.name = nameMatch[1].trim();
+    if (descMatch?.[1] !== undefined) result.description = descMatch[1].trim();
   }
 
   // Discovery Keywords section (single line, comma-separated)
   const kwMatch = result.body.match(/## Discovery Keywords\s*\n([^\n#]+)/i);
-  if (kwMatch) {
+  if (kwMatch?.[1] !== undefined) {
     result.discoveryKeywords = kwMatch[1]
       .split(',')
       .map((k) => k.trim())
@@ -223,7 +223,7 @@ export function parseSkillFrontmatter(content: string): SkillFrontmatter {
 
   // Triggers section (bulleted list, terminates at next H2 or H1)
   const triggerMatch = result.body.match(/## Triggers\s*\n([\s\S]*?)(?=\n##|\n#[^#]|$)/i);
-  if (triggerMatch) {
+  if (triggerMatch?.[1] !== undefined) {
     result.triggers = triggerMatch[1]
       .split('\n')
       .map((l) => l.replace(/^[-*]\s*/, '').trim())
@@ -383,8 +383,7 @@ export function generateIDEInstructions(
         .filter((f) => f.endsWith('.agent.md'))
         .map(
           (f) =>
-            `@${basename(f, '.agent.md')
-              .split('.')[0]
+            `@${(basename(f, '.agent.md').split('.')[0] ?? '')
               .replace(/-/g, ' ')
               .replace(/\b\w/g, (c) => c.toUpperCase())}`
         )

--- a/src/lib/mock-responses.ts
+++ b/src/lib/mock-responses.ts
@@ -116,8 +116,12 @@ export function createMockRegistry(): MockRegistry {
         // 3. Fallback: pick recommended option, else first option
         if (q.options && q.options.length > 0) {
           const recommended = q.options.find((o) => o.recommended);
-          const selected = recommended ? recommended.label : q.options[0].label;
-          answers[header] = { selected: [selected], freeText: null, skipped: false };
+          const selected = recommended ? recommended.label : q.options[0]?.label;
+          if (selected !== undefined) {
+            answers[header] = { selected: [selected], freeText: null, skipped: false };
+          } else {
+            answers[header] = { selected: [], freeText: 'Approved', skipped: false };
+          }
         } else {
           answers[header] = { selected: [], freeText: 'Approved', skipped: false };
         }

--- a/src/lib/next-phase.ts
+++ b/src/lib/next-phase.ts
@@ -153,7 +153,9 @@ function isArtifactApproved(content: string): boolean {
   if (!/## Phase Gate Approval/i.test(content)) return false;
 
   const approvedByMatch = content.match(/\*\*Approved by:\*\*\s*(.+)/i);
-  if (!approvedByMatch || approvedByMatch[1].trim().toLowerCase() === 'pending') return false;
+  if (!approvedByMatch || (approvedByMatch[1] ?? '').trim().toLowerCase() === 'pending') {
+    return false;
+  }
 
   const gateSection = content.split(/## Phase Gate Approval/i)[1] || '';
   const unchecked = gateSection.match(/- \[ \]/g);
@@ -259,8 +261,8 @@ export function determineNextAction(options: NextActionOptions = {}): NextAction
           current_phase: 0,
           next_phase: 1,
           next_agent: 'analyst',
-          command: AGENT_COMMANDS.analyst,
-          message: `Phase 0 (Challenger) is already approved. Next: Phase 1 — ${PHASE_DESCRIPTIONS['1']}`,
+          command: AGENT_COMMANDS.analyst ?? '',
+          message: `Phase 0 (Challenger) is already approved. Next: Phase 1 — ${PHASE_DESCRIPTIONS['1'] ?? ''}`,
           context_files: getHandoff(0).context_files || [],
           focus: focusConfig?.enabled
             ? {
@@ -301,15 +303,15 @@ export function determineNextAction(options: NextActionOptions = {}): NextAction
         '3': 'architect',
         '4': 'developer',
       };
-      const agent = agentNames[String(focusStart)];
-      const command = AGENT_COMMANDS[agent];
+      const agent = agentNames[String(focusStart)] ?? 'challenger';
+      const command = AGENT_COMMANDS[agent] ?? '';
       return {
         action: 'start',
         current_phase: null,
         next_phase: focusStart,
         next_agent: agent,
         command,
-        message: `Focus mode active (${focusConfig.preset || 'custom'}). Start with Phase ${focusStart} — ${PHASE_DESCRIPTIONS[String(focusStart)]}`,
+        message: `Focus mode active (${focusConfig.preset || 'custom'}). Start with Phase ${focusStart} — ${PHASE_DESCRIPTIONS[String(focusStart)] ?? ''}`,
         context_files: [],
         focus: {
           active: true,
@@ -325,8 +327,8 @@ export function determineNextAction(options: NextActionOptions = {}): NextAction
         current_phase: null,
         next_phase: -1,
         next_agent: 'scout',
-        command: AGENT_COMMANDS.scout,
-        message: `Brownfield project detected. Start with the Scout to analyze the existing codebase. ${PHASE_DESCRIPTIONS['-1']}`,
+        command: AGENT_COMMANDS.scout ?? '',
+        message: `Brownfield project detected. Start with the Scout to analyze the existing codebase. ${PHASE_DESCRIPTIONS['-1'] ?? ''}`,
         context_files: [],
       };
     }
@@ -351,8 +353,8 @@ export function determineNextAction(options: NextActionOptions = {}): NextAction
         current_phase: -1,
         next_phase: 0,
         next_agent: 'challenger',
-        command: AGENT_COMMANDS.challenger,
-        message: `Scout phase is approved. Next: Phase 0 — ${PHASE_DESCRIPTIONS['0']}`,
+        command: AGENT_COMMANDS.challenger ?? '',
+        message: `Scout phase is approved. Next: Phase 0 — ${PHASE_DESCRIPTIONS['0'] ?? ''}`,
         context_files: getHandoff(-1).context_files || [],
       };
     }
@@ -362,8 +364,8 @@ export function determineNextAction(options: NextActionOptions = {}): NextAction
       current_phase: null,
       next_phase: 0,
       next_agent: 'challenger',
-      command: AGENT_COMMANDS.challenger,
-      message: `Ready to begin! Start with Phase 0 — ${PHASE_DESCRIPTIONS['0']}`,
+      command: AGENT_COMMANDS.challenger ?? '',
+      message: `Ready to begin! Start with Phase 0 — ${PHASE_DESCRIPTIONS['0'] ?? ''}`,
       context_files: [],
     };
   }
@@ -405,8 +407,8 @@ export function determineNextAction(options: NextActionOptions = {}): NextAction
     const artifactPath = join(root, artifactRelPath);
 
     if (!existsSync(artifactPath)) {
-      const agentName = PHASE_NAMES[String(currentPhase)].toLowerCase();
-      const command = AGENT_COMMANDS[agentName] || AGENT_COMMANDS[state.current_agent || ''];
+      const agentName = (PHASE_NAMES[String(currentPhase)] ?? '').toLowerCase();
+      const command = AGENT_COMMANDS[agentName] ?? AGENT_COMMANDS[state.current_agent || ''] ?? '';
       return {
         action: 'continue',
         current_phase: currentPhase,

--- a/src/lib/timeline.ts
+++ b/src/lib/timeline.ts
@@ -535,8 +535,16 @@ export function getTimelineSummary(filePath?: string): TimelineSummary {
     if (evt.session_id) sessions.add(evt.session_id);
   }
 
-  const firstTs = new Date(events[0].timestamp).getTime();
-  const lastTs = new Date(events[events.length - 1].timestamp).getTime();
+  const first = events[0];
+  const last = events[events.length - 1];
+  if (first === undefined || last === undefined) {
+    // Already returned EMPTY_SUMMARY at the top of the function for an
+    // empty events array; this branch is dead but exhaustive for the
+    // strict-flag check.
+    throw new Error('Unreachable — empty events handled earlier');
+  }
+  const firstTs = new Date(first.timestamp).getTime();
+  const lastTs = new Date(last.timestamp).getTime();
 
   return {
     total_events: events.length,
@@ -545,8 +553,8 @@ export function getTimelineSummary(filePath?: string): TimelineSummary {
     by_phase: byPhase,
     sessions: [...sessions],
     duration_ms: lastTs - firstTs,
-    first_event: events[0].timestamp,
-    last_event: events[events.length - 1].timestamp,
+    first_event: first.timestamp,
+    last_event: last.timestamp,
   };
 }
 
@@ -601,7 +609,9 @@ export function renderMarkdown(events: TimelineEvent[], options: RenderOptions =
   const lines: string[] = [];
   lines.push(`# ${title}\n`);
   lines.push(`**Events:** ${events.length}  `);
-  lines.push(`**Period:** ${events[0].timestamp} → ${events[events.length - 1].timestamp}  `);
+  lines.push(
+    `**Period:** ${events[0]?.timestamp ?? ''} → ${events[events.length - 1]?.timestamp ?? ''}  `
+  );
 
   const sessions = [...new Set(events.map((e) => e.session_id).filter(Boolean))];
   if (sessions.length > 0) {

--- a/src/lib/usage.ts
+++ b/src/lib/usage.ts
@@ -186,19 +186,17 @@ export function summarizeUsage(logPath: string): UsageSummary {
   const byAgent: Record<string, UsageBreakdown> = {};
 
   for (const entry of log.entries) {
-    if (!byPhase[entry.phase]) {
-      byPhase[entry.phase] = { tokens: 0, cost_usd: 0, sessions: 0 };
-    }
-    byPhase[entry.phase].tokens += entry.estimated_tokens;
-    byPhase[entry.phase].cost_usd += entry.estimated_cost_usd;
-    byPhase[entry.phase].sessions++;
+    const phaseBucket = byPhase[entry.phase] ?? { tokens: 0, cost_usd: 0, sessions: 0 };
+    phaseBucket.tokens += entry.estimated_tokens;
+    phaseBucket.cost_usd += entry.estimated_cost_usd;
+    phaseBucket.sessions++;
+    byPhase[entry.phase] = phaseBucket;
 
-    if (!byAgent[entry.agent]) {
-      byAgent[entry.agent] = { tokens: 0, cost_usd: 0, sessions: 0 };
-    }
-    byAgent[entry.agent].tokens += entry.estimated_tokens;
-    byAgent[entry.agent].cost_usd += entry.estimated_cost_usd;
-    byAgent[entry.agent].sessions++;
+    const agentBucket = byAgent[entry.agent] ?? { tokens: 0, cost_usd: 0, sessions: 0 };
+    agentBucket.tokens += entry.estimated_tokens;
+    agentBucket.cost_usd += entry.estimated_cost_usd;
+    agentBucket.sessions++;
+    byAgent[entry.agent] = agentBucket;
   }
 
   return {


### PR DESCRIPTION
## Summary

Phase 2d of [#31](https://github.com/scombey/JumpStart-AutoNav/issues/31). Closes the 81 errors across 11 files in the state + LLM + marketplace cluster that surface under `noUncheckedIndexedAccess`. Pure defensive guards; no runtime behavior change. Flag stays OFF until phase 3.

## Files touched

| File | Errors | Fix pattern |
|---|---|---|
| `handoff-validator.ts` | 26 | regex-capture guards across PRD/architect/dev-QA payload extractors; tech-stack table parser |
| `next-phase.ts` | 9 | PHASE_DESCRIPTIONS / AGENT_COMMANDS / PHASE_NAMES record-index `?? ''` |
| `focus.ts` | 9 | VALID_PRESETS catalog narrowing; regex-capture guards |
| `ceremony.ts` | 7 | keys[i] guard in nested-object writer; VALID_PROFILES narrowing |
| `integrate.ts` | 7 | SKILL.md frontmatter parser regex-capture guards |
| `usage.ts` | 6 | byPhase/byAgent bucket-upsert pattern |
| `timeline.ts` | 6 | events[0]/events[length-1] narrowing |
| `install.ts` | 4 | semver compat regex; stagingEntries[0]; bundle-result narrowing |
| `dashboard.ts` | 3 | line guard; typeMatch capture; firstScore reduce-seed |
| `cost-router.ts` | 3 | BUDGET_PROFILES narrowing |
| `mock-responses.ts` | 1 | q.options[0] guard |

## Test plan

- [x] `npx tsc --noEmit` — clean (flag stays OFF)
- [x] `npm run verify-baseline` — 12/12 green
- [x] `npm run lint` — clean
- [x] 3,421 tests pass

## Cluster progression

- phase 1   `exactOptionalPropertyTypes` ON         → #35 (`ed3aab2`)
- phase 2a  Foundation cluster                      → #37 (`5e93076`)
- phase 2b  Config cluster                          → #38 (`9b79a07`)
- phase 2c  Spec validation + graph cluster         → #40 (`1bdb356`)
- phase 2d  State + LLM + marketplace cluster       → **this PR**
- phase 2e  Governance + enterprise + collab        → next, largest cluster
- phase 2f  CLI commands                            → last per-cluster
- phase 3   Final flag-flip                         → tiny once all clusters done

## Refs

- T6.6 / issue #31 phase 2d