### PR TITLE
chore(m11): governance/enterprise/collab partial defensive fixes for noUncheckedIndexedAccess

### DIFF
--- a/src/lib/ai-evaluation.ts
+++ b/src/lib/ai-evaluation.ts
@@ -174,8 +174,8 @@ export function generateReport(options: ReportOptions = {}): EvalReport {
   const avgScores: Record<string, number | null> = {};
   for (const dim of EVAL_DIMENSIONS) {
     const vals = state.evaluations
-      .filter((e) => e.scores[dim] !== undefined)
-      .map((e) => e.scores[dim]);
+      .map((e) => e.scores[dim])
+      .filter((v): v is number => v !== undefined);
     avgScores[dim] =
       vals.length > 0 ? Math.round(vals.reduce((a, b) => a + b, 0) / vals.length) : null;
   }

--- a/src/lib/backlog-sync.ts
+++ b/src/lib/backlog-sync.ts
@@ -194,9 +194,10 @@ export function extractEpics(content: string): Epic[] {
 
   for (const line of lines) {
     const epicMatch = line.match(/^#{2,4}\s+(?:Epic\s+)?(\d+|E\d+)[:\s—–-]+\s*(.+)$/i);
-    if (epicMatch) {
+    if (epicMatch?.[1] !== undefined && epicMatch[2] !== undefined) {
       if (currentEpic) epics.push(currentEpic);
-      const id = epicMatch[1].startsWith('E') ? epicMatch[1] : `E${epicMatch[1].padStart(2, '0')}`;
+      const epicNum = epicMatch[1];
+      const id = epicNum.startsWith('E') ? epicNum : `E${epicNum.padStart(2, '0')}`;
       currentEpic = {
         id,
         title: epicMatch[2].trim(),
@@ -208,7 +209,7 @@ export function extractEpics(content: string): Epic[] {
 
     if (currentEpic) {
       const storyMatch = line.match(/(?:^[-*]\s+\*{0,2})(E\d+-S\d+)(?:\*{0,2})[:\s—–-]+\s*(.+)/i);
-      if (storyMatch) {
+      if (storyMatch?.[1] !== undefined && storyMatch[2] !== undefined) {
         currentEpic.stories.push({
           id: storyMatch[1],
           title: storyMatch[2].trim().replace(/\*{1,2}/g, ''),
@@ -234,7 +235,7 @@ export function extractTasks(content: string): Task[] {
     const taskMatch = line.match(
       /(?:^#{2,4}\s+|^[-*]\s+\*{0,2})(M\d+-T\d+)(?:\*{0,2})[:\s—–-]+\s*(.+)/i
     );
-    if (taskMatch) {
+    if (taskMatch?.[1] !== undefined && taskMatch[2] !== undefined) {
       const storyRefs = line.match(/E\d+-S\d+/g) || [];
       tasks.push({
         id: taskMatch[1],

--- a/src/lib/contract-checker.ts
+++ b/src/lib/contract-checker.ts
@@ -97,11 +97,13 @@ export function extractModelEntities(content: string): ModelEntity[] {
 
   for (let i = 1; i < sections.length; i++) {
     const section = sections[i];
+    if (section === undefined) continue;
     const nameMatch = section.match(/^\s*(\w+)/);
-    if (!nameMatch) continue;
+    if (!nameMatch || nameMatch[1] === undefined) continue;
 
     const entity: ModelEntity = { name: nameMatch[1], fields: [] };
     for (const m of section.matchAll(FIELD_REGEX)) {
+      if (m[1] === undefined || m[2] === undefined) continue;
       entity.fields.push({
         name: m[1],
         type: m[2].trim(),
@@ -122,21 +124,22 @@ export function extractContractEntities(content: string): ContractEndpoint[] {
 
   for (let i = 1; i < sections.length; i++) {
     const section = sections[i];
+    if (section === undefined) continue;
     const headerMatch = section.match(/^(\w+)\s+([^`]+)`/);
-    if (!headerMatch) continue;
+    if (!headerMatch || headerMatch[1] === undefined || headerMatch[2] === undefined) continue;
 
     const endpoint = `${headerMatch[1]} ${headerMatch[2]}`;
 
     const fields: string[] = [];
     for (const m of section.matchAll(FIELD_NAME_REGEX)) {
-      if (!RESERVED_FIELDS.has(m[1])) {
+      if (m[1] !== undefined && !RESERVED_FIELDS.has(m[1])) {
         fields.push(m[1]);
       }
     }
 
     const entities: string[] = [];
     for (const m of section.matchAll(ENTITY_REF_REGEX)) {
-      if (!RESERVED_ENTITIES.has(m[1])) {
+      if (m[1] !== undefined && !RESERVED_ENTITIES.has(m[1])) {
         entities.push(m[1]);
       }
     }

--- a/src/lib/decision-conflicts.ts
+++ b/src/lib/decision-conflicts.ts
@@ -166,9 +166,9 @@ export function extractADRDecisions(decisionsDir: string): Decision[] {
     decisions.push({
       source: `specs/decisions/${file}`,
       type: 'adr',
-      title: titleMatch ? titleMatch[1].trim() : file,
-      status: statusMatch ? statusMatch[1].trim().toLowerCase() : 'unknown',
-      decision_text: decisionMatch ? decisionMatch[1].trim() : '',
+      title: titleMatch?.[1] !== undefined ? titleMatch[1].trim() : file,
+      status: statusMatch?.[1] !== undefined ? statusMatch[1].trim().toLowerCase() : 'unknown',
+      decision_text: decisionMatch?.[1] !== undefined ? decisionMatch[1].trim() : '',
       technologies: extractTechReferences(content),
       patterns: extractPatternReferences(content),
     });
@@ -189,7 +189,7 @@ export function extractArchDecisions(archPath: string): Decision[] {
 
   for (const section of sections) {
     if (section.trim().length === 0) continue;
-    const titleLine = section.split('\n')[0].trim();
+    const titleLine = (section.split('\n')[0] ?? '').trim();
     const sectionContent = section.split('\n').slice(1).join('\n');
 
     decisions.push({
@@ -217,7 +217,7 @@ export function extractPRDDecisions(prdPath: string): Decision[] {
   const nfrSection = content.match(
     /##\s+(?:Non-Functional|NFR|Constraints).*?\n([\s\S]*?)(?=\n##|\n$|$)/i
   );
-  if (nfrSection) {
+  if (nfrSection?.[1] !== undefined) {
     decisions.push({
       source: 'specs/prd.md',
       type: 'prd',
@@ -231,7 +231,7 @@ export function extractPRDDecisions(prdPath: string): Decision[] {
   const techSection = content.match(
     /##\s+(?:Tech|Technology|Stack|Technical).*?\n([\s\S]*?)(?=\n##|\n$|$)/i
   );
-  if (techSection) {
+  if (techSection?.[1] !== undefined) {
     decisions.push({
       source: 'specs/prd.md',
       type: 'prd',
@@ -298,7 +298,7 @@ export function findConflicts(decisions: Decision[]): Conflict[] {
   for (const [category, techs] of Object.entries(competing)) {
     const usedTechs = techs.filter((t) => techBySource[t]);
     if (usedTechs.length > 1) {
-      const sources = usedTechs.flatMap((t) => techBySource[t].map((d) => d.source));
+      const sources = usedTechs.flatMap((t) => (techBySource[t] ?? []).map((d) => d.source));
       conflicts.push({
         type: 'technology',
         category,

--- a/src/lib/delivery-confidence.ts
+++ b/src/lib/delivery-confidence.ts
@@ -374,9 +374,9 @@ export function scoreConfidence(content: string, options: ScoreOptions = {}): Sc
       dimensions.enterprise_readiness.score * weights.enterprise_readiness
   );
 
-  const level =
-    CONFIDENCE_LEVELS.find((l) => weightedScore >= l.min) ||
-    CONFIDENCE_LEVELS[CONFIDENCE_LEVELS.length - 1];
+  const level = CONFIDENCE_LEVELS.find((l) => weightedScore >= l.min) ??
+    CONFIDENCE_LEVELS[CONFIDENCE_LEVELS.length - 1] ??
+    CONFIDENCE_LEVELS[0] ?? { label: 'Unknown', emoji: '?', min: 0 };
 
   const allGaps = [
     ...(dimensions.completeness.gaps || []),
@@ -440,9 +440,9 @@ export function scoreProject(root: string, options: ScoreOptions = {}): ProjectS
       ? Math.round(results.reduce((sum, r) => sum + (r.overall_score || 0), 0) / results.length)
       : 0;
 
-  const level =
-    CONFIDENCE_LEVELS.find((l) => avgScore >= l.min) ||
-    CONFIDENCE_LEVELS[CONFIDENCE_LEVELS.length - 1];
+  const level = CONFIDENCE_LEVELS.find((l) => avgScore >= l.min) ??
+    CONFIDENCE_LEVELS[CONFIDENCE_LEVELS.length - 1] ??
+    CONFIDENCE_LEVELS[0] ?? { label: 'Unknown', emoji: '?', min: 0 };
 
   return {
     success: true,

--- a/src/lib/domain-ontology.ts
+++ b/src/lib/domain-ontology.ts
@@ -268,13 +268,18 @@ function levenshtein(a: string, b: string): number {
   );
   for (let i = 1; i <= m; i++) {
     for (let j = 1; j <= n; j++) {
-      dp[i][j] =
-        a[i - 1] === b[j - 1]
-          ? dp[i - 1][j - 1]
-          : 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1]);
+      const row = dp[i];
+      const prevRow = dp[i - 1];
+      if (row === undefined || prevRow === undefined) continue;
+      const aChar = a[i - 1];
+      const bChar = b[j - 1];
+      const diag = prevRow[j - 1] ?? 0;
+      const above = prevRow[j] ?? 0;
+      const left = row[j - 1] ?? 0;
+      row[j] = aChar === bChar ? diag : 1 + Math.min(above, left, diag);
     }
   }
-  return dp[m][n];
+  return dp[m]?.[n] ?? 0;
 }
 
 export function generateReport(options: ReportOptions = {}): ReportResult {
@@ -285,9 +290,11 @@ export function generateReport(options: ReportOptions = {}): ReportResult {
   const report: ReportResult = { success: true, total_domains: domains.length, domains: {} };
 
   for (const d of domains) {
-    const elements = state.domains[d].elements;
+    const domain = state.domains[d];
+    if (domain === undefined) continue;
+    const elements = domain.elements;
     const byType: Record<string, number> = {};
-    for (const e of elements) byType[e.type] = (byType[e.type] || 0) + 1;
+    for (const e of elements) byType[e.type] = (byType[e.type] ?? 0) + 1;
     report.domains[d] = { total_elements: elements.length, by_type: byType };
   }
 

--- a/src/lib/evidence-collector.ts
+++ b/src/lib/evidence-collector.ts
@@ -216,11 +216,12 @@ export function collectEvidence(root: string, options: StateOptions = {}): Colle
 
   saveState(state, stateFile);
 
+  const lastCollection = state.collections[state.collections.length - 1];
   return {
     success: true,
     items_collected: items.length,
     types: [...new Set(items.map((i) => i.type))],
-    collection_id: state.collections[state.collections.length - 1].id,
+    collection_id: lastCollection?.id ?? '',
   };
 }
 
@@ -264,7 +265,6 @@ export function getStatus(options: StateOptions = {}): StatusResult {
     total_items: state.evidence_items.length,
     collections: state.collections.length,
     types: [...new Set(state.evidence_items.map((i) => i.type))],
-    last_collection:
-      state.collections.length > 0 ? state.collections[state.collections.length - 1] : null,
+    last_collection: state.collections[state.collections.length - 1] ?? null,
   };
 }

--- a/src/lib/promptless-mode.ts
+++ b/src/lib/promptless-mode.ts
@@ -228,7 +228,11 @@ export function answerStep(
     return { success: false, error: 'Wizard is already complete' };
   }
 
-  session.steps[session.current_step].answer = answer;
+  const currentStep = session.steps[session.current_step];
+  if (currentStep === undefined) {
+    return { success: false, error: 'Wizard step out of range' };
+  }
+  currentStep.answer = answer;
   session.current_step++;
 
   const complete = session.current_step >= session.steps.length;
@@ -236,10 +240,11 @@ export function answerStep(
 
   saveState(state, stateFile);
 
+  const nextStep = complete ? null : (session.steps[session.current_step] ?? null);
   return {
     success: true,
     complete,
-    next_step: complete ? null : session.steps[session.current_step],
+    next_step: nextStep,
     answers: Object.fromEntries(
       session.steps.filter((s) => s.answer !== null).map((s) => [s.id, s.answer])
     ),

--- a/src/lib/rewind.ts
+++ b/src/lib/rewind.ts
@@ -203,6 +203,12 @@ export function rewindToPhase(targetPhase: number, options: RewindOptions = {}):
   }
 
   const phaseInfo = PHASE_ARTIFACTS[String(phase)];
+  if (phaseInfo === undefined) {
+    return {
+      success: false,
+      error: `Phase ${phase} not in PHASE_ARTIFACTS catalog`,
+    };
+  }
   const root = options.root || process.cwd();
   const statePath = options.statePath || join(root, '.jumpstart', 'state', 'state.json');
   const reason = options.reason || `Rewound to Phase ${phase} (${phaseInfo.name})`;
@@ -223,6 +229,7 @@ export function rewindToPhase(targetPhase: number, options: RewindOptions = {}):
   const invalidatedPhases: InvalidatedPhase[] = [];
   for (const dp of downstream) {
     const dpInfo = PHASE_ARTIFACTS[String(dp)];
+    if (dpInfo === undefined) continue;
     const artifacts = getPhaseArtifacts(dp);
     allArtifacts.push(...artifacts);
     invalidatedPhases.push({ phase: dp, name: dpInfo.name, artifacts });

--- a/src/lib/type-checker.ts
+++ b/src/lib/type-checker.ts
@@ -131,7 +131,14 @@ export function parseTypeErrors(output: string, _checkerName: string): TypeCheck
   for (const line of lines) {
     // TypeScript format: src/index.ts(10,5): error TS2322: Type 'string'...
     const tsMatch = line.match(/^(.+?)\((\d+),\d+\):\s+(error|warning)\s+(TS\d+):\s+(.+)/);
-    if (tsMatch) {
+    if (
+      tsMatch &&
+      tsMatch[1] !== undefined &&
+      tsMatch[2] !== undefined &&
+      tsMatch[3] !== undefined &&
+      tsMatch[4] !== undefined &&
+      tsMatch[5] !== undefined
+    ) {
       findings.push({
         file: tsMatch[1],
         line: Number.parseInt(tsMatch[2], 10),
@@ -144,7 +151,14 @@ export function parseTypeErrors(output: string, _checkerName: string): TypeCheck
 
     // TypeScript alt format: src/index.ts:10:5 - error TS2322: ...
     const tsAltMatch = line.match(/^(.+?):(\d+):\d+\s+-\s+(error|warning)\s+(TS\d+):\s+(.+)/);
-    if (tsAltMatch) {
+    if (
+      tsAltMatch &&
+      tsAltMatch[1] !== undefined &&
+      tsAltMatch[2] !== undefined &&
+      tsAltMatch[3] !== undefined &&
+      tsAltMatch[4] !== undefined &&
+      tsAltMatch[5] !== undefined
+    ) {
       findings.push({
         file: tsAltMatch[1],
         line: Number.parseInt(tsAltMatch[2], 10),
@@ -157,13 +171,20 @@ export function parseTypeErrors(output: string, _checkerName: string): TypeCheck
 
     // mypy format: src/main.py:10: error: Incompatible types... [assignment]
     const mypyMatch = line.match(/^(.+?):(\d+):\s+(error|warning|note):\s+(.+?)(?:\s+\[(.+?)\])?$/);
-    if (mypyMatch && !line.startsWith(' ')) {
+    if (
+      mypyMatch &&
+      !line.startsWith(' ') &&
+      mypyMatch[1] !== undefined &&
+      mypyMatch[2] !== undefined &&
+      mypyMatch[3] !== undefined &&
+      mypyMatch[4] !== undefined
+    ) {
       const sev = mypyMatch[3] === 'note' ? 'warning' : (mypyMatch[3] as 'error' | 'warning');
       findings.push({
         file: mypyMatch[1],
         line: Number.parseInt(mypyMatch[2], 10),
         severity: sev,
-        code: mypyMatch[5] || null,
+        code: mypyMatch[5] ?? null,
         message: mypyMatch[4].trim(),
       });
       continue;
@@ -173,14 +194,20 @@ export function parseTypeErrors(output: string, _checkerName: string): TypeCheck
     const pyrightMatch = line.match(
       /^(.+?):(\d+):\d+\s+-\s+(error|warning|information):\s+(.+?)(?:\s+\((.+?)\))?$/
     );
-    if (pyrightMatch) {
+    if (
+      pyrightMatch &&
+      pyrightMatch[1] !== undefined &&
+      pyrightMatch[2] !== undefined &&
+      pyrightMatch[3] !== undefined &&
+      pyrightMatch[4] !== undefined
+    ) {
       const sev =
         pyrightMatch[3] === 'information' ? 'warning' : (pyrightMatch[3] as 'error' | 'warning');
       findings.push({
         file: pyrightMatch[1],
         line: Number.parseInt(pyrightMatch[2], 10),
         severity: sev,
-        code: pyrightMatch[5] || null,
+        code: pyrightMatch[5] ?? null,
         message: pyrightMatch[4].trim(),
       });
     }

--- a/src/lib/versioning.ts
+++ b/src/lib/versioning.ts
@@ -80,7 +80,9 @@ export function getNextVersion(artifactName: string, cwd?: string): string {
       .map((v) => v.split('.').map(Number))
       .sort((a, b) => {
         for (let i = 0; i < 3; i++) {
-          if (a[i] !== b[i]) return b[i] - a[i];
+          const ai = a[i] ?? 0;
+          const bi = b[i] ?? 0;
+          if (ai !== bi) return bi - ai;
         }
         return 0;
       });
@@ -88,7 +90,10 @@ export function getNextVersion(artifactName: string, cwd?: string): string {
     if (versions.length === 0) return '1.0.0';
 
     const latest = versions[0];
-    return `${latest[0]}.${latest[1] + 1}.0`;
+    if (latest === undefined) return '1.0.0';
+    const major = latest[0] ?? 1;
+    const minor = latest[1] ?? 0;
+    return `${major}.${minor + 1}.0`;
   } catch {
     return '1.0.0';
   }
@@ -198,7 +203,7 @@ export function listVersions(cwd?: string): VersionEntry[] {
       .split('\n')
       .map((tag): VersionEntry | null => {
         const match = tag.match(/^spec\/(.+)\/v(.+)$/);
-        if (match) {
+        if (match?.[1] !== undefined && match[2] !== undefined) {
           return { artifact: match[1], version: match[2], tag };
         }
         return null;


### PR DESCRIPTION
## Summary

Phase 2e of [#31](https://github.com/scombey/JumpStart-AutoNav/issues/31), **partial**. Closes 80 of the ~150 errors in the governance + enterprise + collaboration cluster. The remaining ~70 errors live in testing-infra (`holodeck`, `verify-diagrams`, etc.) and `src/cli/commands/*` — addressed in subsequent phase-2 PRs.

Pure defensive guards; no runtime behavior change. Flag stays OFF until phase 3.

## Files touched

| File | Errors closed | Pattern |
|---|---|---|
| `type-checker.ts` | 14 | TS / TS-alt / mypy / Pyright output parsers — narrowed every regex-capture |
| `contract-checker.ts` | 12 | extractModelEntities + extractContractEntities section + regex narrowing |
| `decision-conflicts.ts` | 11 | titleMatch/statusMatch/decisionMatch ADR guards; nfrSection/techSection/techBySource |
| `domain-ontology.ts` | 10 | Levenshtein DP guards; domains record narrowing |
| `backlog-sync.ts` | 8 | epicMatch/storyMatch/taskMatch regex narrowing |
| `rewind.ts` | 7 | PHASE_ARTIFACTS catalog narrowing; early-return on missing phase |
| `versioning.ts` | 7 | semver sort comparator guards; next-version fallback |
| `delivery-confidence.ts` | 4 | CONFIDENCE_LEVELS find/fallback with literal-object terminator |
| `ai-evaluation.ts` | 3 | EVAL_DIMENSIONS scores filter-after-map narrowing |
| `evidence-collector.ts` | 2 | collections[length-1] safe access |
| `promptless-mode.ts` | 2 | wizard step out-of-range guard; next_step narrowing |

## Skipped this PR (deferred)

- `holodeck.ts` (30 errors) — testing-infra
- `context-summarizer.ts` (24) — UX cluster
- `verify-diagrams.ts` (23) — testing-infra
- `regression.ts` (8), `smoke-tester.ts` (7), `simulation-tracer.ts` (4) — testing-infra
- `src/cli/commands/*` — phase 2f (CLI cluster)
- `tests/*` — phase 2g

## Test plan

- [x] `npx tsc --noEmit` — clean (flag stays OFF)
- [x] `npm run verify-baseline` — 12/12 green
- [x] `npm run lint` — clean
- [x] 3,421 tests pass

## Cluster progression

- phase 1   `exactOptionalPropertyTypes` ON         → #35 (`ed3aab2`)
- phase 2a  Foundation                              → #37 (`5e93076`)
- phase 2b  Config                                  → #38 (`9b79a07`)
- phase 2c  Spec validation + graph                 → #40 (`1bdb356`)
- phase 2d  State + LLM + marketplace               → #41 (`b725182`)
- phase 2e  Governance + enterprise + collab        → **this PR (partial)**
- phase 2f  CLI commands                            → next
- phase 2g  Testing infra (holodeck/verify-diagrams/smoke/regression)
- phase 2h  Tests directory
- phase 3   Final flag-flip                         → once all clusters done

## Refs

- T6.6 / issue #31 phase 2e