### PR TITLE
chore(m11): cli cluster + 3 testing-infra defensive fixes

### DIFF
--- a/src/cli/commands/spec-validation.ts
+++ b/src/cli/commands/spec-validation.ts
@@ -400,6 +400,7 @@ export function shardImpl(deps: Deps, args: ShardArgs): CommandResult {
   if (!existsSync(shardDir)) mkdirSync(shardDir, { recursive: true });
   for (let i = 0; i < epics.length; i++) {
     const epic = epics[i];
+    if (epic === undefined) continue;
     const shard = sharder.generateShard(epic, i + 1);
     const shardPath = path.join(
       shardDir,

--- a/src/lib/context7-setup.ts
+++ b/src/lib/context7-setup.ts
@@ -372,6 +372,9 @@ export function installForClient(
       return { success: false, message: 'CLI argv is empty' };
     }
     const [bin, ...rest] = argv;
+    if (bin === undefined) {
+      return { success: false, message: 'CLI argv is empty' };
+    }
     const result = spawnSync(bin, rest, {
       stdio: 'pipe',
       cwd: targetDir,
@@ -556,7 +559,7 @@ export async function setupContext7(options: SetupOptions): Promise<SetupOutcome
   if (dryRun) {
     console.log(chalk.yellow.bold('   [DRY RUN] Would configure Context7 for:'));
     for (const c of selectedClients as string[]) {
-      console.log(chalk.gray(`     - ${CLIENT_CONFIGS[c].name}`));
+      console.log(chalk.gray(`     - ${CLIENT_CONFIGS[c]?.name ?? c}`));
     }
     console.log('');
     return { installed: false, clients: selectedClients };
@@ -564,7 +567,9 @@ export async function setupContext7(options: SetupOptions): Promise<SetupOutcome
 
   const results: Array<{ clientKey: string } & InstallResult> = [];
   for (const clientKey of selectedClients as string[]) {
-    const clientName = CLIENT_CONFIGS[clientKey].name;
+    const clientCfg = CLIENT_CONFIGS[clientKey];
+    if (clientCfg === undefined) continue;
+    const clientName = clientCfg.name;
     const result = installForClient(clientKey, trimmedKey, targetDir);
     results.push({ clientKey, ...result });
 

--- a/src/lib/simulation-tracer.ts
+++ b/src/lib/simulation-tracer.ts
@@ -491,13 +491,17 @@ export class SimulationTracer {
       totalCompletionTokens += call.completionTokens;
       totalCost += call.cost;
 
-      if (!byModel[call.model]) {
-        byModel[call.model] = { calls: 0, promptTokens: 0, completionTokens: 0, cost: 0 };
-      }
-      byModel[call.model].calls++;
-      byModel[call.model].promptTokens += call.promptTokens;
-      byModel[call.model].completionTokens += call.completionTokens;
-      byModel[call.model].cost += call.cost;
+      const bucket = byModel[call.model] ?? {
+        calls: 0,
+        promptTokens: 0,
+        completionTokens: 0,
+        cost: 0,
+      };
+      bucket.calls++;
+      bucket.promptTokens += call.promptTokens;
+      bucket.completionTokens += call.completionTokens;
+      bucket.cost += call.cost;
+      byModel[call.model] = bucket;
     }
 
     return {

--- a/src/lib/tool-bridge.ts
+++ b/src/lib/tool-bridge.ts
@@ -327,9 +327,11 @@ export function createToolBridge(options: ToolBridgeOptions): ToolBridge {
               const content = readFileSync(fullPath, 'utf8');
               const lines = content.split('\n');
               for (let i = 0; i < lines.length; i++) {
-                const match = regex ? regex.test(lines[i]) : lines[i].includes(query);
+                const line = lines[i];
+                if (line === undefined) continue;
+                const match = regex ? regex.test(line) : line.includes(query);
                 if (match) {
-                  results.push({ file: fullPath, line: i + 1, content: lines[i] });
+                  results.push({ file: fullPath, line: i + 1, content: line });
                 }
                 if (regex) regex.lastIndex = 0; // reset for global regex
               }


### PR DESCRIPTION
## Summary
- Continues the per-cluster ratchet for #31 phase 2 by hardening 4 files flagged when `noUncheckedIndexedAccess` was turned on locally
- Flag stays off in `tsconfig.json` (full ratchet is tracked across phases 2f-h), but the underlying defensive fixes are correct in their own right
- 4 files: `spec-validation.ts` (epic guard), `context7-setup.ts` (bin + CLIENT_CONFIGS narrowing), `simulation-tracer.ts` (byModel upsert), `tool-bridge.ts` (line guard)

## Files changed
- `src/cli/commands/spec-validation.ts` — guard `epics[i]` before passing into `sharder.generateShard`
- `src/lib/context7-setup.ts` — narrow destructured `bin` and `CLIENT_CONFIGS[clientKey]` lookups
- `src/lib/simulation-tracer.ts` — per-model usage bucket now upserts via `??` (3 fewer hashmap lookups per call)
- `src/lib/tool-bridge.ts` — search-in-files iteration caches line into const, skips undefined slots

## Test plan
- [x] `npm run verify-baseline` → 12/12 gates green
- [x] No public-API change (all 4 functions keep their signatures)
- [x] No behavior change for callers passing well-formed inputs (pure defensive fences)
- [x] Biome lint clean
- [ ] CI green on PR

Refs #31