### PR TITLE
chore(m11): testing-infra cluster defensive fixes

### DIFF
--- a/src/lib/context-summarizer.ts
+++ b/src/lib/context-summarizer.ts
@@ -185,21 +185,24 @@ export function extractFrontmatter(content: string): {
   const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
   if (!match) return { frontmatter: null, body: content };
 
+  const [, frontmatterRaw = '', bodyRaw = content] = match;
   const frontmatter: Frontmatter = {};
-  const lines = match[1].split('\n');
+  const lines = frontmatterRaw.split('\n');
   for (const line of lines) {
     const kv = line.match(/^(\w[\w-]*):\s*(.+)$/);
     if (kv) {
-      const raw = kv[2].trim();
+      const [, key, valueRaw = ''] = kv;
+      if (key === undefined) continue;
+      const raw = valueRaw.trim();
       let value: string | boolean = raw;
       if (raw === 'true') value = true;
       else if (raw === 'false') value = false;
       else if (/^["'].*["']$/.test(raw)) value = raw.slice(1, -1);
-      frontmatter[kv[1]] = value;
+      frontmatter[key] = value;
     }
   }
 
-  return { frontmatter, body: match[2] };
+  return { frontmatter, body: bodyRaw };
 }
 
 /** Extract all markdown sections (## and ### headings) with their content. */
@@ -210,14 +213,16 @@ export function extractSections(body: string): SectionRaw[] {
 
   for (let i = 0; i < matches.length; i++) {
     const m = matches[i];
+    if (m === undefined) continue;
+    const [whole = '', hashes = '', heading = ''] = m;
     const idx = m.index ?? 0;
-    const start = idx + m[0].length;
+    const start = idx + whole.length;
     const next = matches[i + 1];
     const end = next ? (next.index ?? body.length) : body.length;
     const content = body.substring(start, end).trim();
     sections.push({
-      level: m[1].length,
-      heading: m[2].trim(),
+      level: hashes.length,
+      heading: heading.trim(),
       content,
     });
   }
@@ -243,8 +248,10 @@ export function extractUserStories(content: string): UserStory[] {
   const storyRegex = /####\s+(E\d+-S\d+):\s*(.+)/g;
 
   for (const match of content.matchAll(storyRegex)) {
+    const [whole = '', id, title = ''] = match;
+    if (id === undefined) continue;
     const matchIdx = match.index ?? 0;
-    const storyStart = matchIdx + match[0].length;
+    const storyStart = matchIdx + whole.length;
     const nextStoryRegex = /####\s+E\d+-S\d+/g;
     nextStoryRegex.lastIndex = storyStart;
     const nextStory = nextStoryRegex.exec(content);
@@ -255,8 +262,8 @@ export function extractUserStories(content: string): UserStory[] {
 
     const criteriaMatches = storySection.match(/- (?:Given|When|Then|And).+/g);
     stories.push({
-      id: match[1],
-      title: match[2].trim(),
+      id,
+      title: title.trim(),
       acceptance_criteria: criteriaMatches
         ? criteriaMatches.map((c) => c.replace(/^- /, '').trim())
         : [],
@@ -272,8 +279,10 @@ export function extractNFRs(content: string): NFR[] {
   const nfrRegex = /###\s+NFR-(\d+):\s*(.+)/g;
 
   for (const match of content.matchAll(nfrRegex)) {
+    const [whole = '', num, title = ''] = match;
+    if (num === undefined) continue;
     const matchIdx = match.index ?? 0;
-    const nfrStart = matchIdx + match[0].length;
+    const nfrStart = matchIdx + whole.length;
     const nextSection = content.indexOf('\n### ', nfrStart);
     const nfrBody = content
       .substring(nfrStart, nextSection > 0 ? nextSection : nfrStart + 500)
@@ -284,8 +293,8 @@ export function extractNFRs(content: string): NFR[] {
     );
 
     nfrs.push({
-      id: `NFR-${match[1]}`,
-      title: match[2].trim(),
+      id: `NFR-${num}`,
+      title: title.trim(),
       metric: metricMatch ? metricMatch[0].trim() : null,
     });
   }
@@ -303,8 +312,16 @@ export function extractTechStack(content: string): TechStackItem[] {
       .split('|')
       .filter((c) => c.trim())
       .map((c) => c.trim());
-    if (cols.length >= 3 && cols[0].toLowerCase() !== 'layer' && cols[0] !== '---') {
-      stack.push({ layer: cols[0], technology: cols[1], version: cols[2] });
+    const [layer, technology, version] = cols;
+    if (
+      cols.length >= 3 &&
+      layer !== undefined &&
+      technology !== undefined &&
+      version !== undefined &&
+      layer.toLowerCase() !== 'layer' &&
+      layer !== '---'
+    ) {
+      stack.push({ layer, technology, version });
     }
   }
 
@@ -317,15 +334,18 @@ export function extractComponents(content: string): ComponentEntry[] {
   const compRegex = /### Component:\s*(.+)/g;
 
   for (const match of content.matchAll(compRegex)) {
+    const [whole = '', name] = match;
+    if (name === undefined) continue;
     const matchIdx = match.index ?? 0;
-    const compStart = matchIdx + match[0].length;
+    const compStart = matchIdx + whole.length;
     const nextComp = content.indexOf('\n### ', compStart);
     const compBody = content.substring(compStart, nextComp > 0 ? nextComp : compStart + 500);
 
     const purposeMatch = compBody.match(/\*\*Purpose:\*\*\s*(.+)/);
+    const purposeRaw = purposeMatch?.[1];
     components.push({
-      name: match[1].trim(),
-      purpose: purposeMatch ? purposeMatch[1].trim() : 'Not specified',
+      name: name.trim(),
+      purpose: purposeRaw ? purposeRaw.trim() : 'Not specified',
     });
   }
 
@@ -338,10 +358,13 @@ export function extractTasks(content: string): TaskEntry[] {
   const taskRegex = /(M\d+-T\d+)\s*[:-]\s*(.+)/g;
 
   for (const match of content.matchAll(taskRegex)) {
+    const [, id, title = ''] = match;
+    if (id === undefined) continue;
+    const milestone = id.split('-')[0] ?? id;
     tasks.push({
-      id: match[1],
-      title: match[2].trim(),
-      milestone: match[1].split('-')[0],
+      id,
+      title: title.trim(),
+      milestone,
     });
   }
 
@@ -573,8 +596,9 @@ export function renderContextMarkdown(packet: ContextPacket): string {
     lines.push('');
     const milestones: Record<string, TaskEntry[]> = {};
     for (const task of allTasks) {
-      if (!milestones[task.milestone]) milestones[task.milestone] = [];
-      milestones[task.milestone].push(task);
+      const bucket = milestones[task.milestone] ?? [];
+      bucket.push(task);
+      milestones[task.milestone] = bucket;
     }
     for (const [milestone, tasks] of Object.entries(milestones)) {
       lines.push(`### ${milestone}`);

--- a/src/lib/holodeck.ts
+++ b/src/lib/holodeck.ts
@@ -556,6 +556,7 @@ export async function runHolodeck(
 
   for (let i = 0; i < PHASE_CONFIG.length; i++) {
     const phase = PHASE_CONFIG[i];
+    if (phase === undefined) continue;
     const phaseSrcDir = path.join(scenarioDir, phase.dir);
 
     if (!existsSync(phaseSrcDir)) {
@@ -609,8 +610,9 @@ export async function runHolodeck(
 
       // 5. HANDOFF
       if (i > 0) {
-        const upstream = PHASE_CONFIG[i - 1].name;
-        const upstreamArtifact = PHASE_CONFIG[i - 1].artifacts[0];
+        const prevPhase = PHASE_CONFIG[i - 1];
+        const upstream = prevPhase?.name ?? '';
+        const upstreamArtifact = prevPhase?.artifacts[0] ?? '';
         const upstreamPath = path.join(targetDir, 'specs', upstreamArtifact);
 
         if (existsSync(upstreamPath) && existsSync(handoffsDir)) {

--- a/src/lib/regression.ts
+++ b/src/lib/regression.ts
@@ -122,15 +122,17 @@ export function loadGoldenMaster(name: string, mastersDir: string): GoldenMaster
     ? readdirSync(expectedDir).filter((f) => f.includes(name))
     : [];
 
-  if (inputFiles.length === 0) {
+  const [inputName] = inputFiles;
+  const [expectedName] = expectedFiles;
+  if (inputName === undefined) {
     throw new Error(`No golden master input found for '${name}' in ${inputDir}`);
   }
-  if (expectedFiles.length === 0) {
+  if (expectedName === undefined) {
     throw new Error(`No golden master expected output found for '${name}' in ${expectedDir}`);
   }
 
-  const inputPath = path.join(inputDir, inputFiles[0]);
-  const expectedPath = path.join(expectedDir, expectedFiles[0]);
+  const inputPath = path.join(inputDir, inputName);
+  const expectedPath = path.join(expectedDir, expectedName);
 
   return {
     input: readFileSync(inputPath, 'utf8'),
@@ -314,12 +316,13 @@ export async function runRegressionSuite(
   for (const expectedFile of expectedFiles) {
     // Extract name from expected file (e.g., 'todo-app-prd.md' → 'todo-app')
     const nameParts = expectedFile.replace('.md', '').split('-');
-    const baseName = nameParts.slice(0, -1).join('-') || nameParts[0];
+    const baseName = nameParts.slice(0, -1).join('-') || nameParts[0] || expectedFile;
 
     const inputFiles = readdirSync(inputDir).filter((f) => f.includes(baseName));
-    if (inputFiles.length === 0) continue;
+    const [firstInput] = inputFiles;
+    if (firstInput === undefined) continue;
 
-    const inputFilePath = path.join(inputDir, inputFiles[0]);
+    const inputFilePath = path.join(inputDir, firstInput);
     const expected = readFileSync(path.join(expectedDir, expectedFile), 'utf8');
 
     let actual: string;
@@ -328,7 +331,7 @@ export async function runRegressionSuite(
     } catch (err) {
       results.push({
         name: baseName,
-        input_file: inputFiles[0],
+        input_file: firstInput,
         expected_file: expectedFile,
         similarity: 0,
         pass: false,
@@ -340,7 +343,7 @@ export async function runRegressionSuite(
     const diff = structuralDiff(actual, expected);
     results.push({
       name: baseName,
-      input_file: inputFiles[0],
+      input_file: firstInput,
       expected_file: expectedFile,
       similarity: diff.similarity,
       pass: diff.similarity >= threshold,

--- a/src/lib/smoke-tester.ts
+++ b/src/lib/smoke-tester.ts
@@ -258,8 +258,18 @@ export function runBuild(command: string, root: string): BuildReport {
     };
   }
 
+  const [head, ...tail] = parts;
+  if (head === undefined) {
+    return {
+      pass: false,
+      command,
+      duration_ms: 0,
+      output: 'Empty build command',
+      exit_code: 1,
+    };
+  }
   try {
-    const result = spawnSync(parts[0], parts.slice(1), {
+    const result = spawnSync(head, tail, {
       cwd: root,
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -370,7 +380,12 @@ export function startAndWait(
 ): Promise<StartupOutcome> {
   return new Promise((resolve) => {
     const parts = command.split(' ');
-    const proc = spawn(parts[0], parts.slice(1), {
+    const [head, ...tail] = parts;
+    if (head === undefined) {
+      resolve({ process: null, ready: false, error: 'Empty start command' });
+      return;
+    }
+    const proc = spawn(head, tail, {
       cwd: root,
       stdio: ['pipe', 'pipe', 'pipe'],
       detached: false,

--- a/src/lib/verify-diagrams.ts
+++ b/src/lib/verify-diagrams.ts
@@ -141,10 +141,13 @@ export function parseArgs(argv: string[]): RunOptions & { help?: boolean } {
   };
   for (let i = 2; i < argv.length; i++) {
     const a = argv[i];
-    if (a === '--dir' && argv[i + 1]) {
-      (args.dirs as string[]).push(argv[++i]);
-    } else if (a === '--file' && argv[i + 1]) {
-      (args.files as string[]).push(argv[++i]);
+    const next = argv[i + 1];
+    if (a === '--dir' && next !== undefined) {
+      (args.dirs as string[]).push(next);
+      i++;
+    } else if (a === '--file' && next !== undefined) {
+      (args.files as string[]).push(next);
+      i++;
     } else if (a === '--strict') {
       args.strict = true;
     } else if (a === '--json') {
@@ -200,7 +203,9 @@ export function extractMermaidBlocks(content: string): MermaidBlock[] {
   let body: string[] = [];
 
   for (let i = 0; i < lines.length; i++) {
-    const trimmed = lines[i].trim();
+    const line = lines[i];
+    if (line === undefined) continue;
+    const trimmed = line.trim();
     if (!inside && /^```mermaid\b/i.test(trimmed)) {
       inside = true;
       startLine = i + 1; // 1-based
@@ -213,7 +218,7 @@ export function extractMermaidBlocks(content: string): MermaidBlock[] {
       });
       inside = false;
     } else if (inside) {
-      body.push(lines[i]);
+      body.push(line);
     }
   }
 
@@ -340,7 +345,7 @@ export function validateBlock(block: MermaidBlock): Issue[] {
 
   // Determine diagram type from first meaningful line
   const bodyLines = trimmedBody.split('\n');
-  const firstLine = bodyLines[0].trim();
+  const firstLine = (bodyLines[0] ?? '').trim();
   const diagramType = detectDiagramType(firstLine);
 
   if (!diagramType) {
@@ -406,25 +411,29 @@ function checkBracketBalance(body: string, baseLineNum: number): Issue[] {
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
+    if (line === undefined) continue;
     // Skip comment lines
     if (line.trim().startsWith('%%')) continue;
     // Skip quoted strings (rough heuristic)
     const unquoted = line.replace(/"[^"]*"/g, '').replace(/'[^']*'/g, '');
 
     for (const ch of unquoted) {
-      if (ch in stacks) {
-        stacks[ch].push(baseLineNum + i);
-      } else if (ch in closers) {
-        const opener = closers[ch];
-        if (stacks[opener].length === 0) {
-          issues.push({
-            level: 'error',
-            message: `Unmatched closing '${ch}'`,
-            line: baseLineNum + i,
-          });
-        } else {
-          stacks[opener].pop();
-        }
+      const opens = stacks[ch];
+      if (opens) {
+        opens.push(baseLineNum + i);
+        continue;
+      }
+      const openerCh = closers[ch];
+      if (openerCh === undefined) continue;
+      const openerStack = stacks[openerCh];
+      if (openerStack === undefined || openerStack.length === 0) {
+        issues.push({
+          level: 'error',
+          message: `Unmatched closing '${ch}'`,
+          line: baseLineNum + i,
+        });
+      } else {
+        openerStack.pop();
       }
     }
   }
@@ -452,7 +461,9 @@ function checkSubgraphEndPairing(body: string, baseLineNum: number): Issue[] {
   const lines = body.split('\n');
 
   for (let i = 0; i < lines.length; i++) {
-    const trimmed = lines[i].trim();
+    const line = lines[i];
+    if (line === undefined) continue;
+    const trimmed = line.trim();
     if (/^subgraph\b/i.test(trimmed)) {
       depth++;
     } else if (/^end$/i.test(trimmed)) {
@@ -488,7 +499,9 @@ function checkArrowSyntax(body: string, baseLineNum: number): Issue[] {
   const validArrowPattern = /-->|==>|-.->|---->|~~~|---|===|---|--\s|-->/;
 
   for (let i = 0; i < lines.length; i++) {
-    const trimmed = lines[i].trim();
+    const line = lines[i];
+    if (line === undefined) continue;
+    const trimmed = line.trim();
     if (
       trimmed.startsWith('%%') ||
       trimmed.startsWith('style') ||
@@ -526,7 +539,9 @@ function checkC4Syntax(body: string, baseLineNum: number): Issue[] {
   const funcPattern = /^\s*(\w+)\s*\(/;
 
   for (let i = 0; i < lines.length; i++) {
-    const trimmed = lines[i].trim();
+    const line = lines[i];
+    if (line === undefined) continue;
+    const trimmed = line.trim();
     if (
       !trimmed ||
       trimmed.startsWith('%%') ||
@@ -541,6 +556,7 @@ function checkC4Syntax(body: string, baseLineNum: number): Issue[] {
     const funcMatch = trimmed.match(funcPattern);
     if (funcMatch) {
       const funcName = funcMatch[1];
+      if (funcName === undefined) continue;
 
       // Check if it's a known C4 function
       if (!C4_FUNCTIONS.includes(funcName)) {
@@ -637,8 +653,8 @@ function checkC4Syntax(body: string, baseLineNum: number): Issue[] {
  */
 function countArgs(line: string): number {
   const match = line.match(/\(([^)]*)\)/);
-  if (!match?.[1].trim()) return 0;
-  const inner = match[1];
+  const inner = match?.[1];
+  if (inner === undefined || !inner.trim()) return 0;
 
   let count = 1;
   let inQuote = false;
@@ -668,7 +684,9 @@ function checkErDiagram(body: string, baseLineNum: number): Issue[] {
   const validCardinality = /(\|\||o\||o\{|\}\||o\}|\{o|\|o|\|\{|\{\||\}o)/;
 
   for (let i = 0; i < lines.length; i++) {
-    const trimmed = lines[i].trim();
+    const line = lines[i];
+    if (line === undefined) continue;
+    const trimmed = line.trim();
     if (!trimmed || trimmed.startsWith('%%') || trimmed === 'erDiagram') continue;
 
     // Check for entity blocks
@@ -684,7 +702,7 @@ function checkErDiagram(body: string, baseLineNum: number): Issue[] {
         // Check if cardinality symbols look wrong
         const parts = trimmed.split('--');
         if (parts.length === 2) {
-          const leftSide = parts[0].trim();
+          const leftSide = (parts[0] ?? '').trim();
           const leftSymbol = leftSide.split(/\s+/).pop();
           if (leftSymbol && !validCardinality.test(leftSymbol) && !/^\w+$/.test(leftSymbol)) {
             issues.push({
@@ -711,7 +729,9 @@ function checkClassDiagram(body: string, _baseLineNum: number): Issue[] {
   const validRelationships = /(<\|--|--\*|--o|-->|-->|\.\.>|\.\.\|>|--|\.\.)/;
 
   for (let i = 0; i < lines.length; i++) {
-    const trimmed = lines[i].trim();
+    const line = lines[i];
+    if (line === undefined) continue;
+    const trimmed = line.trim();
     if (
       !trimmed ||
       trimmed.startsWith('%%') ||
@@ -730,7 +750,7 @@ function checkClassDiagram(body: string, _baseLineNum: number): Issue[] {
     }
 
     // Check for class member lines inside a class block (indented)
-    if (/^\s+[+\-#~]/.test(lines[i])) continue;
+    if (/^\s+[+\-#~]/.test(line)) continue;
 
     // Check relationship lines — legacy parity: a future enhancement
     // could verify the relationship has a label; for now we accept any


### PR DESCRIPTION
## Summary
- Continues the per-cluster ratchet for #31 phase 2 by hardening 5 testing-infra modules flagged when `noUncheckedIndexedAccess` was turned on locally
- Flag stays off in `tsconfig.json` (full ratchet is tracked across phases 2g-h), but the underlying defensive fixes are correct in their own right
- 92 errors fixed across 5 files: `holodeck.ts` (30), `context-summarizer.ts` (24), `verify-diagrams.ts` (23), `regression.ts` (8), `smoke-tester.ts` (7)

## Files changed
- `src/lib/holodeck.ts` - guard PHASE_CONFIG[i] in main loop, collapse PHASE_CONFIG[i-1] through `?? ''`
- `src/lib/context-summarizer.ts` - all regex-capture reads switched to destructuring with defaults across 7 extract* functions; milestone bucket upserts via `?? []`
- `src/lib/verify-diagrams.ts` - all line-by-line loops narrow `lines[i]` once per iteration (6 functions); `parseArgs` argv index narrowing; `countArgs` optional chain; `checkBracketBalance` proper stack-lookup narrowing
- `src/lib/regression.ts` - `loadGoldenMaster` and `runGoldenMasterSuite` destructure first input/expected and skip on miss; baseName fallback for empty hyphen splits
- `src/lib/smoke-tester.ts` - `spawnSync` and `spawn` callers destructure command head, return legacy empty-command result on miss

## Test plan
- [x] `npm run verify-baseline` → 12/12 gates green (with clean dist/)
- [x] No public-API change (all functions keep their signatures)
- [x] No behavior change for well-formed inputs (pure defensive fences)
- [x] Biome lint clean
- [ ] CI green on PR

Refs #31