### PR TITLE
feat(m11-batch3): port 4 legacy modules — legacy-modernizer, agent-checkpoint, release-readiness, template-merge

### DIFF
--- a/src/cli/commands/enterprise.ts
+++ b/src/cli/commands/enterprise.ts
@@ -36,6 +36,7 @@
 import { defineCommand } from 'citty';
 import * as legacyEnterpriseSearch from '../../lib/enterprise-search.js';
 import * as legacyEnterpriseTemplates from '../../lib/enterprise-templates.js';
+import * as legacyLegacyModernizer from '../../lib/legacy-modernizer.js';
 import * as legacyMigrationPlanner from '../../lib/migration-planner.js';
 import * as legacyPatternLibrary from '../../lib/pattern-library.js';
 import * as legacyPersonaPacks from '../../lib/persona-packs.js';
@@ -380,17 +381,40 @@ export const knowledgeGraphCommand = defineCommand({
 export interface LegacyModernizerArgs {
   action?: string | undefined;
   arg?: string | undefined;
+  platform?: string | undefined;
   json?: boolean | undefined;
 }
 
 export function legacyModernizerImpl(deps: Deps, args: LegacyModernizerArgs): CommandResult {
-  const lib = legacyRequire<LegacyLib>('legacy-modernizer');
-  const action = args.action ?? 'scan';
+  // M11 strangler-tail cleanup: switched from `legacyRequire('legacy-modernizer')`
+  // to a static import of the TS port at `src/lib/legacy-modernizer.ts`. The
+  // previous wiring called `lib.scan` / `lib.planModernization` — neither was
+  // exported by the legacy module, so the command silently produced
+  // `undefined` results regardless of arg shape. Replaced with the actual
+  // legacy contract: `assessSystem` / `createPlan` / `generateReport`. The
+  // legacy CLI default action was `report` (see bin/cli.js ~3982), preserved.
+  const stateFile = safeJoin(deps, '.jumpstart', 'state', 'legacy-modernization.json');
+  const action = args.action ?? 'report';
   let result: unknown;
-  if (action === 'plan') {
-    result = lib.planModernization?.(deps.projectRoot) ?? lib.scan?.(deps.projectRoot);
+  if (action === 'assess') {
+    if (!args.arg) {
+      deps.logger.error(
+        'Usage: jumpstart-mode legacy-modernizer assess <name> --platform <platform>'
+      );
+      return { exitCode: 1 };
+    }
+    result = legacyLegacyModernizer.assessSystem(
+      { name: args.arg, platform: args.platform ?? 'unknown' },
+      { stateFile }
+    );
+  } else if (action === 'plan') {
+    if (!args.arg) {
+      deps.logger.error('Usage: jumpstart-mode legacy-modernizer plan <assessment-id>');
+      return { exitCode: 1 };
+    }
+    result = legacyLegacyModernizer.createPlan(args.arg, {}, { stateFile });
   } else {
-    result = lib.scan?.(deps.projectRoot) ?? lib.scanLegacy?.(deps.projectRoot);
+    result = legacyLegacyModernizer.generateReport({ stateFile });
   }
   maybeJson(deps, args.json, result);
   if (!args.json) deps.logger.info(`Legacy modernizer: ${action}`);
@@ -400,14 +424,20 @@ export function legacyModernizerImpl(deps: Deps, args: LegacyModernizerArgs): Co
 export const legacyModernizerCommand = defineCommand({
   meta: { name: 'legacy-modernizer', description: 'Legacy code modernization scanner' },
   args: {
-    action: { type: 'positional', required: false, description: 'scan | plan' },
-    arg: { type: 'positional', required: false, description: 'optional argument' },
+    action: { type: 'positional', required: false, description: 'report | assess | plan' },
+    arg: {
+      type: 'positional',
+      required: false,
+      description: 'name (assess) or assessment id (plan)',
+    },
+    platform: { type: 'string', required: false, description: 'legacy platform (assess only)' },
     json: { type: 'boolean', required: false, description: 'JSON output' },
   },
   run({ args }) {
     const r = legacyModernizerImpl(createRealDeps(), {
       action: args.action,
       arg: args.arg,
+      platform: args.platform,
       json: Boolean(args.json),
     });
     if (r.exitCode !== 0) throw new Error(r.message ?? 'legacy-modernizer failed');

--- a/src/cli/commands/enterprise.ts
+++ b/src/cli/commands/enterprise.ts
@@ -42,8 +42,9 @@ import * as legacyPatternLibrary from '../../lib/pattern-library.js';
 import * as legacyPersonaPacks from '../../lib/persona-packs.js';
 import * as legacyPlatformEngineering from '../../lib/platform-engineering.js';
 import * as legacyReleaseReadiness from '../../lib/release-readiness.js';
+import * as legacyTemplateMerge from '../../lib/template-merge.js';
 import { type CommandResult, createRealDeps, type Deps } from '../deps.js';
-import { assertUserPath, legacyImport, legacyRequire, safeJoin } from './_helpers.js';
+import { assertUserPath, legacyRequire, safeJoin } from './_helpers.js';
 
 // Permissive shape for legacy lib modules — every callsite immediately narrows
 // via property access. Documenting once here so individual commands stay terse.
@@ -454,10 +455,13 @@ export interface MergeTemplatesArgs {
   projectPath?: string | undefined;
 }
 
-export async function mergeTemplatesImpl(
-  deps: Deps,
-  args: MergeTemplatesArgs
-): Promise<CommandResult> {
+// M11 strangler-tail cleanup: switched from async `legacyImport('template-merge')`
+// (M9 ESM-cutover shim) to a static import of the TS port at
+// `src/lib/template-merge.ts`. Now sync — `await` at call sites is a no-op.
+// The M8 + M9 regression tests in tests/test-m9-pitcrew-regressions.test.ts
+// + tests/test-cli-enterprise.test.ts continue to use `await mergeTemplatesImpl(...)`
+// for back-compat; both still pass.
+export function mergeTemplatesImpl(deps: Deps, args: MergeTemplatesArgs): CommandResult {
   if (!args.basePath || !args.projectPath) {
     deps.logger.error('Usage: jumpstart-mode merge-templates <base-path> <project-path>');
     return { exitCode: 1 };
@@ -467,9 +471,7 @@ export async function mergeTemplatesImpl(
   // which keeps both inside projectRoot per ADR-009.
   const safeBase = assertUserPath(deps, args.basePath, 'merge-templates:base');
   const safeProject = assertUserPath(deps, args.projectPath, 'merge-templates:project');
-  // M9 ESM cutover: template-merge is an ESM legacy module (.mjs).
-  const lib = await legacyImport<LegacyLib>('template-merge');
-  const result = lib.mergeTemplateFiles(safeBase, safeProject);
+  const result = legacyTemplateMerge.mergeTemplateFiles(safeBase, safeProject);
   deps.logger.info(JSON.stringify({ stats: result.stats }, null, 2));
   if (result.merged) deps.logger.info(result.merged);
   return { exitCode: 0 };
@@ -481,8 +483,8 @@ export const mergeTemplatesCommand = defineCommand({
     basePath: { type: 'positional', required: false, description: 'base template path' },
     projectPath: { type: 'positional', required: false, description: 'project path' },
   },
-  async run({ args }) {
-    const r = await mergeTemplatesImpl(createRealDeps(), {
+  run({ args }) {
+    const r = mergeTemplatesImpl(createRealDeps(), {
       basePath: args.basePath,
       projectPath: args.projectPath,
     });

--- a/src/cli/commands/enterprise.ts
+++ b/src/cli/commands/enterprise.ts
@@ -41,6 +41,7 @@ import * as legacyMigrationPlanner from '../../lib/migration-planner.js';
 import * as legacyPatternLibrary from '../../lib/pattern-library.js';
 import * as legacyPersonaPacks from '../../lib/persona-packs.js';
 import * as legacyPlatformEngineering from '../../lib/platform-engineering.js';
+import * as legacyReleaseReadiness from '../../lib/release-readiness.js';
 import { type CommandResult, createRealDeps, type Deps } from '../deps.js';
 import { assertUserPath, legacyImport, legacyRequire, safeJoin } from './_helpers.js';
 
@@ -946,15 +947,23 @@ export interface ReleaseReadinessArgs {
 }
 
 export function releaseReadinessImpl(deps: Deps, args: ReleaseReadinessArgs): CommandResult {
-  const lib = legacyRequire<LegacyLib>('release-readiness');
+  // M11 strangler-tail cleanup: switched from `legacyRequire('release-readiness')`
+  // to a static import of the TS port at `src/lib/release-readiness.ts`. The
+  // previous wiring called `lib.checkReadiness` / `lib.getStatus` — neither was
+  // exported by the legacy module, so the command silently produced
+  // `undefined` results regardless of arg shape. Replaced with the actual
+  // legacy contract: `assessReadiness` / `generateReport`. The legacy CLI
+  // route (bin/cli.js ~3450) ultimately calls `assessReadiness` on the
+  // happy path, preserved as the default `check` action.
   const action = args.action ?? 'check';
   const stateFile = safeJoin(deps, '.jumpstart', 'state', 'release-readiness.json');
   let result: unknown;
   if (action === 'check') {
-    result = lib.checkReadiness?.(deps.projectRoot, { stateFile });
+    result = legacyReleaseReadiness.assessReadiness(deps.projectRoot, { stateFile });
+  } else if (action === 'report' || action === 'status') {
+    result = legacyReleaseReadiness.generateReport({ stateFile });
   } else {
-    result =
-      lib.getStatus?.({ stateFile }) ?? lib.checkReadiness?.(deps.projectRoot, { stateFile });
+    result = legacyReleaseReadiness.assessReadiness(deps.projectRoot, { stateFile });
   }
   maybeJson(deps, args.json, result);
   if (!args.json) deps.logger.info(`Release readiness: ${action}`);
@@ -964,7 +973,7 @@ export function releaseReadinessImpl(deps: Deps, args: ReleaseReadinessArgs): Co
 export const releaseReadinessCommand = defineCommand({
   meta: { name: 'release-readiness', description: 'Release readiness checklist' },
   args: {
-    action: { type: 'positional', required: false, description: 'check | status' },
+    action: { type: 'positional', required: false, description: 'check | report | status' },
     arg: { type: 'positional', required: false, description: 'optional argument' },
     json: { type: 'boolean', required: false, description: 'JSON output' },
   },

--- a/src/cli/commands/lifecycle.ts
+++ b/src/cli/commands/lifecycle.ts
@@ -29,6 +29,7 @@
 import { existsSync } from 'node:fs';
 import * as path from 'node:path';
 import { defineCommand } from 'citty';
+import * as legacyAgentCheckpoint from '../../lib/agent-checkpoint.js';
 import {
   approveArtifact,
   detectCurrentArtifact,
@@ -265,37 +266,23 @@ export interface AgentCheckpointArgs {
   json?: boolean | undefined;
 }
 
-interface AgentCheckpointLib {
-  saveCheckpoint: (
-    payload: { agent: string; type: string },
-    opts: { stateFile: string }
-  ) => { checkpoint: { id: string } };
-  restoreCheckpoint: (
-    cpId: string,
-    opts: { stateFile: string }
-  ) => { success: boolean; checkpoint?: { id: string }; error?: string };
-  cleanCheckpoints: (opts: { stateFile: string }) => { removed: number; remaining: number };
-  listCheckpoints: (
-    filter: Record<string, unknown>,
-    opts: { stateFile: string }
-  ) => {
-    total: number;
-    checkpoints: { id: string; agent: string; phase?: string; saved_at: string }[];
-  };
-}
-
 export function agentCheckpointImpl(deps: Deps, args: AgentCheckpointArgs): CommandResult {
-  const lib = legacyRequire<AgentCheckpointLib>('agent-checkpoint');
+  // M11 strangler-tail cleanup: switched from `legacyRequire('agent-checkpoint')`
+  // to a static import of the TS port at `src/lib/agent-checkpoint.ts`. Public
+  // surface preserved verbatim — see refs in tests/test-agent-checkpoint.test.ts.
   const stateFile = safeJoin(deps, '.jumpstart', 'state', 'agent-checkpoints.json');
   const action = args.action ?? 'list';
 
   if (action === 'save') {
     const agent = args.arg ?? 'cli';
-    const result = lib.saveCheckpoint({ agent, type: 'manual' }, { stateFile });
+    const result = legacyAgentCheckpoint.saveCheckpoint({ agent, type: 'manual' }, { stateFile });
     if (args.json) {
       writeResult(result as unknown as Record<string, unknown>);
-    } else {
+    } else if (result.success) {
       deps.logger.success(`Checkpoint saved: ${result.checkpoint.id}`);
+    } else {
+      deps.logger.error(result.error);
+      return { exitCode: 1 };
     }
     return { exitCode: 0 };
   }
@@ -304,10 +291,10 @@ export function agentCheckpointImpl(deps: Deps, args: AgentCheckpointArgs): Comm
       deps.logger.error('Usage: jumpstart-mode agent-checkpoint restore <checkpoint-id>');
       return { exitCode: 1 };
     }
-    const result = lib.restoreCheckpoint(args.arg, { stateFile });
+    const result = legacyAgentCheckpoint.restoreCheckpoint(args.arg, { stateFile });
     if (args.json) {
       writeResult(result as unknown as Record<string, unknown>);
-    } else if (result.success && result.checkpoint) {
+    } else if (result.success) {
       deps.logger.success(`Restored: ${result.checkpoint.id}`);
     } else {
       deps.logger.error(result.error ?? 'restore failed');
@@ -316,7 +303,7 @@ export function agentCheckpointImpl(deps: Deps, args: AgentCheckpointArgs): Comm
     return { exitCode: 0 };
   }
   if (action === 'clean') {
-    const result = lib.cleanCheckpoints({ stateFile });
+    const result = legacyAgentCheckpoint.cleanCheckpoints({ stateFile });
     if (args.json) {
       writeResult(result as unknown as Record<string, unknown>);
     } else {
@@ -325,13 +312,13 @@ export function agentCheckpointImpl(deps: Deps, args: AgentCheckpointArgs): Comm
     return { exitCode: 0 };
   }
   // list (default)
-  const result = lib.listCheckpoints({}, { stateFile });
+  const result = legacyAgentCheckpoint.listCheckpoints({}, { stateFile });
   if (args.json) {
     writeResult(result as unknown as Record<string, unknown>);
   } else {
     deps.logger.info(`Checkpoints (${result.total})`);
     for (const c of result.checkpoints) {
-      deps.logger.info(`  ${c.id}: ${c.agent} ${c.phase || ''} (${c.saved_at})`);
+      deps.logger.info(`  ${c.id}: ${c.agent} ${c.phase ?? ''} (${c.saved_at})`);
     }
   }
   return { exitCode: 0 };

--- a/src/lib/agent-checkpoint.ts
+++ b/src/lib/agent-checkpoint.ts
@@ -1,0 +1,289 @@
+/**
+ * agent-checkpoint.ts — Agent Self-Checkpoint & Resume port (M11 batch 3).
+ *
+ * Pure-library port of `bin/lib/agent-checkpoint.js`. Public surface
+ * preserved verbatim by name + signature:
+ *
+ *   - `defaultState()` => AgentCheckpointState
+ *   - `loadState(stateFile?)` => AgentCheckpointState
+ *   - `saveState(state, stateFile?)` => void
+ *   - `saveCheckpoint(checkpoint, options?)` => SaveCheckpointResult
+ *   - `restoreCheckpoint(checkpointId?, options?)` => RestoreCheckpointResult
+ *   - `listCheckpoints(filter?, options?)` => ListCheckpointsResult
+ *   - `cleanCheckpoints(options?)` => CleanCheckpointsResult
+ *   - `CHECKPOINT_TYPES`
+ *
+ * Behavior parity:
+ *   - Default state file: `.jumpstart/state/agent-checkpoints.json`.
+ *   - 6 checkpoint types: phase-start, phase-end, task-start, task-end,
+ *     error-recovery, manual.
+ *   - Auto-trim to last 50 checkpoints on save.
+ *   - cleanCheckpoints default keep=10.
+ *   - M3 hardening: shape-validated JSON; rejects __proto__/constructor/
+ *     prototype keys recursively; defaultState fallback on parse failure.
+ *
+ * @see bin/lib/agent-checkpoint.js (legacy reference)
+ * @see specs/implementation-plan.md M11 strangler cleanup
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+const DEFAULT_STATE_FILE = join('.jumpstart', 'state', 'agent-checkpoints.json');
+
+export const CHECKPOINT_TYPES = [
+  'phase-start',
+  'phase-end',
+  'task-start',
+  'task-end',
+  'error-recovery',
+  'manual',
+] as const;
+
+export type CheckpointType = (typeof CHECKPOINT_TYPES)[number];
+
+export interface AgentCheckpoint {
+  id: string;
+  agent: string;
+  phase: string | null;
+  task: string | null;
+  type: string;
+  context: Record<string, unknown>;
+  files_snapshot: string[];
+  saved_at: string;
+}
+
+export interface RecoveryLogEntry {
+  checkpoint_id: string;
+  restored_at: string;
+}
+
+export interface AgentCheckpointState {
+  version: string;
+  created_at: string;
+  last_updated: string | null;
+  checkpoints: AgentCheckpoint[];
+  recovery_log: RecoveryLogEntry[];
+}
+
+export interface SaveCheckpointInput {
+  agent: string;
+  phase?: string | null | undefined;
+  task?: string | null | undefined;
+  type?: string | undefined;
+  context?: Record<string, unknown> | undefined;
+  files_snapshot?: string[] | undefined;
+}
+
+export interface SaveCheckpointOptions {
+  stateFile?: string | undefined;
+}
+
+export type SaveCheckpointResult =
+  | { success: true; checkpoint: AgentCheckpoint }
+  | { success: false; error: string };
+
+export interface RestoreCheckpointOptions {
+  stateFile?: string | undefined;
+}
+
+export type RestoreCheckpointResult =
+  | {
+      success: true;
+      checkpoint: AgentCheckpoint;
+      agent: string;
+      phase: string | null;
+      task: string | null;
+      context: Record<string, unknown>;
+    }
+  | { success: false; error: string };
+
+export interface CheckpointFilter {
+  agent?: string | undefined;
+  phase?: string | undefined;
+  type?: string | undefined;
+}
+
+export interface ListCheckpointsOptions {
+  stateFile?: string | undefined;
+}
+
+export interface ListCheckpointsResult {
+  success: true;
+  checkpoints: AgentCheckpoint[];
+  total: number;
+}
+
+export interface CleanCheckpointsOptions {
+  stateFile?: string | undefined;
+  keep?: number | undefined;
+}
+
+export interface CleanCheckpointsResult {
+  success: true;
+  removed: number;
+  remaining: number;
+}
+
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function hasForbiddenKey(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    for (const item of value) if (hasForbiddenKey(item)) return true;
+    return false;
+  }
+  if (!isPlainObject(value)) return false;
+  for (const key of Object.keys(value)) {
+    if (FORBIDDEN_KEYS.has(key)) return true;
+    if (hasForbiddenKey(value[key])) return true;
+  }
+  return false;
+}
+
+export function defaultState(): AgentCheckpointState {
+  return {
+    version: '1.0.0',
+    created_at: new Date().toISOString(),
+    last_updated: null,
+    checkpoints: [],
+    recovery_log: [],
+  };
+}
+
+export function loadState(stateFile?: string | undefined): AgentCheckpointState {
+  const filePath = stateFile ?? DEFAULT_STATE_FILE;
+  if (!existsSync(filePath)) return defaultState();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(filePath, 'utf8'));
+  } catch {
+    return defaultState();
+  }
+  if (!isPlainObject(parsed) || hasForbiddenKey(parsed)) return defaultState();
+  return parsed as unknown as AgentCheckpointState;
+}
+
+export function saveState(state: AgentCheckpointState, stateFile?: string | undefined): void {
+  const filePath = stateFile ?? DEFAULT_STATE_FILE;
+  const dir = dirname(filePath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  state.last_updated = new Date().toISOString();
+  writeFileSync(filePath, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
+}
+
+/**
+ * Save a checkpoint. Auto-trims `state.checkpoints` to the most recent
+ * 50 entries (legacy parity — see bin/lib/agent-checkpoint.js:75-77).
+ */
+export function saveCheckpoint(
+  checkpoint: SaveCheckpointInput | null | undefined,
+  options: SaveCheckpointOptions = {}
+): SaveCheckpointResult {
+  if (!checkpoint?.agent) {
+    return { success: false, error: 'agent is required' };
+  }
+
+  const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
+  const state = loadState(stateFile);
+
+  const cp: AgentCheckpoint = {
+    id: `CP-${Date.now().toString(36).toUpperCase()}`,
+    agent: checkpoint.agent,
+    phase: checkpoint.phase ?? null,
+    task: checkpoint.task ?? null,
+    type: checkpoint.type ?? 'manual',
+    context: checkpoint.context ?? {},
+    files_snapshot: checkpoint.files_snapshot ?? [],
+    saved_at: new Date().toISOString(),
+  };
+
+  state.checkpoints.push(cp);
+
+  // Keep only the most recent 50 checkpoints (legacy parity).
+  if (state.checkpoints.length > 50) {
+    state.checkpoints = state.checkpoints.slice(-50);
+  }
+
+  saveState(state, stateFile);
+
+  return { success: true, checkpoint: cp };
+}
+
+/**
+ * Restore a checkpoint. If `checkpointId` is omitted, restores from the
+ * most recent checkpoint. Pushes a recovery_log entry on success.
+ */
+export function restoreCheckpoint(
+  checkpointId?: string | undefined,
+  options: RestoreCheckpointOptions = {}
+): RestoreCheckpointResult {
+  const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
+  const state = loadState(stateFile);
+
+  let checkpoint: AgentCheckpoint | undefined;
+  if (checkpointId) {
+    checkpoint = state.checkpoints.find((c) => c.id === checkpointId);
+  } else {
+    checkpoint = state.checkpoints[state.checkpoints.length - 1];
+  }
+
+  if (!checkpoint) {
+    return {
+      success: false,
+      error: checkpointId ? `Checkpoint not found: ${checkpointId}` : 'No checkpoints available',
+    };
+  }
+
+  state.recovery_log.push({
+    checkpoint_id: checkpoint.id,
+    restored_at: new Date().toISOString(),
+  });
+  saveState(state, stateFile);
+
+  return {
+    success: true,
+    checkpoint,
+    agent: checkpoint.agent,
+    phase: checkpoint.phase,
+    task: checkpoint.task,
+    context: checkpoint.context,
+  };
+}
+
+/**
+ * List available checkpoints. Optional filter by `agent` / `phase` / `type`.
+ */
+export function listCheckpoints(
+  filter: CheckpointFilter = {},
+  options: ListCheckpointsOptions = {}
+): ListCheckpointsResult {
+  const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
+  const state = loadState(stateFile);
+  let checkpoints = state.checkpoints;
+
+  if (filter.agent) checkpoints = checkpoints.filter((c) => c.agent === filter.agent);
+  if (filter.phase) checkpoints = checkpoints.filter((c) => c.phase === filter.phase);
+  if (filter.type) checkpoints = checkpoints.filter((c) => c.type === filter.type);
+
+  return { success: true, checkpoints, total: checkpoints.length };
+}
+
+/**
+ * Clean old checkpoints. `keep` defaults to 10 (legacy parity).
+ * `removed` is `Math.max(0, checkpoints.length - keep)`.
+ */
+export function cleanCheckpoints(options: CleanCheckpointsOptions = {}): CleanCheckpointsResult {
+  const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
+  const state = loadState(stateFile);
+  const keep = options.keep ?? 10;
+  const removed = Math.max(0, state.checkpoints.length - keep);
+
+  state.checkpoints = state.checkpoints.slice(-keep);
+  saveState(state, stateFile);
+
+  return { success: true, removed, remaining: state.checkpoints.length };
+}

--- a/src/lib/legacy-modernizer.ts
+++ b/src/lib/legacy-modernizer.ts
@@ -1,0 +1,299 @@
+/**
+ * legacy-modernizer.ts — Legacy Code Modernization Mode port (M11 batch 3).
+ *
+ * Pure-library port of `bin/lib/legacy-modernizer.js`. Public surface
+ * preserved verbatim by name + signature:
+ *
+ *   - `defaultState()` => LegacyModernizerState
+ *   - `loadState(stateFile?)` => LegacyModernizerState
+ *   - `saveState(state, stateFile?)` => void
+ *   - `assessSystem(system, options?)` => AssessSystemResult
+ *   - `createPlan(assessmentId, plan, options?)` => CreatePlanResult
+ *   - `generateReport(options?)` => LegacyModernizerReport
+ *   - `LEGACY_PLATFORMS`, `MODERNIZATION_PATTERNS`
+ *
+ * Behavior parity:
+ *   - Default state file: `.jumpstart/state/legacy-modernization.json`.
+ *   - 8 known platforms (cobol, dotnet-framework, java-monolith, ssis,
+ *     angular-legacy, react-legacy, jquery, php-legacy). Unknown platforms
+ *     fall back to medium-risk + phased-cutover.
+ *   - 5 modernization patterns.
+ *   - M3 hardening: shape-validated JSON; rejects __proto__/constructor/
+ *     prototype keys; defaultState fallback on parse failure.
+ *
+ * @see bin/lib/legacy-modernizer.js (legacy reference)
+ * @see specs/implementation-plan.md M11 strangler cleanup
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+const DEFAULT_STATE_FILE = join('.jumpstart', 'state', 'legacy-modernization.json');
+
+export interface LegacyPlatformInfo {
+  risk: 'low' | 'medium' | 'high';
+  strategy: string;
+  estimated_effort: 'low' | 'medium' | 'high' | 'very-high';
+}
+
+export const LEGACY_PLATFORMS: Record<string, LegacyPlatformInfo> = {
+  cobol: { risk: 'high', strategy: 'strangler-fig', estimated_effort: 'very-high' },
+  'dotnet-framework': { risk: 'medium', strategy: 'phased-cutover', estimated_effort: 'high' },
+  'java-monolith': { risk: 'medium', strategy: 'strangler-fig', estimated_effort: 'high' },
+  ssis: { risk: 'medium', strategy: 'phased-cutover', estimated_effort: 'medium' },
+  'angular-legacy': { risk: 'low', strategy: 'phased-cutover', estimated_effort: 'medium' },
+  'react-legacy': { risk: 'low', strategy: 'in-place', estimated_effort: 'low' },
+  jquery: { risk: 'low', strategy: 'phased-cutover', estimated_effort: 'medium' },
+  'php-legacy': { risk: 'medium', strategy: 'strangler-fig', estimated_effort: 'high' },
+};
+
+export const MODERNIZATION_PATTERNS = [
+  'strangler-fig',
+  'phased-cutover',
+  'big-bang',
+  'in-place',
+  'rewrite',
+] as const;
+
+export type ModernizationPattern = (typeof MODERNIZATION_PATTERNS)[number];
+
+export interface LegacyAssessment {
+  id: string;
+  name: string;
+  platform: string;
+  age_years: number | null;
+  loc: number | null;
+  risk_level: string;
+  recommended_strategy: string;
+  estimated_effort: string;
+  modernization_targets: string[];
+  assessed_at: string;
+}
+
+export interface ModernizationPhase {
+  order: number;
+  name: string;
+  status: 'pending' | 'in-progress' | 'completed';
+}
+
+export interface ModernizationPlan {
+  id: string;
+  assessment_id: string;
+  source_platform: string;
+  target_platform: string;
+  strategy: string;
+  phases: ModernizationPhase[];
+  timeline: string | null;
+  created_at: string;
+}
+
+export interface LegacyModernizerState {
+  version: string;
+  created_at: string;
+  last_updated: string | null;
+  assessments: LegacyAssessment[];
+  modernization_plans: ModernizationPlan[];
+}
+
+export interface AssessSystemInput {
+  name: string;
+  platform: string;
+  age_years?: number | null | undefined;
+  loc?: number | null | undefined;
+  modernization_targets?: string[] | undefined;
+}
+
+export interface AssessSystemOptions {
+  stateFile?: string | undefined;
+}
+
+export type AssessSystemResult =
+  | { success: true; assessment: LegacyAssessment }
+  | { success: false; error: string };
+
+export interface CreatePlanInput {
+  target_platform?: string | undefined;
+  phases?: Array<string | { name: string }> | undefined;
+  timeline?: string | null | undefined;
+}
+
+export interface CreatePlanOptions {
+  stateFile?: string | undefined;
+}
+
+export type CreatePlanResult =
+  | { success: true; plan: ModernizationPlan }
+  | { success: false; error: string };
+
+export interface GenerateReportOptions {
+  stateFile?: string | undefined;
+}
+
+export interface LegacyModernizerReport {
+  success: true;
+  total_assessments: number;
+  total_plans: number;
+  by_platform: Record<string, number>;
+  by_risk: Record<string, number>;
+  assessments: LegacyAssessment[];
+}
+
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function hasForbiddenKey(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    for (const item of value) if (hasForbiddenKey(item)) return true;
+    return false;
+  }
+  if (!isPlainObject(value)) return false;
+  for (const key of Object.keys(value)) {
+    if (FORBIDDEN_KEYS.has(key)) return true;
+    if (hasForbiddenKey(value[key])) return true;
+  }
+  return false;
+}
+
+export function defaultState(): LegacyModernizerState {
+  return {
+    version: '1.0.0',
+    created_at: new Date().toISOString(),
+    last_updated: null,
+    assessments: [],
+    modernization_plans: [],
+  };
+}
+
+export function loadState(stateFile?: string | undefined): LegacyModernizerState {
+  const filePath = stateFile ?? DEFAULT_STATE_FILE;
+  if (!existsSync(filePath)) return defaultState();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(filePath, 'utf8'));
+  } catch {
+    return defaultState();
+  }
+  if (!isPlainObject(parsed) || hasForbiddenKey(parsed)) return defaultState();
+  return parsed as unknown as LegacyModernizerState;
+}
+
+export function saveState(state: LegacyModernizerState, stateFile?: string | undefined): void {
+  const filePath = stateFile ?? DEFAULT_STATE_FILE;
+  const dir = dirname(filePath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  state.last_updated = new Date().toISOString();
+  writeFileSync(filePath, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
+}
+
+/**
+ * Assess a legacy system for modernization.
+ *
+ * Mirrors legacy `assessSystem` shape verbatim. Unknown platforms fall
+ * back to medium-risk / phased-cutover / medium-effort, matching the
+ * legacy `||` defaulting.
+ */
+export function assessSystem(
+  system: AssessSystemInput | null | undefined,
+  options: AssessSystemOptions = {}
+): AssessSystemResult {
+  if (!system?.name || !system.platform) {
+    return { success: false, error: 'name and platform are required' };
+  }
+
+  const platform = system.platform.toLowerCase();
+  const platformInfo: LegacyPlatformInfo = LEGACY_PLATFORMS[platform] ?? {
+    risk: 'medium',
+    strategy: 'phased-cutover',
+    estimated_effort: 'medium',
+  };
+
+  const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
+  const state = loadState(stateFile);
+
+  const assessment: LegacyAssessment = {
+    id: `LEG-${(state.assessments.length + 1).toString().padStart(3, '0')}`,
+    name: system.name,
+    platform,
+    age_years: system.age_years ?? null,
+    loc: system.loc ?? null,
+    risk_level: platformInfo.risk,
+    recommended_strategy: platformInfo.strategy,
+    estimated_effort: platformInfo.estimated_effort,
+    modernization_targets: system.modernization_targets ?? [],
+    assessed_at: new Date().toISOString(),
+  };
+
+  state.assessments.push(assessment);
+  saveState(state, stateFile);
+
+  return { success: true, assessment };
+}
+
+/**
+ * Create a modernization plan for an existing assessment. Returns
+ * `success: false` if the assessment id can't be found in the state.
+ */
+export function createPlan(
+  assessmentId: string,
+  plan: CreatePlanInput,
+  options: CreatePlanOptions = {}
+): CreatePlanResult {
+  const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
+  const state = loadState(stateFile);
+
+  const assessment = state.assessments.find((a) => a.id === assessmentId);
+  if (!assessment) {
+    return { success: false, error: `Assessment not found: ${assessmentId}` };
+  }
+
+  const phasesInput = plan.phases ?? ['assess', 'plan', 'implement', 'validate', 'cutover'];
+  const phases: ModernizationPhase[] = phasesInput.map((p, i) => ({
+    order: i + 1,
+    name: typeof p === 'string' ? p : p.name,
+    status: 'pending',
+  }));
+
+  const modPlan: ModernizationPlan = {
+    id: `MOD-${(state.modernization_plans.length + 1).toString().padStart(3, '0')}`,
+    assessment_id: assessmentId,
+    source_platform: assessment.platform,
+    target_platform: plan.target_platform ?? 'modern-stack',
+    strategy: assessment.recommended_strategy,
+    phases,
+    timeline: plan.timeline ?? null,
+    created_at: new Date().toISOString(),
+  };
+
+  state.modernization_plans.push(modPlan);
+  saveState(state, stateFile);
+
+  return { success: true, plan: modPlan };
+}
+
+/**
+ * Generate a modernization report aggregating assessments by platform
+ * + risk level. Mirrors legacy reduce logic verbatim.
+ */
+export function generateReport(options: GenerateReportOptions = {}): LegacyModernizerReport {
+  const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
+  const state = loadState(stateFile);
+
+  const byPlatform: Record<string, number> = {};
+  const byRisk: Record<string, number> = {};
+  for (const a of state.assessments) {
+    byPlatform[a.platform] = (byPlatform[a.platform] ?? 0) + 1;
+    byRisk[a.risk_level] = (byRisk[a.risk_level] ?? 0) + 1;
+  }
+
+  return {
+    success: true,
+    total_assessments: state.assessments.length,
+    total_plans: state.modernization_plans.length,
+    by_platform: byPlatform,
+    by_risk: byRisk,
+    assessments: state.assessments,
+  };
+}

--- a/src/lib/release-readiness.ts
+++ b/src/lib/release-readiness.ts
@@ -1,0 +1,307 @@
+/**
+ * release-readiness.ts — Release Readiness Reviews port (M11 batch 3).
+ *
+ * Pure-library port of `bin/lib/release-readiness.js`. Public surface
+ * preserved verbatim by name + signature:
+ *
+ *   - `defaultState()` => ReleaseReadinessState
+ *   - `loadState(stateFile?)` => ReleaseReadinessState
+ *   - `saveState(state, stateFile?)` => void
+ *   - `assessReadiness(root, options?)` => AssessReadinessResult
+ *   - `generateReport(options?)` => GenerateReportResult
+ *   - `READINESS_CATEGORIES`, `READINESS_LEVELS`
+ *
+ * Behavior parity:
+ *   - 8 readiness categories: quality, security, performance, dependencies,
+ *     documentation, rollback, monitoring, compliance.
+ *   - 4 readiness levels keyed by score floor (>=90 ready, >=70 conditional,
+ *     >=50 not-ready, <50 blocked).
+ *   - Scoring heuristics applied via filesystem probes from `root` (test
+ *     directories, specs, secret-scan-results, policies, package-lock,
+ *     README, compliance state, NFR mention in architecture.md).
+ *   - State file: caller passes via options; in legacy fallback was
+ *     `path.join(root, '.jumpstart/state/release-readiness.json')` for
+ *     `assessReadiness` and `path.join('.jumpstart/state/release-readiness.json')`
+ *     (cwd-relative) for `generateReport`. Preserved verbatim.
+ *   - M3 hardening: shape-validated JSON; rejects __proto__/constructor/
+ *     prototype keys recursively; defaultState fallback on parse failure.
+ *   - Path-safety: `assessReadiness` calls `assertInsideRoot` on the root
+ *     argument before any fs probe.
+ *
+ * @see bin/lib/release-readiness.js (legacy reference)
+ * @see specs/implementation-plan.md M11 strangler cleanup
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { assertInsideRoot } from './path-safety.js';
+
+const DEFAULT_STATE_FILE = join('.jumpstart', 'state', 'release-readiness.json');
+
+export const READINESS_CATEGORIES = [
+  'quality',
+  'security',
+  'performance',
+  'dependencies',
+  'documentation',
+  'rollback',
+  'monitoring',
+  'compliance',
+] as const;
+
+export type ReadinessCategory = (typeof READINESS_CATEGORIES)[number];
+
+export interface ReadinessLevel {
+  min: number;
+  label: string;
+  emoji: string;
+  recommendation: string;
+}
+
+export const READINESS_LEVELS: ReadinessLevel[] = [
+  { min: 90, label: 'Ready', emoji: '🟢', recommendation: 'go' },
+  { min: 70, label: 'Conditionally Ready', emoji: '🟡', recommendation: 'conditional-go' },
+  { min: 50, label: 'Not Ready', emoji: '🟠', recommendation: 'no-go' },
+  { min: 0, label: 'Blocked', emoji: '🔴', recommendation: 'blocked' },
+];
+
+export interface ReadinessAssessment {
+  id: string;
+  assessed_at: string;
+  scores: Record<string, number>;
+  total_score: number;
+  level: string;
+  recommendation: string;
+  blockers: string[];
+  risks: string[];
+}
+
+export interface ReleaseReadinessState {
+  version: string;
+  created_at: string;
+  last_updated: string | null;
+  assessments: ReadinessAssessment[];
+  current_readiness: ReadinessAssessment | null;
+}
+
+export interface AssessReadinessOptions {
+  stateFile?: string | undefined;
+}
+
+export interface AssessReadinessResult extends ReadinessAssessment {
+  success: true;
+}
+
+export interface GenerateReportOptions {
+  stateFile?: string | undefined;
+}
+
+export interface ReportCategory {
+  name: string;
+  score: number;
+  status: 'pass' | 'warning' | 'fail';
+}
+
+export type GenerateReportResult =
+  | {
+      success: true;
+      recommendation: string;
+      total_score: number;
+      level: string;
+      categories: ReportCategory[];
+      blockers: string[];
+      risks: string[];
+      assessed_at: string;
+    }
+  | { success: false; error: string };
+
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function hasForbiddenKey(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    for (const item of value) if (hasForbiddenKey(item)) return true;
+    return false;
+  }
+  if (!isPlainObject(value)) return false;
+  for (const key of Object.keys(value)) {
+    if (FORBIDDEN_KEYS.has(key)) return true;
+    if (hasForbiddenKey(value[key])) return true;
+  }
+  return false;
+}
+
+export function defaultState(): ReleaseReadinessState {
+  return {
+    version: '1.0.0',
+    created_at: new Date().toISOString(),
+    last_updated: null,
+    assessments: [],
+    current_readiness: null,
+  };
+}
+
+export function loadState(stateFile?: string | undefined): ReleaseReadinessState {
+  const filePath = stateFile ?? DEFAULT_STATE_FILE;
+  if (!existsSync(filePath)) return defaultState();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(filePath, 'utf8'));
+  } catch {
+    return defaultState();
+  }
+  if (!isPlainObject(parsed) || hasForbiddenKey(parsed)) return defaultState();
+  return parsed as unknown as ReleaseReadinessState;
+}
+
+export function saveState(state: ReleaseReadinessState, stateFile?: string | undefined): void {
+  const filePath = stateFile ?? DEFAULT_STATE_FILE;
+  const dir = dirname(filePath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  state.last_updated = new Date().toISOString();
+  writeFileSync(filePath, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
+}
+
+/**
+ * Assess release readiness across all 8 categories.
+ *
+ * Score heuristics (preserved verbatim from legacy):
+ *   - quality: tests + specs → 80, tests only → 60, neither → 30
+ *   - security: secret-scan + policies → 85, policies only → 60, neither → 40
+ *   - performance: NFR mention in architecture.md → 75, else 40
+ *   - dependencies: package-lock or yarn.lock → 80, else 50
+ *   - documentation: README + specs → 85, README only → 60, neither → 30
+ *   - rollback: 50 (default; needs manual assessment)
+ *   - monitoring: 50 (default; needs manual assessment)
+ *   - compliance: compliance.json → 70, else 40
+ *
+ * State file fallback `path.join(root, DEFAULT_STATE_FILE)` matches
+ * legacy bin/lib/release-readiness.js:122.
+ */
+export function assessReadiness(
+  root: string,
+  options: AssessReadinessOptions = {}
+): AssessReadinessResult {
+  // Path-safety: gate root before any fs probe. Per ADR-009, every
+  // user-supplied path through the trust boundary must be confirmed
+  // inside its declared root. For assessReadiness `root` IS the
+  // declared root, so the check is self-referential — succeeds for
+  // any valid filesystem path that's its own canonical root.
+  assertInsideRoot(root, root, { schemaId: 'release-readiness:assessReadiness:root' });
+
+  const scores: Record<string, number> = {};
+
+  // Quality: check if tests exist and specs are approved
+  const hasTests = existsSync(join(root, 'tests')) || existsSync(join(root, 'test'));
+  const hasSpecs = existsSync(join(root, 'specs'));
+  scores.quality = hasTests && hasSpecs ? 80 : hasTests ? 60 : 30;
+
+  // Security: check for secret scanner results, policy engine
+  const hasSecurityScan = existsSync(join(root, '.jumpstart', 'state', 'secret-scan-results.json'));
+  const hasPolicies = existsSync(join(root, '.jumpstart', 'policies.json'));
+  scores.security = hasSecurityScan && hasPolicies ? 85 : hasPolicies ? 60 : 40;
+
+  // Performance: check for NFR documentation
+  const archFile = join(root, 'specs', 'architecture.md');
+  let hasNFRs = false;
+  if (existsSync(archFile)) {
+    try {
+      const content = readFileSync(archFile, 'utf8');
+      hasNFRs = /\bNFR\b|non-functional|performance/i.test(content);
+    } catch {
+      /* ignore */
+    }
+  }
+  scores.performance = hasNFRs ? 75 : 40;
+
+  // Dependencies: check for lock file
+  const hasLockFile =
+    existsSync(join(root, 'package-lock.json')) || existsSync(join(root, 'yarn.lock'));
+  scores.dependencies = hasLockFile ? 80 : 50;
+
+  // Documentation
+  const hasReadme = existsSync(join(root, 'README.md'));
+  scores.documentation = hasReadme && hasSpecs ? 85 : hasReadme ? 60 : 30;
+
+  // Rollback: defaults — needs manual assessment.
+  scores.rollback = 50;
+
+  // Monitoring: defaults — needs manual assessment.
+  scores.monitoring = 50;
+
+  // Compliance: check for compliance state
+  const hasCompliance = existsSync(join(root, '.jumpstart', 'state', 'compliance.json'));
+  scores.compliance = hasCompliance ? 70 : 40;
+
+  const totalScore = Math.round(
+    Object.values(scores).reduce((sum, s) => sum + s, 0) / READINESS_CATEGORIES.length
+  );
+
+  // Find the highest-floor level the score satisfies. Defensive fallback
+  // to the lowest band ('Blocked') if levels happen to be empty.
+  const level: ReadinessLevel = READINESS_LEVELS.find((l) => totalScore >= l.min) ??
+    READINESS_LEVELS[READINESS_LEVELS.length - 1] ?? {
+      min: 0,
+      label: 'Blocked',
+      emoji: '🔴',
+      recommendation: 'blocked',
+    };
+
+  const assessment: ReadinessAssessment = {
+    id: `rr-${Date.now()}`,
+    assessed_at: new Date().toISOString(),
+    scores,
+    total_score: totalScore,
+    level: level.label,
+    recommendation: level.recommendation,
+    blockers: Object.entries(scores)
+      .filter(([, v]) => v < 50)
+      .map(([k]) => k),
+    risks: Object.entries(scores)
+      .filter(([, v]) => v >= 50 && v < 70)
+      .map(([k]) => k),
+  };
+
+  const stateFile = options.stateFile ?? join(root, DEFAULT_STATE_FILE);
+  const state = loadState(stateFile);
+  state.assessments.push(assessment);
+  state.current_readiness = assessment;
+  saveState(state, stateFile);
+
+  return { success: true, ...assessment };
+}
+
+/**
+ * Generate a go/no-go report. Returns success: false if no current
+ * readiness assessment exists in the state file.
+ */
+export function generateReport(options: GenerateReportOptions = {}): GenerateReportResult {
+  const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
+  const state = loadState(stateFile);
+
+  if (!state.current_readiness) {
+    return { success: false, error: 'No readiness assessment found. Run assess first.' };
+  }
+
+  const r = state.current_readiness;
+
+  return {
+    success: true,
+    recommendation: r.recommendation,
+    total_score: r.total_score,
+    level: r.level,
+    categories: Object.entries(r.scores).map(
+      ([name, score]): ReportCategory => ({
+        name,
+        score,
+        status: score >= 70 ? 'pass' : score >= 50 ? 'warning' : 'fail',
+      })
+    ),
+    blockers: r.blockers,
+    risks: r.risks,
+    assessed_at: r.assessed_at,
+  };
+}

--- a/src/lib/template-merge.ts
+++ b/src/lib/template-merge.ts
@@ -1,0 +1,221 @@
+/**
+ * template-merge.ts — Template Inheritance System port (M11 batch 3).
+ *
+ * Pure-library port of `bin/lib/template-merge.mjs` (ESM legacy). Public
+ * surface preserved verbatim by name + signature:
+ *
+ *   - `parseSections(content)` => ParsedSections
+ *   - `mergeTemplates(baseContent, projectContent, options?)` => MergeResult
+ *   - `mergeTemplateFiles(basePath, projectPath, options?)` => MergeResult
+ *
+ * Behavior parity:
+ *   - H2 (`## Header`)-based section keying. Project sections win over
+ *     base sections on conflict (default `strategy: 'project-wins'`).
+ *   - Frontmatter (YAML between `---` fences) preserved from project
+ *     when present, else base.
+ *   - Preamble (content above first H2) preserved from project when
+ *     present, else base.
+ *   - `mergeTemplateFiles` returns the lone file's content if only one
+ *     side exists; empty merged + zeroed stats if neither exists.
+ *
+ * Path-safety: `mergeTemplateFiles` does not call `assertInsideRoot`
+ * directly — its callers (cluster wiring) gate paths through
+ * `assertUserPath` before invoking. The library remains a pure helper.
+ *
+ * @see bin/lib/template-merge.mjs (legacy reference)
+ * @see specs/implementation-plan.md M11 strangler cleanup
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+
+export interface ParsedSections {
+  frontmatter: string | null;
+  preamble: string;
+  sections: Map<string, string>;
+}
+
+export interface MergeStats {
+  base_only: number;
+  project_only: number;
+  overridden: number;
+  total: number;
+}
+
+export interface MergeResult {
+  merged: string;
+  stats: MergeStats;
+}
+
+export interface MergeOptions {
+  strategy?: 'project-wins' | 'base-wins' | undefined;
+}
+
+/**
+ * Parse a markdown document into sections keyed by H2 headers.
+ *
+ * Frontmatter detection requires the document to start with a `---`
+ * fence on line 0. Anything between H1 (or other content) and the
+ * first H2 is preserved as `preamble`.
+ *
+ * Returns a Map (insertion-ordered) so reconstruction preserves
+ * section order from the source document — important for human-readable
+ * output diffs.
+ */
+export function parseSections(content: string): ParsedSections {
+  const lines = content.split('\n');
+  let frontmatter: string | null = null;
+  let preamble = '';
+  const sections = new Map<string, string>();
+
+  let currentSection: string | null = null;
+  let currentContent: string[] = [];
+  let inFrontmatter = false;
+  const frontmatterLines: string[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line === undefined) continue; // defensive (noUncheckedIndexedAccess-friendly)
+
+    // Track frontmatter
+    if (i === 0 && line.trim() === '---') {
+      inFrontmatter = true;
+      frontmatterLines.push(line);
+      continue;
+    }
+    if (inFrontmatter) {
+      frontmatterLines.push(line);
+      if (line.trim() === '---') {
+        frontmatter = frontmatterLines.join('\n');
+        inFrontmatter = false;
+      }
+      continue;
+    }
+
+    // Detect H2 sections
+    const h2Match = line.match(/^## (.+)$/);
+    if (h2Match) {
+      // Save previous section
+      if (currentSection) {
+        sections.set(currentSection, currentContent.join('\n'));
+      } else if (currentContent.length > 0) {
+        preamble = currentContent.join('\n');
+      }
+      currentSection = (h2Match[1] ?? '').trim();
+      currentContent = [line];
+      continue;
+    }
+
+    currentContent.push(line);
+  }
+
+  // Save last section
+  if (currentSection) {
+    sections.set(currentSection, currentContent.join('\n'));
+  } else if (currentContent.length > 0) {
+    preamble += (preamble ? '\n' : '') + currentContent.join('\n');
+  }
+
+  return { frontmatter, preamble, sections };
+}
+
+/**
+ * Merge a base template with project overrides. Project sections win
+ * on conflict by default (`strategy: 'project-wins'`); base sections
+ * not present in project are kept; project-only sections are appended.
+ *
+ * Stats:
+ *   - `base_only`: count of sections in base but not project
+ *   - `project_only`: count of sections in project but not base
+ *   - `overridden`: count of sections present in both (project won)
+ *   - `total`: total sections in the merged output
+ */
+export function mergeTemplates(
+  baseContent: string,
+  projectContent: string,
+  options: MergeOptions = {}
+): MergeResult {
+  const strategy = options.strategy ?? 'project-wins';
+
+  const base = parseSections(baseContent);
+  const project = parseSections(projectContent);
+
+  const stats: MergeStats = { base_only: 0, project_only: 0, overridden: 0, total: 0 };
+
+  // Use project frontmatter if available, else base
+  const frontmatter = project.frontmatter ?? base.frontmatter;
+  const preamble = project.preamble || base.preamble;
+
+  // Merge sections
+  const mergedSections = new Map<string, string>();
+
+  // Start with base sections
+  for (const [key, value] of base.sections) {
+    mergedSections.set(key, value);
+  }
+
+  // Override/add project sections
+  for (const [key, value] of project.sections) {
+    if (mergedSections.has(key)) {
+      if (strategy === 'project-wins') {
+        mergedSections.set(key, value);
+        stats.overridden++;
+      }
+      // 'base-wins' would keep the base version
+    } else {
+      mergedSections.set(key, value);
+      stats.project_only++;
+    }
+  }
+
+  // Count base-only sections
+  for (const key of base.sections.keys()) {
+    if (!project.sections.has(key)) {
+      stats.base_only++;
+    }
+  }
+
+  stats.total = mergedSections.size;
+
+  // Reconstruct document
+  const parts: string[] = [];
+  if (frontmatter) parts.push(frontmatter);
+  if (preamble.trim()) parts.push(preamble);
+  for (const [, value] of mergedSections) {
+    parts.push(value);
+  }
+
+  return { merged: parts.join('\n\n'), stats };
+}
+
+/**
+ * Merge template files from disk. Either side may be missing — the
+ * non-empty side is returned verbatim if exactly one exists; empty
+ * `merged` + zeroed stats if neither exists.
+ */
+export function mergeTemplateFiles(
+  basePath: string,
+  projectPath: string,
+  options: MergeOptions = {}
+): MergeResult {
+  const baseContent = existsSync(basePath) ? readFileSync(basePath, 'utf8') : '';
+  const projectContent = existsSync(projectPath) ? readFileSync(projectPath, 'utf8') : '';
+
+  if (!baseContent && !projectContent) {
+    return { merged: '', stats: { base_only: 0, project_only: 0, overridden: 0, total: 0 } };
+  }
+
+  if (!baseContent) {
+    return {
+      merged: projectContent,
+      stats: { base_only: 0, project_only: 0, overridden: 0, total: 0 },
+    };
+  }
+  if (!projectContent) {
+    return {
+      merged: baseContent,
+      stats: { base_only: 0, project_only: 0, overridden: 0, total: 0 },
+    };
+  }
+
+  return mergeTemplates(baseContent, projectContent, options);
+}

--- a/tests/test-agent-checkpoint.test.ts
+++ b/tests/test-agent-checkpoint.test.ts
@@ -1,0 +1,284 @@
+/**
+ * test-agent-checkpoint.test.ts — M11 batch 3 port coverage.
+ *
+ * Verifies the TS port at `src/lib/agent-checkpoint.ts` matches the
+ * legacy `bin/lib/agent-checkpoint.js` public surface:
+ *   - CHECKPOINT_TYPES constant byte-identical
+ *   - saveCheckpoint validation, ID format, default fields
+ *   - restoreCheckpoint by-id / latest / not-found rejection
+ *   - listCheckpoints filtering by agent/phase/type
+ *   - cleanCheckpoints default-keep + removed/remaining math
+ *   - Auto-trim to 50 on save
+ *   - M3 hardening: rejects __proto__/constructor/prototype keys
+ *
+ * @see src/lib/agent-checkpoint.ts
+ * @see bin/lib/agent-checkpoint.js (legacy reference)
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  CHECKPOINT_TYPES,
+  cleanCheckpoints,
+  defaultState,
+  listCheckpoints,
+  loadState,
+  restoreCheckpoint,
+  saveCheckpoint,
+  saveState,
+} from '../src/lib/agent-checkpoint.js';
+
+let tmpDir: string;
+let stateFile: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'agent-checkpoint-'));
+  stateFile = join(tmpDir, 'state.json');
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('agent-checkpoint — constants', () => {
+  it('exposes the 6 documented checkpoint types', () => {
+    expect(CHECKPOINT_TYPES).toEqual([
+      'phase-start',
+      'phase-end',
+      'task-start',
+      'task-end',
+      'error-recovery',
+      'manual',
+    ]);
+  });
+});
+
+describe('agent-checkpoint — defaultState', () => {
+  it('returns an empty state with the canonical shape', () => {
+    const s = defaultState();
+    expect(s.version).toBe('1.0.0');
+    expect(s.checkpoints).toEqual([]);
+    expect(s.recovery_log).toEqual([]);
+    expect(s.last_updated).toBeNull();
+    expect(s.created_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+describe('agent-checkpoint — loadState/saveState', () => {
+  it('returns defaultState when the file does not exist', () => {
+    expect(loadState(stateFile).checkpoints).toEqual([]);
+  });
+
+  it('round-trips through saveState → loadState', () => {
+    const s = defaultState();
+    s.checkpoints.push({
+      id: 'CP-ABC',
+      agent: 'developer',
+      phase: 'P3',
+      task: 'task-1',
+      type: 'manual',
+      context: { foo: 'bar' },
+      files_snapshot: ['src/x.ts'],
+      saved_at: '2026-01-01T00:00:00Z',
+    });
+    saveState(s, stateFile);
+    const reloaded = loadState(stateFile);
+    expect(reloaded.checkpoints).toHaveLength(1);
+    expect(reloaded.checkpoints[0]?.agent).toBe('developer');
+    expect(reloaded.last_updated).not.toBeNull();
+  });
+
+  it('rejects __proto__ key (M3 hardening)', () => {
+    writeFileSync(stateFile, JSON.stringify({ __proto__: { polluted: true }, checkpoints: [] }));
+    const s = loadState(stateFile);
+    expect(s.checkpoints).toEqual([]);
+  });
+
+  it('rejects constructor / prototype keys', () => {
+    writeFileSync(stateFile, JSON.stringify({ constructor: { x: 1 }, checkpoints: [] }));
+    const s = loadState(stateFile);
+    expect(s.checkpoints).toEqual([]);
+  });
+
+  it('falls back to defaultState on malformed JSON', () => {
+    writeFileSync(stateFile, '{not-json');
+    const s = loadState(stateFile);
+    expect(s.checkpoints).toEqual([]);
+  });
+});
+
+describe('agent-checkpoint — saveCheckpoint', () => {
+  it('creates a checkpoint with CP- prefix + base36 timestamp', () => {
+    const r = saveCheckpoint({ agent: 'developer' }, { stateFile });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.checkpoint.id).toMatch(/^CP-[A-Z0-9]+$/);
+      expect(r.checkpoint.agent).toBe('developer');
+      expect(r.checkpoint.type).toBe('manual'); // default
+      expect(r.checkpoint.phase).toBeNull();
+      expect(r.checkpoint.task).toBeNull();
+      expect(r.checkpoint.context).toEqual({});
+      expect(r.checkpoint.files_snapshot).toEqual([]);
+    }
+  });
+
+  it('honours all optional fields', () => {
+    const r = saveCheckpoint(
+      {
+        agent: 'pm',
+        phase: 'P2',
+        task: 'task-7',
+        type: 'phase-start',
+        context: { stage: 'plan' },
+        files_snapshot: ['specs/prd.md'],
+      },
+      { stateFile }
+    );
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.checkpoint.phase).toBe('P2');
+      expect(r.checkpoint.task).toBe('task-7');
+      expect(r.checkpoint.type).toBe('phase-start');
+      expect(r.checkpoint.context).toEqual({ stage: 'plan' });
+      expect(r.checkpoint.files_snapshot).toEqual(['specs/prd.md']);
+    }
+  });
+
+  it('rejects empty agent', () => {
+    const r = saveCheckpoint({ agent: '' }, { stateFile });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects null input', () => {
+    const r = saveCheckpoint(null, { stateFile });
+    expect(r.success).toBe(false);
+  });
+
+  it('persists to disk', () => {
+    saveCheckpoint({ agent: 'a' }, { stateFile });
+    saveCheckpoint({ agent: 'b' }, { stateFile });
+    const reloaded = loadState(stateFile);
+    expect(reloaded.checkpoints).toHaveLength(2);
+  });
+
+  it('auto-trims to last 50 checkpoints', () => {
+    const s = defaultState();
+    for (let i = 0; i < 55; i++) {
+      s.checkpoints.push({
+        id: `CP-${i}`,
+        agent: 'a',
+        phase: null,
+        task: null,
+        type: 'manual',
+        context: {},
+        files_snapshot: [],
+        saved_at: '2026-01-01T00:00:00Z',
+      });
+    }
+    saveState(s, stateFile);
+    saveCheckpoint({ agent: 'final' }, { stateFile });
+    const reloaded = loadState(stateFile);
+    expect(reloaded.checkpoints).toHaveLength(50);
+    // The newest entry should be the freshly-saved one.
+    expect(reloaded.checkpoints[reloaded.checkpoints.length - 1]?.agent).toBe('final');
+  });
+});
+
+describe('agent-checkpoint — restoreCheckpoint', () => {
+  it('restores by id', () => {
+    const a = saveCheckpoint({ agent: 'developer' }, { stateFile });
+    if (!a.success) throw new Error('setup');
+    const r = restoreCheckpoint(a.checkpoint.id, { stateFile });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.checkpoint.id).toBe(a.checkpoint.id);
+      expect(r.agent).toBe('developer');
+    }
+  });
+
+  it('restores latest when no id provided', () => {
+    saveCheckpoint({ agent: 'a' }, { stateFile });
+    saveCheckpoint({ agent: 'b' }, { stateFile });
+    const r = restoreCheckpoint(undefined, { stateFile });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.agent).toBe('b');
+  });
+
+  it('appends to recovery_log on restore', () => {
+    const a = saveCheckpoint({ agent: 'x' }, { stateFile });
+    if (!a.success) throw new Error('setup');
+    restoreCheckpoint(a.checkpoint.id, { stateFile });
+    const reloaded = loadState(stateFile);
+    expect(reloaded.recovery_log).toHaveLength(1);
+    expect(reloaded.recovery_log[0]?.checkpoint_id).toBe(a.checkpoint.id);
+  });
+
+  it('rejects unknown id', () => {
+    const r = restoreCheckpoint('CP-XYZ', { stateFile });
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error).toContain('Checkpoint not found');
+  });
+
+  it('rejects when no checkpoints exist + no id provided', () => {
+    const r = restoreCheckpoint(undefined, { stateFile });
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error).toContain('No checkpoints');
+  });
+});
+
+describe('agent-checkpoint — listCheckpoints', () => {
+  beforeEach(() => {
+    saveCheckpoint({ agent: 'developer', phase: 'P3', type: 'task-start' }, { stateFile });
+    saveCheckpoint({ agent: 'developer', phase: 'P4', type: 'task-end' }, { stateFile });
+    saveCheckpoint({ agent: 'pm', phase: 'P2', type: 'phase-start' }, { stateFile });
+  });
+
+  it('returns all when no filter', () => {
+    const r = listCheckpoints({}, { stateFile });
+    expect(r.total).toBe(3);
+  });
+
+  it('filters by agent', () => {
+    const r = listCheckpoints({ agent: 'developer' }, { stateFile });
+    expect(r.total).toBe(2);
+  });
+
+  it('filters by phase', () => {
+    const r = listCheckpoints({ phase: 'P3' }, { stateFile });
+    expect(r.total).toBe(1);
+  });
+
+  it('filters by type', () => {
+    const r = listCheckpoints({ type: 'task-end' }, { stateFile });
+    expect(r.total).toBe(1);
+  });
+});
+
+describe('agent-checkpoint — cleanCheckpoints', () => {
+  it('removes oldest checkpoints, keeps last `keep`', () => {
+    for (let i = 0; i < 15; i++) saveCheckpoint({ agent: `a-${i}` }, { stateFile });
+    const r = cleanCheckpoints({ stateFile, keep: 5 });
+    expect(r.removed).toBe(10);
+    expect(r.remaining).toBe(5);
+    const reloaded = loadState(stateFile);
+    expect(reloaded.checkpoints).toHaveLength(5);
+    // Newest entries kept.
+    expect(reloaded.checkpoints[reloaded.checkpoints.length - 1]?.agent).toBe('a-14');
+  });
+
+  it('defaults keep=10 (legacy parity)', () => {
+    for (let i = 0; i < 12; i++) saveCheckpoint({ agent: `a-${i}` }, { stateFile });
+    const r = cleanCheckpoints({ stateFile });
+    expect(r.removed).toBe(2);
+    expect(r.remaining).toBe(10);
+  });
+
+  it('removed=0 when below keep threshold', () => {
+    saveCheckpoint({ agent: 'a' }, { stateFile });
+    const r = cleanCheckpoints({ stateFile, keep: 10 });
+    expect(r.removed).toBe(0);
+    expect(r.remaining).toBe(1);
+  });
+});

--- a/tests/test-legacy-modernizer.test.ts
+++ b/tests/test-legacy-modernizer.test.ts
@@ -1,0 +1,269 @@
+/**
+ * test-legacy-modernizer.test.ts — M11 batch 3 port coverage.
+ *
+ * Verifies the TS port at `src/lib/legacy-modernizer.ts` matches the
+ * legacy `bin/lib/legacy-modernizer.js` public surface:
+ *   - LEGACY_PLATFORMS / MODERNIZATION_PATTERNS constants byte-identical
+ *   - assessSystem validation, ID generation, unknown-platform fallback
+ *   - createPlan happy path + assessment-not-found rejection + default phases
+ *   - generateReport aggregation by platform + risk
+ *   - M3 hardening: rejects __proto__ / constructor / prototype keys
+ *
+ * @see src/lib/legacy-modernizer.ts
+ * @see bin/lib/legacy-modernizer.js (legacy reference)
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  assessSystem,
+  createPlan,
+  defaultState,
+  generateReport,
+  LEGACY_PLATFORMS,
+  loadState,
+  MODERNIZATION_PATTERNS,
+  saveState,
+} from '../src/lib/legacy-modernizer.js';
+
+let tmpDir: string;
+let stateFile: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'legacy-modernizer-'));
+  stateFile = join(tmpDir, 'state.json');
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('legacy-modernizer — constants', () => {
+  it('exposes the 8 documented platforms with risk + strategy + effort', () => {
+    expect(Object.keys(LEGACY_PLATFORMS)).toEqual([
+      'cobol',
+      'dotnet-framework',
+      'java-monolith',
+      'ssis',
+      'angular-legacy',
+      'react-legacy',
+      'jquery',
+      'php-legacy',
+    ]);
+    expect(LEGACY_PLATFORMS.cobol).toEqual({
+      risk: 'high',
+      strategy: 'strangler-fig',
+      estimated_effort: 'very-high',
+    });
+    expect(LEGACY_PLATFORMS['react-legacy']).toEqual({
+      risk: 'low',
+      strategy: 'in-place',
+      estimated_effort: 'low',
+    });
+  });
+
+  it('exposes the 5 documented modernization patterns', () => {
+    expect(MODERNIZATION_PATTERNS).toEqual([
+      'strangler-fig',
+      'phased-cutover',
+      'big-bang',
+      'in-place',
+      'rewrite',
+    ]);
+  });
+});
+
+describe('legacy-modernizer — defaultState', () => {
+  it('returns an empty state with the canonical shape', () => {
+    const s = defaultState();
+    expect(s.version).toBe('1.0.0');
+    expect(s.assessments).toEqual([]);
+    expect(s.modernization_plans).toEqual([]);
+    expect(s.last_updated).toBeNull();
+    expect(s.created_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+describe('legacy-modernizer — loadState/saveState', () => {
+  it('returns defaultState when the file does not exist', () => {
+    expect(loadState(stateFile).assessments).toEqual([]);
+  });
+
+  it('round-trips through saveState → loadState', () => {
+    const s = defaultState();
+    s.assessments.push({
+      id: 'LEG-001',
+      name: 'mainframe',
+      platform: 'cobol',
+      age_years: 30,
+      loc: 100000,
+      risk_level: 'high',
+      recommended_strategy: 'strangler-fig',
+      estimated_effort: 'very-high',
+      modernization_targets: ['cloud-native'],
+      assessed_at: '2026-01-01T00:00:00Z',
+    });
+    saveState(s, stateFile);
+    const reloaded = loadState(stateFile);
+    expect(reloaded.assessments).toHaveLength(1);
+    expect(reloaded.assessments[0]?.name).toBe('mainframe');
+    expect(reloaded.last_updated).not.toBeNull();
+  });
+
+  it('rejects __proto__ key (M3 hardening)', () => {
+    writeFileSync(stateFile, JSON.stringify({ __proto__: { polluted: true }, assessments: [] }));
+    const s = loadState(stateFile);
+    expect(s.assessments).toEqual([]);
+  });
+
+  it('rejects constructor / prototype keys', () => {
+    writeFileSync(stateFile, JSON.stringify({ constructor: { x: 1 }, assessments: [] }));
+    const s = loadState(stateFile);
+    expect(s.assessments).toEqual([]);
+  });
+
+  it('falls back to defaultState on malformed JSON', () => {
+    writeFileSync(stateFile, '{not-json');
+    const s = loadState(stateFile);
+    expect(s.assessments).toEqual([]);
+  });
+});
+
+describe('legacy-modernizer — assessSystem', () => {
+  it('creates an assessment with zero-padded ID + lowered platform key', () => {
+    const r = assessSystem({ name: 'monolith', platform: 'JAVA-MONOLITH' }, { stateFile });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.assessment.id).toBe('LEG-001');
+      expect(r.assessment.platform).toBe('java-monolith');
+      expect(r.assessment.risk_level).toBe('medium');
+      expect(r.assessment.recommended_strategy).toBe('strangler-fig');
+    }
+  });
+
+  it('falls back to medium-risk + phased-cutover for unknown platforms', () => {
+    const r = assessSystem({ name: 'foo', platform: 'unknown-thing' }, { stateFile });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.assessment.risk_level).toBe('medium');
+      expect(r.assessment.recommended_strategy).toBe('phased-cutover');
+      expect(r.assessment.estimated_effort).toBe('medium');
+    }
+  });
+
+  it('rejects missing system input', () => {
+    const r = assessSystem(null, { stateFile });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects missing name', () => {
+    const r = assessSystem({ name: '', platform: 'cobol' }, { stateFile });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects missing platform', () => {
+    const r = assessSystem({ name: 'x', platform: '' }, { stateFile });
+    expect(r.success).toBe(false);
+  });
+
+  it('increments the ID for each new assessment', () => {
+    assessSystem({ name: 'a', platform: 'cobol' }, { stateFile });
+    const r = assessSystem({ name: 'b', platform: 'jquery' }, { stateFile });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.assessment.id).toBe('LEG-002');
+  });
+
+  it('accepts age_years + loc + modernization_targets', () => {
+    const r = assessSystem(
+      { name: 'm', platform: 'cobol', age_years: 25, loc: 50000, modernization_targets: ['k8s'] },
+      { stateFile }
+    );
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.assessment.age_years).toBe(25);
+      expect(r.assessment.loc).toBe(50000);
+      expect(r.assessment.modernization_targets).toEqual(['k8s']);
+    }
+  });
+});
+
+describe('legacy-modernizer — createPlan', () => {
+  it('creates a plan with the canonical 5 default phases', () => {
+    const a = assessSystem({ name: 'm', platform: 'cobol' }, { stateFile });
+    if (!a.success) throw new Error('setup');
+    const r = createPlan(a.assessment.id, {}, { stateFile });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.plan.id).toBe('MOD-001');
+      expect(r.plan.phases).toHaveLength(5);
+      expect(r.plan.phases[0]).toMatchObject({ order: 1, name: 'assess', status: 'pending' });
+      expect(r.plan.target_platform).toBe('modern-stack');
+      expect(r.plan.strategy).toBe('strangler-fig');
+    }
+  });
+
+  it('honours custom phases (string + object both)', () => {
+    const a = assessSystem({ name: 'm', platform: 'cobol' }, { stateFile });
+    if (!a.success) throw new Error('setup');
+    const r = createPlan(
+      a.assessment.id,
+      { phases: ['scope', { name: 'lift' }, { name: 'shift' }] },
+      { stateFile }
+    );
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.plan.phases).toHaveLength(3);
+      expect(r.plan.phases[0]?.name).toBe('scope');
+      expect(r.plan.phases[1]?.name).toBe('lift');
+    }
+  });
+
+  it('rejects unknown assessment id', () => {
+    const r = createPlan('LEG-XYZ', {}, { stateFile });
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error).toContain('Assessment not found');
+  });
+
+  it('honours custom target_platform + timeline', () => {
+    const a = assessSystem({ name: 'm', platform: 'cobol' }, { stateFile });
+    if (!a.success) throw new Error('setup');
+    const r = createPlan(
+      a.assessment.id,
+      { target_platform: 'kubernetes', timeline: 'Q3 2026' },
+      { stateFile }
+    );
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.plan.target_platform).toBe('kubernetes');
+      expect(r.plan.timeline).toBe('Q3 2026');
+    }
+  });
+});
+
+describe('legacy-modernizer — generateReport', () => {
+  it('aggregates by platform + risk', () => {
+    assessSystem({ name: 'a', platform: 'cobol' }, { stateFile });
+    assessSystem({ name: 'b', platform: 'cobol' }, { stateFile });
+    assessSystem({ name: 'c', platform: 'jquery' }, { stateFile });
+    const a = assessSystem({ name: 'd', platform: 'cobol' }, { stateFile });
+    if (!a.success) throw new Error('setup');
+    createPlan(a.assessment.id, {}, { stateFile });
+
+    const r = generateReport({ stateFile });
+    expect(r.total_assessments).toBe(4);
+    expect(r.total_plans).toBe(1);
+    expect(r.by_platform.cobol).toBe(3);
+    expect(r.by_platform.jquery).toBe(1);
+    expect(r.by_risk.high).toBe(3);
+    expect(r.by_risk.low).toBe(1);
+  });
+
+  it('returns zeroed counts on empty state', () => {
+    const r = generateReport({ stateFile });
+    expect(r.total_assessments).toBe(0);
+    expect(r.total_plans).toBe(0);
+    expect(r.assessments).toEqual([]);
+  });
+});

--- a/tests/test-release-readiness.test.ts
+++ b/tests/test-release-readiness.test.ts
@@ -1,0 +1,226 @@
+/**
+ * test-release-readiness.test.ts — M11 batch 3 port coverage.
+ *
+ * Verifies the TS port at `src/lib/release-readiness.ts` matches the
+ * legacy `bin/lib/release-readiness.js` public surface:
+ *   - READINESS_CATEGORIES / READINESS_LEVELS constants byte-identical
+ *   - assessReadiness scoring heuristics across all 8 categories
+ *   - assessReadiness level + recommendation banding
+ *   - generateReport happy path + no-assessment rejection
+ *   - M3 hardening: rejects __proto__ / constructor / prototype keys
+ *
+ * @see src/lib/release-readiness.ts
+ * @see bin/lib/release-readiness.js (legacy reference)
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  assessReadiness,
+  defaultState,
+  generateReport,
+  loadState,
+  READINESS_CATEGORIES,
+  READINESS_LEVELS,
+  saveState,
+} from '../src/lib/release-readiness.js';
+
+let tmpDir: string;
+let stateFile: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'release-readiness-'));
+  stateFile = join(tmpDir, 'state.json');
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('release-readiness — constants', () => {
+  it('exposes the 8 documented categories', () => {
+    expect(READINESS_CATEGORIES).toEqual([
+      'quality',
+      'security',
+      'performance',
+      'dependencies',
+      'documentation',
+      'rollback',
+      'monitoring',
+      'compliance',
+    ]);
+  });
+
+  it('exposes the 4 readiness levels in descending order', () => {
+    expect(READINESS_LEVELS).toHaveLength(4);
+    expect(READINESS_LEVELS[0]).toMatchObject({ min: 90, recommendation: 'go' });
+    expect(READINESS_LEVELS[1]).toMatchObject({ min: 70, recommendation: 'conditional-go' });
+    expect(READINESS_LEVELS[2]).toMatchObject({ min: 50, recommendation: 'no-go' });
+    expect(READINESS_LEVELS[3]).toMatchObject({ min: 0, recommendation: 'blocked' });
+  });
+});
+
+describe('release-readiness — defaultState', () => {
+  it('returns an empty state with the canonical shape', () => {
+    const s = defaultState();
+    expect(s.version).toBe('1.0.0');
+    expect(s.assessments).toEqual([]);
+    expect(s.current_readiness).toBeNull();
+    expect(s.last_updated).toBeNull();
+  });
+});
+
+describe('release-readiness — loadState/saveState', () => {
+  it('returns defaultState when the file does not exist', () => {
+    expect(loadState(stateFile).assessments).toEqual([]);
+  });
+
+  it('round-trips through saveState → loadState', () => {
+    const s = defaultState();
+    s.assessments.push({
+      id: 'rr-1',
+      assessed_at: '2026-01-01T00:00:00Z',
+      scores: { quality: 80 },
+      total_score: 80,
+      level: 'Conditionally Ready',
+      recommendation: 'conditional-go',
+      blockers: [],
+      risks: [],
+    });
+    saveState(s, stateFile);
+    const reloaded = loadState(stateFile);
+    expect(reloaded.assessments).toHaveLength(1);
+    expect(reloaded.assessments[0]?.total_score).toBe(80);
+    expect(reloaded.last_updated).not.toBeNull();
+  });
+
+  it('rejects __proto__ key (M3 hardening)', () => {
+    writeFileSync(stateFile, JSON.stringify({ __proto__: { polluted: true }, assessments: [] }));
+    const s = loadState(stateFile);
+    expect(s.assessments).toEqual([]);
+  });
+
+  it('rejects constructor / prototype keys', () => {
+    writeFileSync(stateFile, JSON.stringify({ prototype: { x: 1 }, assessments: [] }));
+    const s = loadState(stateFile);
+    expect(s.assessments).toEqual([]);
+  });
+
+  it('falls back to defaultState on malformed JSON', () => {
+    writeFileSync(stateFile, '{not-json');
+    const s = loadState(stateFile);
+    expect(s.assessments).toEqual([]);
+  });
+});
+
+describe('release-readiness — assessReadiness', () => {
+  it('produces all 8 category scores on an empty project root', () => {
+    const r = assessReadiness(tmpDir, { stateFile });
+    expect(r.success).toBe(true);
+    expect(Object.keys(r.scores).sort()).toEqual([...READINESS_CATEGORIES].sort());
+    // All defaults: quality=30, security=40, performance=40, dependencies=50,
+    // documentation=30, rollback=50, monitoring=50, compliance=40 → avg ≈ 41 (Blocked)
+    expect(r.recommendation).toBe('blocked');
+  });
+
+  it('boosts quality score when tests + specs both exist', () => {
+    mkdirSync(join(tmpDir, 'tests'), { recursive: true });
+    mkdirSync(join(tmpDir, 'specs'), { recursive: true });
+    const r = assessReadiness(tmpDir, { stateFile });
+    expect(r.scores.quality).toBe(80);
+  });
+
+  it('boosts quality score when only tests exist', () => {
+    mkdirSync(join(tmpDir, 'tests'), { recursive: true });
+    const r = assessReadiness(tmpDir, { stateFile });
+    expect(r.scores.quality).toBe(60);
+  });
+
+  it('boosts security when policies + secret-scan exist', () => {
+    mkdirSync(join(tmpDir, '.jumpstart', 'state'), { recursive: true });
+    writeFileSync(join(tmpDir, '.jumpstart', 'state', 'secret-scan-results.json'), '{}');
+    writeFileSync(join(tmpDir, '.jumpstart', 'policies.json'), '{}');
+    const r = assessReadiness(tmpDir, { stateFile });
+    expect(r.scores.security).toBe(85);
+  });
+
+  it('boosts dependencies when package-lock.json exists', () => {
+    writeFileSync(join(tmpDir, 'package-lock.json'), '{}');
+    const r = assessReadiness(tmpDir, { stateFile });
+    expect(r.scores.dependencies).toBe(80);
+  });
+
+  it('boosts performance when architecture.md mentions NFR', () => {
+    mkdirSync(join(tmpDir, 'specs'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, 'specs', 'architecture.md'),
+      '# Arch\n\n## NFR\n\nNon-functional requirements include performance.'
+    );
+    const r = assessReadiness(tmpDir, { stateFile });
+    expect(r.scores.performance).toBe(75);
+  });
+
+  it('boosts documentation when README + specs both exist', () => {
+    writeFileSync(join(tmpDir, 'README.md'), '# Project');
+    mkdirSync(join(tmpDir, 'specs'), { recursive: true });
+    const r = assessReadiness(tmpDir, { stateFile });
+    expect(r.scores.documentation).toBe(85);
+  });
+
+  it('persists assessment + sets current_readiness', () => {
+    assessReadiness(tmpDir, { stateFile });
+    const reloaded = loadState(stateFile);
+    expect(reloaded.assessments).toHaveLength(1);
+    expect(reloaded.current_readiness).not.toBeNull();
+  });
+
+  it('lists low-scoring categories as blockers (<50) + risks (50-69)', () => {
+    const r = assessReadiness(tmpDir, { stateFile });
+    // Quality (30), security (40), performance (40), documentation (30), compliance (40)
+    // are all <50 → blockers. dependencies (50), rollback (50), monitoring (50) ≥50 + <70 → risks.
+    expect(r.blockers).toContain('quality');
+    expect(r.blockers).toContain('documentation');
+    expect(r.risks).toContain('rollback');
+    expect(r.risks).toContain('monitoring');
+  });
+});
+
+describe('release-readiness — generateReport', () => {
+  it('returns success=false when no assessment exists', () => {
+    const r = generateReport({ stateFile });
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error).toContain('No readiness assessment');
+  });
+
+  it('returns the latest assessment with category statuses', () => {
+    assessReadiness(tmpDir, { stateFile });
+    const r = generateReport({ stateFile });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.categories).toHaveLength(READINESS_CATEGORIES.length);
+      // Quality is 30 → fail
+      const quality = r.categories.find((c) => c.name === 'quality');
+      expect(quality?.status).toBe('fail');
+      // Dependencies is 50 → warning
+      const deps = r.categories.find((c) => c.name === 'dependencies');
+      expect(deps?.status).toBe('warning');
+    }
+  });
+
+  it('reports pass status for category scores >= 70', () => {
+    // Stage a passing project root.
+    mkdirSync(join(tmpDir, 'tests'), { recursive: true });
+    mkdirSync(join(tmpDir, 'specs'), { recursive: true });
+    writeFileSync(join(tmpDir, 'README.md'), '# r');
+    writeFileSync(join(tmpDir, 'package-lock.json'), '{}');
+    assessReadiness(tmpDir, { stateFile });
+    const r = generateReport({ stateFile });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      const docs = r.categories.find((c) => c.name === 'documentation');
+      expect(docs?.status).toBe('pass'); // score=85
+    }
+  });
+});

--- a/tests/test-template-merge.test.ts
+++ b/tests/test-template-merge.test.ts
@@ -1,0 +1,185 @@
+/**
+ * test-template-merge.test.ts — M11 batch 3 port coverage.
+ *
+ * Verifies the TS port at `src/lib/template-merge.ts` matches the
+ * legacy ESM `bin/lib/template-merge.mjs` public surface:
+ *   - parseSections handles frontmatter, preamble, H2-keyed sections
+ *   - mergeTemplates project-wins strategy + stat counts
+ *   - mergeTemplates base-wins strategy preserves base sections
+ *   - mergeTemplateFiles handles missing files gracefully
+ *   - Frontmatter + preamble inheritance
+ *
+ * @see src/lib/template-merge.ts
+ * @see bin/lib/template-merge.mjs (legacy reference)
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mergeTemplateFiles, mergeTemplates, parseSections } from '../src/lib/template-merge.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'template-merge-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('template-merge — parseSections', () => {
+  it('returns empty parse for empty input', () => {
+    const r = parseSections('');
+    expect(r.frontmatter).toBeNull();
+    expect(r.sections.size).toBe(0);
+  });
+
+  it('extracts H2 sections keyed by header name', () => {
+    const r = parseSections('## Section A\n\nbody A\n\n## Section B\n\nbody B');
+    expect(r.sections.size).toBe(2);
+    expect(r.sections.has('Section A')).toBe(true);
+    expect(r.sections.has('Section B')).toBe(true);
+    expect(r.sections.get('Section A')).toContain('body A');
+  });
+
+  it('captures frontmatter when present at line 0', () => {
+    const content = '---\ntitle: Doc\n---\n\n## Hello\n\nworld';
+    const r = parseSections(content);
+    expect(r.frontmatter).toContain('title: Doc');
+    expect(r.sections.has('Hello')).toBe(true);
+  });
+
+  it('preserves preamble (content before first H2)', () => {
+    const r = parseSections('# Title\n\nintro paragraph\n\n## First Section\n\nbody');
+    expect(r.preamble).toContain('# Title');
+    expect(r.preamble).toContain('intro paragraph');
+    expect(r.sections.has('First Section')).toBe(true);
+  });
+
+  it('does NOT treat a `---` after content as frontmatter', () => {
+    const r = parseSections('Some intro.\n\n---\n\n## Section');
+    expect(r.frontmatter).toBeNull();
+  });
+
+  it('handles documents with no H2 (single-section / preamble-only)', () => {
+    const r = parseSections('Just some markdown\nwith no headers.');
+    expect(r.sections.size).toBe(0);
+    expect(r.preamble).toContain('Just some markdown');
+  });
+});
+
+describe('template-merge — mergeTemplates', () => {
+  it('uses project section over base when both present (default project-wins)', () => {
+    const base = '## Intro\n\nbase intro';
+    const project = '## Intro\n\nproject intro';
+    const r = mergeTemplates(base, project);
+    expect(r.merged).toContain('project intro');
+    expect(r.merged).not.toContain('base intro');
+    expect(r.stats.overridden).toBe(1);
+    expect(r.stats.total).toBe(1);
+  });
+
+  it('keeps base section when not present in project', () => {
+    const base = '## A\n\nbase A\n\n## B\n\nbase B';
+    const project = '## A\n\nproject A';
+    const r = mergeTemplates(base, project);
+    expect(r.merged).toContain('project A');
+    expect(r.merged).toContain('base B');
+    expect(r.stats.overridden).toBe(1);
+    expect(r.stats.base_only).toBe(1);
+    expect(r.stats.total).toBe(2);
+  });
+
+  it('appends project-only sections', () => {
+    const base = '## A\n\nbase A';
+    const project = '## A\n\nproject A\n\n## C\n\nproject C';
+    const r = mergeTemplates(base, project);
+    expect(r.merged).toContain('## C');
+    expect(r.stats.project_only).toBe(1);
+    expect(r.stats.total).toBe(2);
+  });
+
+  it('honours base-wins strategy', () => {
+    const base = '## A\n\nbase A';
+    const project = '## A\n\nproject A';
+    const r = mergeTemplates(base, project, { strategy: 'base-wins' });
+    expect(r.merged).toContain('base A');
+    expect(r.merged).not.toContain('project A');
+    // base-wins doesn't increment `overridden`
+    expect(r.stats.overridden).toBe(0);
+  });
+
+  it('preserves project frontmatter over base frontmatter', () => {
+    const base = '---\nbasekey: base\n---\n\n## X\n\nbase';
+    const project = '---\nprojectkey: project\n---\n\n## X\n\nproject';
+    const r = mergeTemplates(base, project);
+    expect(r.merged).toContain('projectkey');
+    expect(r.merged).not.toContain('basekey');
+  });
+
+  it('falls back to base frontmatter when project has none', () => {
+    const base = '---\nbasekey: base\n---\n\n## X\n\nbase';
+    const project = '## X\n\nproject';
+    const r = mergeTemplates(base, project);
+    expect(r.merged).toContain('basekey');
+  });
+
+  it('counts overridden + base_only + project_only correctly', () => {
+    const base = '## A\n\nb-A\n\n## B\n\nb-B\n\n## C\n\nb-C';
+    const project = '## A\n\np-A\n\n## D\n\np-D';
+    const r = mergeTemplates(base, project);
+    // A: in both → overridden
+    // B, C: base only
+    // D: project only
+    expect(r.stats.overridden).toBe(1);
+    expect(r.stats.base_only).toBe(2);
+    expect(r.stats.project_only).toBe(1);
+    expect(r.stats.total).toBe(4);
+  });
+});
+
+describe('template-merge — mergeTemplateFiles', () => {
+  it('returns empty merge when neither file exists', () => {
+    const r = mergeTemplateFiles(join(tmpDir, 'a.md'), join(tmpDir, 'b.md'));
+    expect(r.merged).toBe('');
+    expect(r.stats.total).toBe(0);
+  });
+
+  it('returns project content verbatim when base is missing', () => {
+    const projectPath = join(tmpDir, 'project.md');
+    writeFileSync(projectPath, '## Only\n\nproject only');
+    const r = mergeTemplateFiles(join(tmpDir, 'missing.md'), projectPath);
+    expect(r.merged).toContain('project only');
+  });
+
+  it('returns base content verbatim when project is missing', () => {
+    const basePath = join(tmpDir, 'base.md');
+    writeFileSync(basePath, '## Only\n\nbase only');
+    const r = mergeTemplateFiles(basePath, join(tmpDir, 'missing.md'));
+    expect(r.merged).toContain('base only');
+  });
+
+  it('merges both files when both exist (project-wins)', () => {
+    const basePath = join(tmpDir, 'base.md');
+    const projectPath = join(tmpDir, 'project.md');
+    writeFileSync(basePath, '## A\n\nbase A\n\n## B\n\nbase B');
+    writeFileSync(projectPath, '## A\n\nproject A\n\n## C\n\nproject C');
+    const r = mergeTemplateFiles(basePath, projectPath);
+    expect(r.merged).toContain('project A');
+    expect(r.merged).toContain('base B');
+    expect(r.merged).toContain('project C');
+    expect(r.stats.total).toBe(3);
+  });
+
+  it('honours custom merge options through to mergeTemplates', () => {
+    const basePath = join(tmpDir, 'base.md');
+    const projectPath = join(tmpDir, 'project.md');
+    writeFileSync(basePath, '## A\n\nbase A');
+    writeFileSync(projectPath, '## A\n\nproject A');
+    const r = mergeTemplateFiles(basePath, projectPath, { strategy: 'base-wins' });
+    expect(r.merged).toContain('base A');
+    expect(r.merged).not.toContain('project A');
+  });
+});


### PR DESCRIPTION
## Summary

Strangler-tail cleanup batch 3 (issue #34). Ports 4 legacy `bin/lib/*.{js,mjs}` modules to canonical `src/lib/*.ts`. Each commit is a single-module port. Public surface preserved verbatim by name + signature; M3 hardening + path-safety gates applied per the M2-M7 standard.

### Modules ported (4)

| # | Module | Legacy LoC | Port LoC | Exports preserved | Hardening | Latent bugs fixed | New tests |
|---|--------|-----------:|---------:|-------------------|-----------|-------------------|----------:|
| 1 | `legacy-modernizer` | 160 (CJS) | 286 | `defaultState`, `loadState`, `saveState`, `assessSystem`, `createPlan`, `generateReport`, `LEGACY_PLATFORMS`, `MODERNIZATION_PATTERNS` | M3 JSON shape-validation rejects `__proto__`/`constructor`/`prototype` | Cluster called phantom `lib.scan` / `lib.planModernization` (never exported) → wired to actual `assessSystem` / `createPlan` / `generateReport` | 21 |
| 2 | `agent-checkpoint` | 168 (CJS) | 295 | `defaultState`, `loadState`, `saveState`, `saveCheckpoint`, `restoreCheckpoint`, `listCheckpoints`, `cleanCheckpoints`, `CHECKPOINT_TYPES` | M3 JSON shape-validation; auto-trim to last 50 checkpoints preserved | None — cluster wiring already invoked the actual exports; switched to discriminated union narrowing for proper error surfacing | 25 |
| 3 | `release-readiness` | 171 (CJS) | 308 | `defaultState`, `loadState`, `saveState`, `assessReadiness`, `generateReport`, `READINESS_CATEGORIES`, `READINESS_LEVELS` | M3 JSON shape-validation; `assessReadiness` gates `root` through `assertInsideRoot` (ADR-009) | Cluster called phantom `lib.checkReadiness` / `lib.getStatus` (never exported) → wired to actual `assessReadiness` / `generateReport` | 20 |
| 4 | `template-merge` | 177 (ESM) | 207 | `parseSections`, `mergeTemplates`, `mergeTemplateFiles` | (no JSON state; pure parsing helper) | `mergeTemplatesImpl` flipped from async `legacyImport()` shim back to sync. `await` at existing call sites is a no-op; M8 + M9 regression tests still pass unchanged | 18 |

**Total:** 84 new vitest cases. All 4 cluster files (`enterprise.ts` x3, `lifecycle.ts` x1) updated to import the TS ports statically. Comments in the cluster files document the latent-bug fixes per the batch-2 pattern.

### ESM-to-TS translation (template-merge)

`bin/lib/template-merge.mjs` used `createRequire(import.meta.url)` to load `fs`/`path` synchronously from ESM. The TS port replaces this with plain `import { existsSync, readFileSync } from 'node:fs'`. The CLI entry point at the bottom of the legacy `.mjs` file is dropped — never reachable from cluster wiring, only the lib API is consumed. M9 ESM-cutover tests in `tests/test-m9-pitcrew-regressions.test.ts` continue to pass with `await mergeTemplatesImpl(...)` (await-on-sync is a no-op).

### Verification

- `npm run verify-baseline` — 12/12 green
- `npx tsc --noEmit` clean
- `npm run lint` (biome) clean
- 84 new tests pass; full vitest suite (3574 tests) green

Refs #34

## Test plan

- [x] `npm run verify-baseline` returns 12/12 PASS
- [x] All 4 new test files pass: `test-legacy-modernizer.test.ts`, `test-agent-checkpoint.test.ts`, `test-release-readiness.test.ts`, `test-template-merge.test.ts`
- [x] Existing legacy `.test.js` siblings (`test-legacy-modernizer.test.js`, `test-agent-checkpoint.test.js`, `test-release-readiness.test.js`) still pass — they import `bin/lib/*.{js,mjs}` directly and remain authoritative for the legacy strangler tail until M11 retires them.
- [x] M9 pit-crew regression tests (`test-m9-pitcrew-regressions.test.ts`) pass — confirms `mergeTemplatesImpl` async-to-sync flip is callsite-compatible.
- [x] CLI cluster tests (`test-cli-enterprise.test.ts`, `test-cli-lifecycle.test.ts`) pass — confirms the `legacyXxx as LegacyLib` wiring change compiles and the `release-readiness` / `legacy-modernizer` action-routing changes don't regress.