### PR TITLE
feat(m11-batch5): port 5 final legacy modules — fitness-functions, finops-planner, plan-executor, proactive-validator, reference-architectures

### DIFF
--- a/src/cli/commands/deferred.ts
+++ b/src/cli/commands/deferred.ts
@@ -53,7 +53,7 @@ import {
   type TimelineFilters,
 } from '../../lib/timeline.js';
 import { type CommandResult, createRealDeps, type Deps } from '../deps.js';
-import { asRest, hasFlag, legacyRequire, parseFlag, safeJoin } from './_helpers.js';
+import { asRest, hasFlag, parseFlag, safeJoin } from './_helpers.js';
 
 // ─────────────────────────────────────────────────────────────────────────
 // self-evolve

--- a/src/cli/commands/deferred.ts
+++ b/src/cli/commands/deferred.ts
@@ -13,8 +13,8 @@
  *   - timeline      (interaction timeline; src/lib/timeline has a
  *                    TypeScript port — top-level ES import. Multi-flag
  *                    query/render surface.)
- *   - validate-all  (proactive validator + suggestion engine; legacy CJS
- *                    in bin/lib/proactive-validator.js — legacyRequire.)
+ *   - validate-all  (proactive validator + suggestion engine; lib-ts
+ *                    ported in M11 batch 5.)
  *
  * **Pragmatic scope.** Per the batch brief, these are interactive or
  * render-heavy and the smoke tests are deliberately lighter than the
@@ -43,6 +43,7 @@ import * as path from 'node:path';
 import { defineCommand } from 'citty';
 import { generateContextPacket, renderContextMarkdown } from '../../lib/context-summarizer.js';
 import { writeResult } from '../../lib/io.js';
+import * as legacyProactiveValidator from '../../lib/proactive-validator.js';
 import {
   clearTimeline,
   generateTimelineReport,
@@ -277,45 +278,28 @@ export interface ValidateAllArgs {
   strict?: boolean | undefined;
 }
 
-interface ProactiveValidatorLib {
-  validateArtifactProactive: (
-    filePath: string,
-    options: { strict?: boolean | undefined }
-  ) => {
-    pass: boolean;
-    score: number;
-    diagnostics: { code: string; message: string; line?: number | undefined }[];
-  };
-  validateAllArtifacts: (
-    specsDir: string,
-    options: { root?: string | undefined; strict?: boolean | undefined }
-  ) => Promise<{
-    files: { pass: boolean; score: number; diagnostics: unknown[] }[];
-    cross_file: Record<string, unknown>;
-    summary: {
-      total_files: number;
-      total_diagnostics: number;
-      pass_count: number;
-      fail_count: number;
-      avg_score: number;
-    };
-  }>;
-  renderValidationReport: (result: unknown) => string;
-}
-
 export async function validateAllImpl(deps: Deps, args: ValidateAllArgs): Promise<CommandResult> {
-  const lib = legacyRequire<ProactiveValidatorLib>('proactive-validator');
-
+  // M11 strangler-tail cleanup: switched from `legacyRequire('proactive-
+  // validator')` to a static import of the TS port at
+  // `src/lib/proactive-validator.ts`. Existing wiring already invoked
+  // the actual exports — no latent bugs to fix here.
   if (args.file) {
     // Pit Crew M8 BLOCKER 2: gate user-supplied path through safeJoin.
     const safePath = safeJoin(deps, args.file);
-    const result = lib.validateArtifactProactive(safePath, { strict: args.strict });
+    const result = legacyProactiveValidator.validateArtifactProactive(safePath, {
+      strict: args.strict,
+    });
     if (args.json) {
       writeResult(result as unknown as Record<string, unknown>);
     } else {
-      const report = lib.renderValidationReport({
+      const report = legacyProactiveValidator.renderValidationReport({
         files: [result],
-        cross_file: {},
+        cross_file: {
+          drift: null,
+          broken_links: null,
+          coverage_gaps: null,
+          unmapped_nfrs: null,
+        },
         summary: {
           total_files: 1,
           total_diagnostics: result.diagnostics.length,
@@ -330,14 +314,14 @@ export async function validateAllImpl(deps: Deps, args: ValidateAllArgs): Promis
   }
 
   const specsDir = safeJoin(deps, 'specs');
-  const result = await lib.validateAllArtifacts(specsDir, {
+  const result = await legacyProactiveValidator.validateAllArtifacts(specsDir, {
     root: deps.projectRoot,
     strict: args.strict,
   });
   if (args.json) {
     writeResult(result as unknown as Record<string, unknown>);
   } else {
-    deps.logger.info(lib.renderValidationReport(result));
+    deps.logger.info(legacyProactiveValidator.renderValidationReport(result));
   }
   return { exitCode: 0 };
 }

--- a/src/cli/commands/enterprise.ts
+++ b/src/cli/commands/enterprise.ts
@@ -37,6 +37,7 @@ import { defineCommand } from 'citty';
 import * as legacyEnterpriseSearch from '../../lib/enterprise-search.js';
 import * as legacyEnterpriseTemplates from '../../lib/enterprise-templates.js';
 import * as legacyEnvironmentPromotion from '../../lib/environment-promotion.js';
+import * as legacyFitnessFunctions from '../../lib/fitness-functions.js';
 import * as legacyLegacyModernizer from '../../lib/legacy-modernizer.js';
 import * as legacyMigrationPlanner from '../../lib/migration-planner.js';
 import * as legacyMultiRepo from '../../lib/multi-repo.js';
@@ -242,7 +243,10 @@ export interface FitnessFunctionsArgs {
 }
 
 export function fitnessFunctionsImpl(deps: Deps, args: FitnessFunctionsArgs): CommandResult {
-  const lib = legacyRequire<LegacyLib>('fitness-functions');
+  // M11 strangler-tail cleanup: switched from `legacyRequire('fitness-
+  // functions')` to a static import of the TS port at
+  // `src/lib/fitness-functions.ts`. Existing wiring already invoked the
+  // actual exports — no latent bugs to fix here.
   const action = args.action ?? 'evaluate';
   const registryFile = safeJoin(deps, '.jumpstart', 'fitness-functions.json');
   let result: unknown;
@@ -251,7 +255,7 @@ export function fitnessFunctionsImpl(deps: Deps, args: FitnessFunctionsArgs): Co
       deps.logger.error('Usage: jumpstart-mode fitness-functions add <name> <category>');
       return { exitCode: 1 };
     }
-    result = lib.addFitnessFunction(
+    result = legacyFitnessFunctions.addFitnessFunction(
       {
         name: args.name,
         category: args.category,
@@ -262,9 +266,9 @@ export function fitnessFunctionsImpl(deps: Deps, args: FitnessFunctionsArgs): Co
       { registryFile }
     );
   } else if (action === 'list') {
-    result = lib.listFitnessFunctions({}, { registryFile });
+    result = legacyFitnessFunctions.listFitnessFunctions({}, { registryFile });
   } else {
-    result = lib.evaluateFitness(deps.projectRoot, { registryFile });
+    result = legacyFitnessFunctions.evaluateFitness(deps.projectRoot, { registryFile });
   }
   maybeJson(deps, args.json, result);
   if (!args.json) deps.logger.info(`Fitness functions: ${action}`);

--- a/src/cli/commands/enterprise.ts
+++ b/src/cli/commands/enterprise.ts
@@ -46,6 +46,7 @@ import * as legacyPatternLibrary from '../../lib/pattern-library.js';
 import * as legacyPersonaPacks from '../../lib/persona-packs.js';
 import * as legacyPlatformEngineering from '../../lib/platform-engineering.js';
 import * as legacyPrPackage from '../../lib/pr-package.js';
+import * as legacyReferenceArchitectures from '../../lib/reference-architectures.js';
 import * as legacyReleaseReadiness from '../../lib/release-readiness.js';
 import * as legacyTemplateMerge from '../../lib/template-merge.js';
 import { type CommandResult, createRealDeps, type Deps } from '../deps.js';
@@ -942,7 +943,10 @@ export interface ReferenceArchArgs {
 }
 
 export function referenceArchImpl(deps: Deps, args: ReferenceArchArgs): CommandResult {
-  const lib = legacyRequire<LegacyLib>('reference-architectures');
+  // M11 strangler-tail cleanup: switched from `legacyRequire('reference-
+  // architectures')` to a static import of the TS port at
+  // `src/lib/reference-architectures.ts`. Existing wiring already
+  // invoked the actual exports — no latent bugs to fix here.
   const action = args.action ?? 'list';
   let result: unknown;
   if (action === 'get') {
@@ -950,13 +954,13 @@ export function referenceArchImpl(deps: Deps, args: ReferenceArchArgs): CommandR
       deps.logger.error('Usage: jumpstart-mode reference-arch get <pattern-id>');
       return { exitCode: 1 };
     }
-    result = lib.getPattern(args.arg);
+    result = legacyReferenceArchitectures.getPattern(args.arg);
   } else if (action === 'register') {
     if (!args.arg) {
       deps.logger.error('Usage: jumpstart-mode reference-arch register <name>');
       return { exitCode: 1 };
     }
-    result = lib.registerPattern({
+    result = legacyReferenceArchitectures.registerPattern({
       name: args.arg,
       category: args.category ?? 'other',
       description: `Custom pattern: ${args.arg}`,
@@ -966,9 +970,9 @@ export function referenceArchImpl(deps: Deps, args: ReferenceArchArgs): CommandR
       deps.logger.error('Usage: jumpstart-mode reference-arch instantiate <pattern-id>');
       return { exitCode: 1 };
     }
-    result = lib.instantiatePattern(args.arg, deps.projectRoot);
+    result = legacyReferenceArchitectures.instantiatePattern(args.arg, deps.projectRoot);
   } else {
-    result = lib.listPatterns();
+    result = legacyReferenceArchitectures.listPatterns();
   }
   maybeJson(deps, args.json, result);
   if (!args.json) deps.logger.info(`Reference arch: ${action}`);

--- a/src/cli/commands/lifecycle.ts
+++ b/src/cli/commands/lifecycle.ts
@@ -12,7 +12,7 @@
  *   - memory             (legacy bin/lib/project-memory.js — but lib-ts port exists; uses legacyRequire to match cli.js)
  *   - rewind             (rewind.rewindToPhase, lib-ts)
  *   - next               (next-phase.determineNextAction, lib-ts)
- *   - plan-executor      (legacy bin/lib/plan-executor.js)
+ *   - plan-executor      (lib-ts: ported in M11 batch 5)
  *
  * **Skipped**: `status` is the marketplace-status branch in bin/cli.js
  * (lines ~1505-1528) — it's not a phase/framework status command. Kept
@@ -48,6 +48,7 @@ import {
 import { writeResult } from '../../lib/io.js';
 import { acquireLock, listLocks, lockStatus, releaseLock } from '../../lib/locks.js';
 import { determineNextAction } from '../../lib/next-phase.js';
+import * as legacyPlanExecutor from '../../lib/plan-executor.js';
 import { renderRewindReport, rewindToPhase } from '../../lib/rewind.js';
 import { createCheckpoint, listCheckpoints, restoreCheckpoint } from '../../lib/state-store.js';
 import { type CommandResult, createRealDeps, type Deps } from '../deps.js';
@@ -812,51 +813,24 @@ export interface PlanExecutorArgs {
   json?: boolean | undefined;
 }
 
-interface PlanExecutorLib {
-  initializeExecution: (
-    root: string,
-    opts: { stateFile: string }
-  ) => {
-    success: boolean;
-    total_jobs?: number | undefined;
-    milestones?: string[] | undefined;
-    error?: string | undefined;
-  };
-  updateJobStatus: (
-    jobId: string,
-    status: string,
-    opts: { stateFile: string }
-  ) => { success: boolean; previous_status?: string; new_status?: string; error?: string };
-  verifyJob: (
-    jobId: string,
-    root: string,
-    opts: { stateFile: string }
-  ) => { success: boolean; verified?: boolean; error?: string };
-  resetExecution: (opts: { stateFile: string }) => { jobs_reset: number };
-  getExecutionStatus: (opts: { stateFile: string }) => {
-    initialized: boolean;
-    progress?: number | undefined;
-    total_jobs?: number | undefined;
-    status_counts?: { completed: number; in_progress: number; pending: number };
-    next_tasks?: { id: string; title: string }[];
-  };
-}
-
 export function planExecutorImpl(deps: Deps, args: PlanExecutorArgs): CommandResult {
-  const execLib = legacyRequire<PlanExecutorLib>('plan-executor');
+  // M11 strangler-tail cleanup: switched from `legacyRequire('plan-
+  // executor')` to a static import of the TS port at
+  // `src/lib/plan-executor.ts`. Existing wiring already invoked the
+  // actual exports — no latent bugs to fix here.
   const stateFile = safeJoin(deps, '.jumpstart', 'state', 'plan-execution.json');
   const action = args.action ?? 'status';
 
   if (action === 'init') {
-    const result = execLib.initializeExecution(deps.projectRoot, { stateFile });
+    const result = legacyPlanExecutor.initializeExecution(deps.projectRoot, { stateFile });
     if (args.json) {
       writeResult(result as unknown as Record<string, unknown>);
     } else if (result.success) {
       deps.logger.success('Plan execution initialized');
       deps.logger.info(`  Jobs: ${result.total_jobs}`);
-      deps.logger.info(`  Milestones: ${(result.milestones ?? []).join(', ')}`);
+      deps.logger.info(`  Milestones: ${result.milestones.join(', ')}`);
     } else {
-      deps.logger.error(result.error ?? 'init failed');
+      deps.logger.error(result.error);
       return { exitCode: 1 };
     }
     return { exitCode: 0 };
@@ -866,13 +840,13 @@ export function planExecutorImpl(deps: Deps, args: PlanExecutorArgs): CommandRes
       deps.logger.error('Usage: jumpstart-mode plan-executor update <job-id> <status>');
       return { exitCode: 1 };
     }
-    const result = execLib.updateJobStatus(args.arg, args.status, { stateFile });
+    const result = legacyPlanExecutor.updateJobStatus(args.arg, args.status, { stateFile });
     if (args.json) {
       writeResult(result as unknown as Record<string, unknown>);
     } else if (result.success) {
       deps.logger.success(`${args.arg}: ${result.previous_status} → ${result.new_status}`);
     } else {
-      deps.logger.error(result.error ?? 'update failed');
+      deps.logger.error(result.error);
       return { exitCode: 1 };
     }
     return { exitCode: 0 };
@@ -882,7 +856,7 @@ export function planExecutorImpl(deps: Deps, args: PlanExecutorArgs): CommandRes
       deps.logger.error('Usage: jumpstart-mode plan-executor verify <job-id>');
       return { exitCode: 1 };
     }
-    const result = execLib.verifyJob(args.arg, deps.projectRoot, { stateFile });
+    const result = legacyPlanExecutor.verifyJob(args.arg, deps.projectRoot, { stateFile });
     if (args.json) {
       writeResult(result as unknown as Record<string, unknown>);
     } else if (result.success && result.verified) {
@@ -890,13 +864,13 @@ export function planExecutorImpl(deps: Deps, args: PlanExecutorArgs): CommandRes
     } else if (result.success) {
       deps.logger.warn(`${args.arg}: verification failed`);
     } else {
-      deps.logger.error(result.error ?? 'verify failed');
+      deps.logger.error(result.error);
       return { exitCode: 1 };
     }
     return { exitCode: 0 };
   }
   if (action === 'reset') {
-    const result = execLib.resetExecution({ stateFile });
+    const result = legacyPlanExecutor.resetExecution({ stateFile });
     if (args.json) {
       writeResult(result as unknown as Record<string, unknown>);
     } else {
@@ -905,15 +879,15 @@ export function planExecutorImpl(deps: Deps, args: PlanExecutorArgs): CommandRes
     return { exitCode: 0 };
   }
   // status (default)
-  const result = execLib.getExecutionStatus({ stateFile });
+  const result = legacyPlanExecutor.getExecutionStatus({ stateFile });
   if (args.json) {
     writeResult(result as unknown as Record<string, unknown>);
-  } else if (result.initialized && result.status_counts) {
+  } else if (result.initialized) {
     deps.logger.info(`Plan Execution: ${result.progress}%`);
     deps.logger.info(
-      `  Total: ${result.total_jobs}  Completed: ${result.status_counts.completed}  In Progress: ${result.status_counts.in_progress}  Pending: ${result.status_counts.pending}`
+      `  Total: ${result.total_jobs}  Completed: ${result.status_counts['completed'] ?? 0}  In Progress: ${result.status_counts['in_progress'] ?? 0}  Pending: ${result.status_counts['pending'] ?? 0}`
     );
-    if (result.next_tasks && result.next_tasks.length > 0) {
+    if (result.next_tasks.length > 0) {
       deps.logger.info('  Next tasks:');
       for (const t of result.next_tasks.slice(0, 5)) {
         deps.logger.info(`    → ${t.id}: ${t.title}`);

--- a/src/cli/commands/lifecycle.ts
+++ b/src/cli/commands/lifecycle.ts
@@ -885,7 +885,7 @@ export function planExecutorImpl(deps: Deps, args: PlanExecutorArgs): CommandRes
   } else if (result.initialized) {
     deps.logger.info(`Plan Execution: ${result.progress}%`);
     deps.logger.info(
-      `  Total: ${result.total_jobs}  Completed: ${result.status_counts['completed'] ?? 0}  In Progress: ${result.status_counts['in_progress'] ?? 0}  Pending: ${result.status_counts['pending'] ?? 0}`
+      `  Total: ${result.total_jobs}  Completed: ${result.status_counts.completed ?? 0}  In Progress: ${result.status_counts.in_progress ?? 0}  Pending: ${result.status_counts.pending ?? 0}`
     );
     if (result.next_tasks.length > 0) {
       deps.logger.info('  Next tasks:');

--- a/src/cli/commands/llm.ts
+++ b/src/cli/commands/llm.ts
@@ -8,7 +8,7 @@
  *   - prompt-governance  (lib-ts: registerAsset + approveVersion + listAssets)
  *   - usage              (lib-ts: summarizeUsage + generateUsageReport)
  *   - ai-intake          (lib-ts: createIntake + listIntakes)
- *   - finops-planner     (legacy bin/lib/finops-planner.js — no lib-ts port yet)
+ *   - finops-planner     (lib-ts: generateReport + getOptimizations)
  *
  * **Skipped**: `freshness-audit` already lives in spec-validation.ts batch 1.
  * No standalone `llm-providers` subcommand exists in `bin/cli.js`; the
@@ -18,8 +18,8 @@
  *
  * Pattern: each leaf command is a `defineCommand` exported as
  * `<name>Command`. Pure logic lives in `<name>Impl(deps, args)`. All
- * lib-ts imports are TOP-LEVEL ES imports; only `finops-planner`
- * (no lib-ts port) goes through `legacyRequire`.
+ * lib-ts imports are TOP-LEVEL ES imports — finops-planner ported to TS
+ * in M11 batch 5, no remaining `legacyRequire` calls in this cluster.
  *
  * @see bin/cli.js (lines 1734-1746, 3643-3666, 3669-3691, 3694-3715,
  *       4096-4115, 4118-4135, 4997-5025 — legacy reference)
@@ -29,6 +29,10 @@
 import { defineCommand } from 'citty';
 import { createIntake, listIntakes } from '../../lib/ai-intake.js';
 import { generateReport as costGenerateReport, routeByCost } from '../../lib/cost-router.js';
+import {
+  generateReport as finopsGenerateReport,
+  getOptimizations as finopsGetOptimizations,
+} from '../../lib/finops-planner.js';
 import { writeResult } from '../../lib/io.js';
 import {
   generateReport as governanceGenerateReport,
@@ -38,7 +42,7 @@ import { generateReport as routerGenerateReport, routeTask } from '../../lib/mod
 import { approveVersion, listAssets, registerAsset } from '../../lib/prompt-governance.js';
 import { generateUsageReport, summarizeUsage } from '../../lib/usage.js';
 import { type CommandResult, createRealDeps, type Deps } from '../deps.js';
-import { legacyRequire, safeJoin } from './_helpers.js';
+import { safeJoin } from './_helpers.js';
 
 // ─────────────────────────────────────────────────────────────────────────
 // cost-router
@@ -438,25 +442,17 @@ export interface FinopsPlannerArgs {
   json?: boolean | undefined;
 }
 
-interface FinopsPlannerLib {
-  generateReport: (opts: { stateFile: string }) => {
-    total_monthly: number;
-    total_annual: number;
-    total_estimates: number;
-  };
-  getOptimizations: (opts: { stateFile: string }) => {
-    total: number;
-    recommendations: { recommendation: string; potential_savings: string }[];
-  };
-}
-
 export function finopsPlannerImpl(deps: Deps, args: FinopsPlannerArgs): CommandResult {
-  const lib = legacyRequire<FinopsPlannerLib>('finops-planner');
+  // M11 strangler-tail cleanup: switched from `legacyRequire('finops-
+  // planner')` to a static import of the TS port at
+  // `src/lib/finops-planner.ts`. Existing wiring already invoked the
+  // actual exports (`generateReport`, `getOptimizations`) — no latent
+  // bugs to fix here.
   const stateFile = safeJoin(deps, '.jumpstart', 'state', 'finops.json');
   const action = args.action ?? 'report';
 
   if (action === 'optimize') {
-    const result = lib.getOptimizations({ stateFile });
+    const result = finopsGetOptimizations({ stateFile });
     if (args.json) {
       writeResult(result as unknown as Record<string, unknown>);
     } else {
@@ -469,7 +465,7 @@ export function finopsPlannerImpl(deps: Deps, args: FinopsPlannerArgs): CommandR
   }
 
   // report (default)
-  const result = lib.generateReport({ stateFile });
+  const result = finopsGenerateReport({ stateFile });
   if (args.json) {
     writeResult(result as unknown as Record<string, unknown>);
   } else {

--- a/src/lib/finops-planner.ts
+++ b/src/lib/finops-planner.ts
@@ -1,0 +1,375 @@
+/**
+ * finops-planner.ts — FinOps-Aware Architecture Planning port (M11 batch 5).
+ *
+ * Pure-library port of `bin/lib/finops-planner.js` (CJS) to a typed ES
+ * module. Public surface preserved verbatim by name + signature:
+ *
+ *   - `defaultState()` => State
+ *   - `loadState(stateFile?)` => State
+ *   - `saveState(state, stateFile?)` => void  (sets last_updated)
+ *   - `createEstimate(estimate, options?)` => CreateEstimateResult
+ *   - `getOptimizations(options?)` => OptimizationsResult
+ *   - `generateReport(options?)` => ReportResult
+ *   - `COST_CATEGORIES` (frozen list)
+ *   - `CLOUD_PRICING_ESTIMATES` (per-category low/medium/high rates)
+ *
+ * Behavior parity:
+ *   - Default state file: `.jumpstart/state/finops.json`.
+ *   - Estimate IDs: `FIN-${Date.now().toString(36).toUpperCase()}`.
+ *   - Storage + monitoring categories use rate * quantity (no hour
+ *     multiplier); compute/network/database/ai-ml multiply by hours.
+ *   - All currency results are rounded to 2 decimals via
+ *     `Math.round(v * 100) / 100`.
+ *   - Optimization heuristics: compute > $500 → reserved/spot;
+ *     storage > $100 → tiering; ai-ml > $200 → smaller models.
+ *
+ * M3 hardening: every JSON parse path runs through a recursive shape
+ * check that rejects __proto__/constructor/prototype keys; falls back
+ * to `defaultState()` on parse failure or pollution detection.
+ *
+ * Path-safety: this module accepts a caller-supplied `stateFile` path
+ * which the CLI cluster constructs via `safeJoin(deps, ...)` — already
+ * gated through `assertInsideRoot` upstream. The library itself does
+ * not walk the filesystem; it only reads/writes the supplied path. We
+ * defensively gate `saveState`'s mkdir and writeFile by re-validating
+ * the supplied stateFile against process.cwd() if it's relative —
+ * matching the legacy `path.dirname(filePath)` semantics.
+ *
+ * @see bin/lib/finops-planner.js (legacy reference)
+ * @see specs/implementation-plan.md M11 strangler cleanup
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+const DEFAULT_STATE_FILE = join('.jumpstart', 'state', 'finops.json');
+
+export const COST_CATEGORIES = [
+  'compute',
+  'storage',
+  'network',
+  'database',
+  'ai-ml',
+  'monitoring',
+  'third-party',
+  'licensing',
+] as const;
+
+export type CostCategory = (typeof COST_CATEGORIES)[number];
+
+export interface PricingTier {
+  unit: string;
+  low: number;
+  medium: number;
+  high: number;
+}
+
+export const CLOUD_PRICING_ESTIMATES: Record<string, PricingTier> = {
+  compute: { unit: 'vCPU-hour', low: 0.02, medium: 0.05, high: 0.1 },
+  storage: { unit: 'GB-month', low: 0.01, medium: 0.023, high: 0.1 },
+  network: { unit: 'GB-transfer', low: 0.01, medium: 0.08, high: 0.12 },
+  database: { unit: 'instance-hour', low: 0.02, medium: 0.1, high: 0.5 },
+  'ai-ml': { unit: '1K-tokens', low: 0.001, medium: 0.01, high: 0.06 },
+  monitoring: { unit: 'GB-logs-month', low: 0.25, medium: 0.5, high: 1.0 },
+};
+
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function hasForbiddenKey(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    for (const item of value) if (hasForbiddenKey(item)) return true;
+    return false;
+  }
+  if (!isPlainObject(value)) return false;
+  for (const key of Object.keys(value)) {
+    if (FORBIDDEN_KEYS.has(key)) return true;
+    if (hasForbiddenKey(value[key])) return true;
+  }
+  return false;
+}
+
+export interface BreakdownEntry {
+  name: string;
+  category: string;
+  quantity: number;
+  monthly_cost: number;
+}
+
+export interface Estimate {
+  id: string;
+  name: string;
+  breakdown: BreakdownEntry[];
+  monthly_total: number;
+  annual_total: number;
+  created_at: string;
+}
+
+export interface Budget {
+  // Legacy code never wrote any specific shape into budgets[]; we treat
+  // it as opaque. The state object accepts whatever the caller stores.
+  [key: string]: unknown;
+}
+
+export interface OptimizationItem {
+  estimate: string;
+  component: string;
+  recommendation: string;
+  potential_savings: string;
+}
+
+export interface State {
+  version: string;
+  created_at: string;
+  last_updated: string | null;
+  estimates: Estimate[];
+  budgets: Budget[];
+  optimizations: OptimizationItem[];
+}
+
+export interface ComponentInput {
+  name?: string;
+  category?: string;
+  tier?: 'low' | 'medium' | 'high';
+  quantity?: number;
+  hours_per_month?: number;
+  monthly_cost?: number;
+}
+
+export interface EstimateInput {
+  name?: string;
+  components?: ComponentInput[];
+}
+
+export interface CommonOptions {
+  stateFile?: string | undefined;
+}
+
+export type CreateEstimateResult =
+  | { success: true; estimate: Estimate }
+  | { success: false; error: string };
+
+export interface OptimizationsResult {
+  success: true;
+  recommendations: OptimizationItem[];
+  total: number;
+}
+
+export interface ReportResult {
+  success: true;
+  total_estimates: number;
+  total_monthly: number;
+  total_annual: number;
+  by_category: Record<string, number>;
+  estimates: Estimate[];
+}
+
+/**
+ * Default FinOps state shape (legacy parity).
+ */
+export function defaultState(): State {
+  return {
+    version: '1.0.0',
+    created_at: new Date().toISOString(),
+    last_updated: null,
+    estimates: [],
+    budgets: [],
+    optimizations: [],
+  };
+}
+
+/**
+ * Load FinOps state from disk.
+ *
+ * Returns `defaultState()` on file missing / parse failure / shape
+ * mismatch / M3 pollution-key detection.
+ */
+export function loadState(stateFile?: string): State {
+  const filePath = stateFile ?? DEFAULT_STATE_FILE;
+  if (!existsSync(filePath)) return defaultState();
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, 'utf8');
+  } catch {
+    return defaultState();
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return defaultState();
+  }
+  if (!isPlainObject(parsed)) return defaultState();
+  if (hasForbiddenKey(parsed)) return defaultState();
+  const base = defaultState();
+  return {
+    version: typeof parsed['version'] === 'string' ? (parsed['version'] as string) : base.version,
+    created_at:
+      typeof parsed['created_at'] === 'string'
+        ? (parsed['created_at'] as string)
+        : base.created_at,
+    last_updated:
+      typeof parsed['last_updated'] === 'string' ? (parsed['last_updated'] as string) : null,
+    estimates: Array.isArray(parsed['estimates']) ? (parsed['estimates'] as Estimate[]) : [],
+    budgets: Array.isArray(parsed['budgets']) ? (parsed['budgets'] as Budget[]) : [],
+    optimizations: Array.isArray(parsed['optimizations'])
+      ? (parsed['optimizations'] as OptimizationItem[])
+      : [],
+  };
+}
+
+/**
+ * Save FinOps state to disk. Sets `last_updated` and creates the parent
+ * dir if missing.
+ */
+export function saveState(state: State, stateFile?: string): void {
+  const filePath = stateFile ?? DEFAULT_STATE_FILE;
+  const dir = dirname(filePath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  state.last_updated = new Date().toISOString();
+  writeFileSync(filePath, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/**
+ * Create a cost estimate for a service / component breakdown. Persists
+ * the new estimate into the FinOps state file.
+ */
+export function createEstimate(
+  estimate: EstimateInput | null | undefined,
+  options: CommonOptions = {}
+): CreateEstimateResult {
+  if (!estimate || !estimate.name) {
+    return { success: false, error: 'estimate.name is required' };
+  }
+
+  const components = estimate.components ?? [];
+  let totalMonthly = 0;
+  const breakdown: BreakdownEntry[] = [];
+
+  for (const comp of components) {
+    const category = comp.category ?? 'compute';
+    const pricing = CLOUD_PRICING_ESTIMATES[category];
+    const tier = comp.tier ?? 'medium';
+    const quantity = comp.quantity ?? 1;
+    const hours = comp.hours_per_month ?? 730; // ~24 * 30
+
+    let monthlyCost: number;
+    if (pricing) {
+      const tierKey = (['low', 'medium', 'high'] as const).includes(
+        tier as 'low' | 'medium' | 'high'
+      )
+        ? (tier as 'low' | 'medium' | 'high')
+        : 'medium';
+      const rate = pricing[tierKey];
+      monthlyCost =
+        rate * quantity * (category === 'storage' || category === 'monitoring' ? 1 : hours);
+    } else {
+      monthlyCost = comp.monthly_cost ?? 0;
+    }
+
+    breakdown.push({
+      name: comp.name ?? category,
+      category,
+      quantity,
+      monthly_cost: round2(monthlyCost),
+    });
+    totalMonthly += monthlyCost;
+  }
+
+  const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
+  const state = loadState(stateFile);
+
+  const est: Estimate = {
+    id: `FIN-${Date.now().toString(36).toUpperCase()}`,
+    name: estimate.name,
+    breakdown,
+    monthly_total: round2(totalMonthly),
+    annual_total: round2(totalMonthly * 12),
+    created_at: new Date().toISOString(),
+  };
+
+  state.estimates.push(est);
+  saveState(state, stateFile);
+
+  return { success: true, estimate: est };
+}
+
+/**
+ * Compute optimization recommendations based on current estimates.
+ *
+ * Heuristics (legacy parity):
+ *   - compute > $500/mo → reserved or spot instances (30-60% savings)
+ *   - storage > $100/mo → storage tiering (20-40%)
+ *   - ai-ml > $200/mo → smaller models, batched requests (40-70%)
+ */
+export function getOptimizations(options: CommonOptions = {}): OptimizationsResult {
+  const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
+  const state = loadState(stateFile);
+
+  const recommendations: OptimizationItem[] = [];
+
+  for (const est of state.estimates) {
+    for (const comp of est.breakdown) {
+      if (comp.category === 'compute' && comp.monthly_cost > 500) {
+        recommendations.push({
+          estimate: est.name,
+          component: comp.name,
+          recommendation: 'Consider reserved instances or spot instances',
+          potential_savings: '30-60%',
+        });
+      }
+      if (comp.category === 'storage' && comp.monthly_cost > 100) {
+        recommendations.push({
+          estimate: est.name,
+          component: comp.name,
+          recommendation: 'Implement storage tiering (hot/warm/cold)',
+          potential_savings: '20-40%',
+        });
+      }
+      if (comp.category === 'ai-ml' && comp.monthly_cost > 200) {
+        recommendations.push({
+          estimate: est.name,
+          component: comp.name,
+          recommendation: 'Use smaller models for simple tasks, batch requests',
+          potential_savings: '40-70%',
+        });
+      }
+    }
+  }
+
+  return { success: true, recommendations, total: recommendations.length };
+}
+
+/**
+ * Generate a FinOps roll-up report: total monthly + annual cost,
+ * cost-by-category histogram, and the full estimate list.
+ */
+export function generateReport(options: CommonOptions = {}): ReportResult {
+  const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
+  const state = loadState(stateFile);
+
+  const totalMonthly = state.estimates.reduce((sum, e) => sum + e.monthly_total, 0);
+  const byCategory: Record<string, number> = {};
+
+  for (const est of state.estimates) {
+    for (const comp of est.breakdown) {
+      byCategory[comp.category] = (byCategory[comp.category] ?? 0) + comp.monthly_cost;
+    }
+  }
+
+  return {
+    success: true,
+    total_estimates: state.estimates.length,
+    total_monthly: round2(totalMonthly),
+    total_annual: round2(totalMonthly * 12),
+    by_category: byCategory,
+    estimates: state.estimates,
+  };
+}

--- a/src/lib/finops-planner.ts
+++ b/src/lib/finops-planner.ts
@@ -206,17 +206,14 @@ export function loadState(stateFile?: string): State {
   if (hasForbiddenKey(parsed)) return defaultState();
   const base = defaultState();
   return {
-    version: typeof parsed['version'] === 'string' ? (parsed['version'] as string) : base.version,
+    version: typeof parsed.version === 'string' ? (parsed.version as string) : base.version,
     created_at:
-      typeof parsed['created_at'] === 'string'
-        ? (parsed['created_at'] as string)
-        : base.created_at,
-    last_updated:
-      typeof parsed['last_updated'] === 'string' ? (parsed['last_updated'] as string) : null,
-    estimates: Array.isArray(parsed['estimates']) ? (parsed['estimates'] as Estimate[]) : [],
-    budgets: Array.isArray(parsed['budgets']) ? (parsed['budgets'] as Budget[]) : [],
-    optimizations: Array.isArray(parsed['optimizations'])
-      ? (parsed['optimizations'] as OptimizationItem[])
+      typeof parsed.created_at === 'string' ? (parsed.created_at as string) : base.created_at,
+    last_updated: typeof parsed.last_updated === 'string' ? (parsed.last_updated as string) : null,
+    estimates: Array.isArray(parsed.estimates) ? (parsed.estimates as Estimate[]) : [],
+    budgets: Array.isArray(parsed.budgets) ? (parsed.budgets as Budget[]) : [],
+    optimizations: Array.isArray(parsed.optimizations)
+      ? (parsed.optimizations as OptimizationItem[])
       : [],
   };
 }
@@ -245,7 +242,7 @@ export function createEstimate(
   estimate: EstimateInput | null | undefined,
   options: CommonOptions = {}
 ): CreateEstimateResult {
-  if (!estimate || !estimate.name) {
+  if (!estimate?.name) {
     return { success: false, error: 'estimate.name is required' };
   }
 

--- a/src/lib/fitness-functions.ts
+++ b/src/lib/fitness-functions.ts
@@ -38,7 +38,7 @@
  * @see specs/implementation-plan.md M11 strangler cleanup
  */
 
-import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, relative } from 'node:path';
 import { assertInsideRoot } from './path-safety.js';
 
@@ -219,20 +219,14 @@ export function loadRegistry(registryFile?: string): Registry {
   // partial shapes.
   const base = defaultRegistry();
   const out: Registry = {
-    version: typeof parsed['version'] === 'string' ? (parsed['version'] as string) : base.version,
+    version: typeof parsed.version === 'string' ? (parsed.version as string) : base.version,
     created_at:
-      typeof parsed['created_at'] === 'string'
-        ? (parsed['created_at'] as string)
-        : base.created_at,
+      typeof parsed.created_at === 'string' ? (parsed.created_at as string) : base.created_at,
     last_evaluated:
-      typeof parsed['last_evaluated'] === 'string'
-        ? (parsed['last_evaluated'] as string)
-        : null,
-    functions: Array.isArray(parsed['functions'])
-      ? (parsed['functions'] as FitnessFunction[])
-      : [],
-    evaluation_history: Array.isArray(parsed['evaluation_history'])
-      ? (parsed['evaluation_history'] as EvaluationSummary[])
+      typeof parsed.last_evaluated === 'string' ? (parsed.last_evaluated as string) : null,
+    functions: Array.isArray(parsed.functions) ? (parsed.functions as FitnessFunction[]) : [],
+    evaluation_history: Array.isArray(parsed.evaluation_history)
+      ? (parsed.evaluation_history as EvaluationSummary[])
       : [],
   };
   return out;
@@ -258,7 +252,7 @@ export function addFitnessFunction(
   func: AddFitnessFunctionInput | null | undefined,
   options: AddOptions = {}
 ): AddResult {
-  if (!func || !func.name || !func.description) {
+  if (!func?.name || !func.description) {
     return { success: false, error: 'name and description are required' };
   }
 
@@ -315,13 +309,12 @@ export const BUILTIN_CHECKS = {
     const funcPattern = /function\s+\w+\s*\(([^)]*)\)/g;
     const arrowPattern = /\(([^)]*)\)\s*(?:=>|{)/g;
     let maxParams = 0;
-    let m: RegExpExecArray | null;
-    while ((m = funcPattern.exec(content)) !== null) {
+    for (const m of content.matchAll(funcPattern)) {
       const captured = m[1] ?? '';
       const params = captured.split(',').filter((p) => p.trim().length > 0).length;
       if (params > maxParams) maxParams = params;
     }
-    while ((m = arrowPattern.exec(content)) !== null) {
+    for (const m of content.matchAll(arrowPattern)) {
       const captured = m[1] ?? '';
       const params = captured.split(',').filter((p) => p.trim().length > 0).length;
       if (params > maxParams) maxParams = params;
@@ -387,11 +380,7 @@ export function evaluateFitness(root: string, options: EvaluateOptions = {}): Ev
               } else if (func.check_type === 'max_function_params') {
                 checkResult = BUILTIN_CHECKS.max_function_params(content, func.threshold);
               } else if (func.check_type === 'pattern' && func.pattern) {
-                checkResult = BUILTIN_CHECKS.pattern_match(
-                  content,
-                  func.threshold,
-                  func.pattern
-                );
+                checkResult = BUILTIN_CHECKS.pattern_match(content, func.threshold, func.pattern);
               } else {
                 checkResult = { passed: true, value: 0 };
               }

--- a/src/lib/fitness-functions.ts
+++ b/src/lib/fitness-functions.ts
@@ -1,0 +1,470 @@
+/**
+ * fitness-functions.ts — Architectural Fitness Functions port (M11 batch 5).
+ *
+ * Pure-library port of `bin/lib/fitness-functions.js` (CJS) to a typed ES
+ * module. Public surface preserved verbatim by name + signature:
+ *
+ *   - `defaultRegistry()` => Registry
+ *   - `loadRegistry(registryFile?)` => Registry
+ *   - `saveRegistry(registry, registryFile?)` => void
+ *   - `addFitnessFunction(func, options?)` => AddResult
+ *   - `evaluateFitness(root, options?)` => EvaluateResult
+ *   - `listFitnessFunctions(filter?, options?)` => ListResult
+ *   - `BUILTIN_CHECKS` (max_file_length / no_circular_imports /
+ *     max_function_params / pattern_match)
+ *   - `FITNESS_CATEGORIES` (frozen list)
+ *
+ * Behavior parity:
+ *   - Default registry file: `.jumpstart/fitness-functions.json`.
+ *   - Registry IDs default to `ff-<Date.now()>-<5-char base36>`.
+ *   - evaluateFitness walks `target_dirs` (default `['src']`) and reads
+ *     files matching `.(js|ts|jsx|tsx|py|go|java|rb|rs)$` — skipping
+ *     dotfiles and `node_modules`.
+ *   - evaluation_history is capped at 50 entries (FIFO via slice(-50)).
+ *
+ * M3 hardening:
+ *   - Every JSON parse path runs through a recursive shape check that
+ *     rejects keys equal to `__proto__`, `constructor`, or `prototype`
+ *     before merge/persist. On parse failure or pollution detection, we
+ *     return `defaultRegistry()` so callers see a clean state rather
+ *     than throwing.
+ *
+ * Path-safety per ADR-009:
+ *   - `evaluateFitness(root, opts)` gates `root` through `assertInsideRoot`
+ *     before any `fs.*` walk. The directory walker resolves only
+ *     `path.join(root, dir)` shapes (no caller-supplied absolute paths).
+ *
+ * @see bin/lib/fitness-functions.js (legacy reference)
+ * @see specs/implementation-plan.md M11 strangler cleanup
+ */
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { assertInsideRoot } from './path-safety.js';
+
+const DEFAULT_FITNESS_FILE = join('.jumpstart', 'fitness-functions.json');
+
+export const FITNESS_CATEGORIES = [
+  'dependency',
+  'structure',
+  'complexity',
+  'naming',
+  'security',
+  'performance',
+  'testing',
+] as const;
+
+export type FitnessCategory = (typeof FITNESS_CATEGORIES)[number];
+
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function hasForbiddenKey(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    for (const item of value) if (hasForbiddenKey(item)) return true;
+    return false;
+  }
+  if (!isPlainObject(value)) return false;
+  for (const key of Object.keys(value)) {
+    if (FORBIDDEN_KEYS.has(key)) return true;
+    if (hasForbiddenKey(value[key])) return true;
+  }
+  return false;
+}
+
+export interface FitnessFunction {
+  id: string;
+  name: string;
+  category: string;
+  description: string;
+  check_type: string;
+  pattern: string | null;
+  threshold: number | null;
+  target_dirs: string[];
+  enabled: boolean;
+  created_at: string;
+}
+
+export interface EvaluationSummary {
+  evaluated_at: string;
+  total_functions: number;
+  passed: number;
+  failed: number;
+  all_passed: boolean;
+}
+
+export interface Registry {
+  version: string;
+  created_at: string;
+  last_evaluated: string | null;
+  functions: FitnessFunction[];
+  evaluation_history: EvaluationSummary[];
+}
+
+export interface AddFitnessFunctionInput {
+  id?: string;
+  name?: string;
+  category?: string;
+  description?: string;
+  check_type?: string;
+  pattern?: string | null;
+  threshold?: number | null;
+  target_dirs?: string[];
+  enabled?: boolean;
+}
+
+export interface AddOptions {
+  registryFile?: string | undefined;
+}
+
+export type AddResult =
+  | { success: true; function: FitnessFunction; total: number }
+  | { success: false; error: string };
+
+export interface BuiltinCheckResult {
+  passed: boolean;
+  value: number;
+  threshold?: number | undefined;
+  pattern?: string | undefined;
+  note?: string | undefined;
+  error?: string | undefined;
+}
+
+export interface EvaluateOptions {
+  registryFile?: string | undefined;
+}
+
+export interface ViolationDetail extends BuiltinCheckResult {
+  file: string;
+}
+
+export interface FunctionResult {
+  id: string;
+  name: string;
+  category: string;
+  passed: boolean;
+  violations: number;
+  details: ViolationDetail[];
+}
+
+export interface EvaluateResult {
+  success: true;
+  all_passed: boolean;
+  results: FunctionResult[];
+  summary: EvaluationSummary;
+}
+
+export interface ListFilter {
+  category?: string | undefined;
+  enabled?: boolean | undefined;
+}
+
+export interface ListOptions {
+  registryFile?: string | undefined;
+}
+
+export interface ListResult {
+  success: true;
+  functions: FitnessFunction[];
+  total: number;
+  last_evaluated: string | null;
+}
+
+/**
+ * Default fitness function registry shape (legacy parity).
+ */
+export function defaultRegistry(): Registry {
+  return {
+    version: '1.0.0',
+    created_at: new Date().toISOString(),
+    last_evaluated: null,
+    functions: [],
+    evaluation_history: [],
+  };
+}
+
+/**
+ * Load fitness function registry from disk.
+ *
+ * Returns `defaultRegistry()` on any of:
+ *   - file missing
+ *   - JSON parse failure
+ *   - shape mismatch (top-level not a plain object)
+ *   - M3 pollution-key detection
+ */
+export function loadRegistry(registryFile?: string): Registry {
+  const filePath = registryFile ?? DEFAULT_FITNESS_FILE;
+  if (!existsSync(filePath)) {
+    return defaultRegistry();
+  }
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, 'utf8');
+  } catch {
+    return defaultRegistry();
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return defaultRegistry();
+  }
+  if (!isPlainObject(parsed)) return defaultRegistry();
+  if (hasForbiddenKey(parsed)) return defaultRegistry();
+  // The legacy module returned the parsed JSON verbatim; we coerce-fill
+  // missing fields so downstream callers don't have to defend against
+  // partial shapes.
+  const base = defaultRegistry();
+  const out: Registry = {
+    version: typeof parsed['version'] === 'string' ? (parsed['version'] as string) : base.version,
+    created_at:
+      typeof parsed['created_at'] === 'string'
+        ? (parsed['created_at'] as string)
+        : base.created_at,
+    last_evaluated:
+      typeof parsed['last_evaluated'] === 'string'
+        ? (parsed['last_evaluated'] as string)
+        : null,
+    functions: Array.isArray(parsed['functions'])
+      ? (parsed['functions'] as FitnessFunction[])
+      : [],
+    evaluation_history: Array.isArray(parsed['evaluation_history'])
+      ? (parsed['evaluation_history'] as EvaluationSummary[])
+      : [],
+  };
+  return out;
+}
+
+/**
+ * Save fitness function registry to disk. Creates parent dir if missing.
+ */
+export function saveRegistry(registry: Registry, registryFile?: string): void {
+  const filePath = registryFile ?? DEFAULT_FITNESS_FILE;
+  const dir = dirname(filePath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  writeFileSync(filePath, `${JSON.stringify(registry, null, 2)}\n`, 'utf8');
+}
+
+/**
+ * Add a fitness function to the registry. Returns `{success: false}` on
+ * validation/duplicate-id failure (legacy parity — does not throw).
+ */
+export function addFitnessFunction(
+  func: AddFitnessFunctionInput | null | undefined,
+  options: AddOptions = {}
+): AddResult {
+  if (!func || !func.name || !func.description) {
+    return { success: false, error: 'name and description are required' };
+  }
+
+  const category = (func.category ?? 'structure').toLowerCase();
+  if (!(FITNESS_CATEGORIES as readonly string[]).includes(category)) {
+    return {
+      success: false,
+      error: `category must be one of: ${FITNESS_CATEGORIES.join(', ')}`,
+    };
+  }
+
+  const registryFile = options.registryFile ?? DEFAULT_FITNESS_FILE;
+  const registry = loadRegistry(registryFile);
+
+  const id = func.id ?? `ff-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+  if (registry.functions.find((f) => f.id === id)) {
+    return { success: false, error: `Fitness function "${id}" already exists` };
+  }
+
+  const newFunc: FitnessFunction = {
+    id,
+    name: func.name.trim(),
+    category,
+    description: func.description.trim(),
+    check_type: func.check_type ?? 'pattern',
+    pattern: func.pattern ?? null,
+    threshold: func.threshold ?? null,
+    target_dirs: func.target_dirs ?? ['src'],
+    enabled: func.enabled !== false,
+    created_at: new Date().toISOString(),
+  };
+
+  registry.functions.push(newFunc);
+  saveRegistry(registry, registryFile);
+
+  return { success: true, function: newFunc, total: registry.functions.length };
+}
+
+/**
+ * Built-in fitness checks. Exported as a frozen-shape object — callers
+ * may probe `BUILTIN_CHECKS.max_file_length` etc. directly.
+ */
+export const BUILTIN_CHECKS = {
+  max_file_length: (content: string, threshold?: number | null): BuiltinCheckResult => {
+    const lineCount = content.split('\n').length;
+    const t = threshold ?? 500;
+    return { passed: lineCount <= t, value: lineCount, threshold: t };
+  },
+  no_circular_imports: (content: string): BuiltinCheckResult => {
+    const imports = content.match(/(?:require|import)\s*\(?['"]([^'"]+)['"]\)?/g) ?? [];
+    return { passed: true, value: imports.length, note: 'static check only' };
+  },
+  max_function_params: (content: string, threshold?: number | null): BuiltinCheckResult => {
+    const funcPattern = /function\s+\w+\s*\(([^)]*)\)/g;
+    const arrowPattern = /\(([^)]*)\)\s*(?:=>|{)/g;
+    let maxParams = 0;
+    let m: RegExpExecArray | null;
+    while ((m = funcPattern.exec(content)) !== null) {
+      const captured = m[1] ?? '';
+      const params = captured.split(',').filter((p) => p.trim().length > 0).length;
+      if (params > maxParams) maxParams = params;
+    }
+    while ((m = arrowPattern.exec(content)) !== null) {
+      const captured = m[1] ?? '';
+      const params = captured.split(',').filter((p) => p.trim().length > 0).length;
+      if (params > maxParams) maxParams = params;
+    }
+    const t = threshold ?? 5;
+    return { passed: maxParams <= t, value: maxParams, threshold: t };
+  },
+  pattern_match: (
+    content: string,
+    _threshold: number | null | undefined,
+    pattern: string | null | undefined
+  ): BuiltinCheckResult => {
+    if (!pattern) return { passed: true, value: 0 };
+    try {
+      const regex = new RegExp(pattern, 'gi');
+      const matches = content.match(regex) ?? [];
+      return { passed: matches.length === 0, value: matches.length, pattern };
+    } catch {
+      return { passed: true, value: 0, error: 'invalid regex' };
+    }
+  },
+} as const;
+
+/**
+ * Evaluate all enabled fitness functions against the project tree.
+ *
+ * Path-safety: `root` gated through `assertInsideRoot` before any walk.
+ * The recursive walker only joins `path.join(root, dir)` — caller never
+ * supplies an absolute traversal target.
+ */
+export function evaluateFitness(root: string, options: EvaluateOptions = {}): EvaluateResult {
+  // Path-safety gate before any fs.* call.
+  assertInsideRoot(root, root, { schemaId: 'fitness-functions:evaluateFitness:root' });
+
+  const registryFile = options.registryFile ?? join(root, DEFAULT_FITNESS_FILE);
+  const registry = loadRegistry(registryFile);
+
+  const enabledFuncs = registry.functions.filter((f) => f.enabled !== false);
+  const results: FunctionResult[] = [];
+
+  for (const func of enabledFuncs) {
+    const violations: ViolationDetail[] = [];
+    const targetDirs = func.target_dirs ?? ['src'];
+
+    for (const dir of targetDirs) {
+      const absDir = join(root, dir);
+      if (!existsSync(absDir)) continue;
+
+      const walk = (d: string): void => {
+        for (const entry of readdirSync(d, { withFileTypes: true })) {
+          if (entry.name.startsWith('.') || entry.name === 'node_modules') continue;
+          const full = join(d, entry.name);
+          if (entry.isDirectory()) {
+            walk(full);
+          } else if (entry.isFile() && /\.(js|ts|jsx|tsx|py|go|java|rb|rs)$/.test(entry.name)) {
+            try {
+              const content = readFileSync(full, 'utf8');
+              const rel = relative(root, full).replace(/\\/g, '/');
+              let checkResult: BuiltinCheckResult;
+
+              if (func.check_type === 'max_file_length') {
+                checkResult = BUILTIN_CHECKS.max_file_length(content, func.threshold);
+              } else if (func.check_type === 'max_function_params') {
+                checkResult = BUILTIN_CHECKS.max_function_params(content, func.threshold);
+              } else if (func.check_type === 'pattern' && func.pattern) {
+                checkResult = BUILTIN_CHECKS.pattern_match(
+                  content,
+                  func.threshold,
+                  func.pattern
+                );
+              } else {
+                checkResult = { passed: true, value: 0 };
+              }
+
+              if (!checkResult.passed) {
+                violations.push({ file: rel, ...checkResult });
+              }
+            } catch {
+              // skip unreadable files (legacy parity)
+            }
+          }
+        }
+      };
+      walk(absDir);
+    }
+
+    results.push({
+      id: func.id,
+      name: func.name,
+      category: func.category,
+      passed: violations.length === 0,
+      violations: violations.length,
+      details: violations.slice(0, 10),
+    });
+  }
+
+  const allPassed = results.every((r) => r.passed);
+  const evaluation: EvaluationSummary = {
+    evaluated_at: new Date().toISOString(),
+    total_functions: results.length,
+    passed: results.filter((r) => r.passed).length,
+    failed: results.filter((r) => !r.passed).length,
+    all_passed: allPassed,
+  };
+
+  registry.last_evaluated = evaluation.evaluated_at;
+  registry.evaluation_history.push(evaluation);
+  if (registry.evaluation_history.length > 50) {
+    registry.evaluation_history = registry.evaluation_history.slice(-50);
+  }
+  saveRegistry(registry, registryFile);
+
+  return {
+    success: true,
+    all_passed: allPassed,
+    results,
+    summary: evaluation,
+  };
+}
+
+/**
+ * List registered fitness functions, optionally filtered by category /
+ * enabled flag.
+ */
+export function listFitnessFunctions(
+  filter: ListFilter = {},
+  options: ListOptions = {}
+): ListResult {
+  const registryFile = options.registryFile ?? DEFAULT_FITNESS_FILE;
+  const registry = loadRegistry(registryFile);
+
+  let functions = registry.functions;
+  if (filter.category !== undefined) {
+    functions = functions.filter((f) => f.category === filter.category);
+  }
+  if (filter.enabled !== undefined) {
+    functions = functions.filter((f) => (f.enabled !== false) === filter.enabled);
+  }
+
+  return {
+    success: true,
+    functions,
+    total: functions.length,
+    last_evaluated: registry.last_evaluated,
+  };
+}

--- a/src/lib/plan-executor.ts
+++ b/src/lib/plan-executor.ts
@@ -44,8 +44,8 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, relative } from 'node:path';
-import { assertInsideRoot } from './path-safety.js';
 import { ValidationError } from './errors.js';
+import { assertInsideRoot } from './path-safety.js';
 
 const DEFAULT_EXECUTION_FILE = join('.jumpstart', 'state', 'plan-execution.json');
 
@@ -229,18 +229,14 @@ export function loadExecutionState(stateFile?: string): ExecutionState {
   if (hasForbiddenKey(parsed)) return defaultExecutionState();
   const base = defaultExecutionState();
   return {
-    version: typeof parsed['version'] === 'string' ? (parsed['version'] as string) : base.version,
+    version: typeof parsed.version === 'string' ? (parsed.version as string) : base.version,
     created_at:
-      typeof parsed['created_at'] === 'string'
-        ? (parsed['created_at'] as string)
-        : base.created_at,
-    last_updated:
-      typeof parsed['last_updated'] === 'string' ? (parsed['last_updated'] as string) : null,
-    plan_source:
-      typeof parsed['plan_source'] === 'string' ? (parsed['plan_source'] as string) : null,
-    jobs: Array.isArray(parsed['jobs']) ? (parsed['jobs'] as Job[]) : [],
-    execution_log: Array.isArray(parsed['execution_log'])
-      ? (parsed['execution_log'] as ExecutionLogEntry[])
+      typeof parsed.created_at === 'string' ? (parsed.created_at as string) : base.created_at,
+    last_updated: typeof parsed.last_updated === 'string' ? (parsed.last_updated as string) : null,
+    plan_source: typeof parsed.plan_source === 'string' ? (parsed.plan_source as string) : null,
+    jobs: Array.isArray(parsed.jobs) ? (parsed.jobs as Job[]) : [],
+    execution_log: Array.isArray(parsed.execution_log)
+      ? (parsed.execution_log as ExecutionLogEntry[])
       : [],
   };
 }
@@ -270,14 +266,10 @@ export function parsePlanToJobs(planContent: string): Job[] {
   let currentMilestone: string | null = null;
 
   for (const line of lines) {
-    const milestoneMatch = line.match(
-      /^#{2,3}\s+(?:Milestone\s+)?(\d+|M\d+)[:\s—–-]+\s*(.+)$/i
-    );
+    const milestoneMatch = line.match(/^#{2,3}\s+(?:Milestone\s+)?(\d+|M\d+)[:\s—–-]+\s*(.+)$/i);
     if (milestoneMatch) {
       const captured = milestoneMatch[1] ?? '';
-      currentMilestone = captured.startsWith('M')
-        ? captured
-        : `M${captured.padStart(2, '0')}`;
+      currentMilestone = captured.startsWith('M') ? captured : `M${captured.padStart(2, '0')}`;
       continue;
     }
 
@@ -297,7 +289,7 @@ export function parsePlanToJobs(planContent: string): Job[] {
       jobs.push({
         id: taskId,
         title,
-        milestone: currentMilestone ?? (taskId.split('-')[0] ?? taskId),
+        milestone: currentMilestone ?? taskId.split('-')[0] ?? taskId,
         status: 'pending',
         story_refs: [...new Set(storyRefs)],
         dependencies,
@@ -376,13 +368,11 @@ export function getExecutionStatus(options: StatusOptions = {}): StatusResult {
     statusCounts[status] = state.jobs.filter((j) => j.status === status).length;
   }
 
-  const completed = statusCounts['completed'] ?? 0;
+  const completed = statusCounts.completed ?? 0;
   const completedPct =
     state.jobs.length > 0 ? Math.round((completed / state.jobs.length) * 100) : 0;
 
-  const completedIds = new Set(
-    state.jobs.filter((j) => j.status === 'completed').map((j) => j.id)
-  );
+  const completedIds = new Set(state.jobs.filter((j) => j.status === 'completed').map((j) => j.id));
   const nextTasks = state.jobs.filter(
     (j) => j.status === 'pending' && j.dependencies.every((dep) => completedIds.has(dep))
   );
@@ -472,11 +462,7 @@ export function updateJobStatus(
  * `root` before fs.existsSync — defends against a malicious state file
  * injecting `../../../etc/passwd`.
  */
-export function verifyJob(
-  jobId: string,
-  root: string,
-  options: VerifyOptions = {}
-): VerifyResult {
+export function verifyJob(jobId: string, root: string, options: VerifyOptions = {}): VerifyResult {
   // Path-safety: gate root before any fs probe.
   assertInsideRoot(root, root, { schemaId: 'plan-executor:verifyJob:root' });
 

--- a/src/lib/plan-executor.ts
+++ b/src/lib/plan-executor.ts
@@ -1,0 +1,567 @@
+/**
+ * plan-executor.ts — Rich Plan Execution Engine port (M11 batch 5).
+ *
+ * Pure-library port of `bin/lib/plan-executor.js` (CJS) to a typed ES
+ * module. Public surface preserved verbatim by name + signature:
+ *
+ *   - `defaultExecutionState()` => ExecutionState
+ *   - `loadExecutionState(stateFile?)` => ExecutionState
+ *   - `saveExecutionState(state, stateFile?)` => void  (sets last_updated)
+ *   - `parsePlanToJobs(planContent)` => Job[]
+ *   - `initializeExecution(root, options?)` => InitResult
+ *   - `getExecutionStatus(options?)` => StatusResult
+ *   - `updateJobStatus(jobId, status, options?)` => UpdateResult
+ *   - `verifyJob(jobId, root, options?)` => VerifyResult
+ *   - `resetExecution(options?)` => ResetResult
+ *   - `TASK_STATUSES` (frozen list)
+ *
+ * Behavior parity:
+ *   - Default state file: `.jumpstart/state/plan-execution.json`.
+ *   - Default plan source: `<root>/specs/implementation-plan.md`.
+ *   - Milestone heading regex: `^#{2,3}\s+(?:Milestone\s+)?(\d+|M\d+)…`.
+ *   - Task heading/list regex: `(?:^#{2,4}\s+|^[-*]\s+\*{0,2})(M\d+-T\d+)…`.
+ *   - Story refs auto-extracted via `E\d+-S\d+` pattern.
+ *   - Dependency refs extracted from "depends on: M01-T02".
+ *   - Status transitions: started_at on first `in_progress`,
+ *     completed_at on `completed`, error on `failed` (when supplied).
+ *   - verifyJob aggregates output_files existence, status_completed,
+ *     has_completion_time, no_errors checks.
+ *
+ * M3 hardening: every JSON parse path runs through a recursive shape
+ * check that rejects __proto__/constructor/prototype keys; falls back
+ * to `defaultExecutionState()` on parse failure or pollution detection.
+ *
+ * Path-safety per ADR-009:
+ *   - `initializeExecution(root, opts)` and `verifyJob(jobId, root, opts)`
+ *     gate `root` through `assertInsideRoot` before any fs access. The
+ *     `output_files` membership check (`fs.existsSync(path.join(root,
+ *     file))`) re-asserts each file-name resolves inside root to defend
+ *     against a malicious state file injecting `../../../etc/passwd`.
+ *
+ * @see bin/lib/plan-executor.js (legacy reference)
+ * @see specs/implementation-plan.md M11 strangler cleanup
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { assertInsideRoot } from './path-safety.js';
+import { ValidationError } from './errors.js';
+
+const DEFAULT_EXECUTION_FILE = join('.jumpstart', 'state', 'plan-execution.json');
+
+export const TASK_STATUSES = [
+  'pending',
+  'in_progress',
+  'completed',
+  'failed',
+  'skipped',
+  'blocked',
+] as const;
+
+export type TaskStatus = (typeof TASK_STATUSES)[number];
+
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function hasForbiddenKey(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    for (const item of value) if (hasForbiddenKey(item)) return true;
+    return false;
+  }
+  if (!isPlainObject(value)) return false;
+  for (const key of Object.keys(value)) {
+    if (FORBIDDEN_KEYS.has(key)) return true;
+    if (hasForbiddenKey(value[key])) return true;
+  }
+  return false;
+}
+
+export interface VerificationCheck {
+  check: string;
+  passed: boolean;
+}
+
+export interface JobVerification {
+  verified_at: string;
+  passed: boolean;
+  checks: VerificationCheck[];
+}
+
+export interface Job {
+  id: string;
+  title: string;
+  milestone: string;
+  status: TaskStatus | string;
+  story_refs: string[];
+  dependencies: string[];
+  started_at: string | null;
+  completed_at: string | null;
+  verification: JobVerification | null;
+  output_files: string[];
+  error: string | null;
+}
+
+export interface ExecutionLogEntry {
+  event: string;
+  timestamp: string;
+  [key: string]: unknown;
+}
+
+export interface ExecutionState {
+  version: string;
+  created_at: string;
+  last_updated: string | null;
+  plan_source: string | null;
+  jobs: Job[];
+  execution_log: ExecutionLogEntry[];
+}
+
+export interface InitOptions {
+  planPath?: string | undefined;
+  stateFile?: string | undefined;
+}
+
+export type InitResult =
+  | {
+      success: true;
+      total_jobs: number;
+      milestones: string[];
+      jobs: { id: string; title: string; milestone: string; dependencies: string[] }[];
+    }
+  | { success: false; error: string };
+
+export interface StatusOptions {
+  stateFile?: string | undefined;
+}
+
+export type StatusResult =
+  | { success: true; initialized: false; message: string }
+  | {
+      success: true;
+      initialized: true;
+      plan_source: string | null;
+      total_jobs: number;
+      progress: number;
+      status_counts: Record<string, number>;
+      next_tasks: { id: string; title: string; milestone: string }[];
+      jobs: { id: string; title: string; status: string; milestone: string }[];
+    };
+
+export interface UpdateOptions {
+  stateFile?: string | undefined;
+  error?: string | undefined;
+  output_files?: string[] | undefined;
+}
+
+export type UpdateResult =
+  | {
+      success: true;
+      job_id: string;
+      previous_status: string;
+      new_status: string;
+      started_at: string | null;
+      completed_at: string | null;
+    }
+  | { success: false; error: string };
+
+export interface VerifyOptions {
+  stateFile?: string | undefined;
+}
+
+export type VerifyResult =
+  | {
+      success: true;
+      job_id: string;
+      verified: boolean;
+      checks: VerificationCheck[];
+      summary: { total_checks: number; passed: number; failed: number };
+    }
+  | { success: false; error: string };
+
+export interface ResetOptions {
+  stateFile?: string | undefined;
+}
+
+export interface ResetResult {
+  success: true;
+  jobs_reset: number;
+}
+
+/**
+ * Default execution state shape (legacy parity).
+ */
+export function defaultExecutionState(): ExecutionState {
+  return {
+    version: '1.0.0',
+    created_at: new Date().toISOString(),
+    last_updated: null,
+    plan_source: null,
+    jobs: [],
+    execution_log: [],
+  };
+}
+
+/**
+ * Load execution state from disk.
+ *
+ * Returns `defaultExecutionState()` on file missing / parse failure /
+ * shape mismatch / M3 pollution-key detection.
+ */
+export function loadExecutionState(stateFile?: string): ExecutionState {
+  const filePath = stateFile ?? DEFAULT_EXECUTION_FILE;
+  if (!existsSync(filePath)) return defaultExecutionState();
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, 'utf8');
+  } catch {
+    return defaultExecutionState();
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return defaultExecutionState();
+  }
+  if (!isPlainObject(parsed)) return defaultExecutionState();
+  if (hasForbiddenKey(parsed)) return defaultExecutionState();
+  const base = defaultExecutionState();
+  return {
+    version: typeof parsed['version'] === 'string' ? (parsed['version'] as string) : base.version,
+    created_at:
+      typeof parsed['created_at'] === 'string'
+        ? (parsed['created_at'] as string)
+        : base.created_at,
+    last_updated:
+      typeof parsed['last_updated'] === 'string' ? (parsed['last_updated'] as string) : null,
+    plan_source:
+      typeof parsed['plan_source'] === 'string' ? (parsed['plan_source'] as string) : null,
+    jobs: Array.isArray(parsed['jobs']) ? (parsed['jobs'] as Job[]) : [],
+    execution_log: Array.isArray(parsed['execution_log'])
+      ? (parsed['execution_log'] as ExecutionLogEntry[])
+      : [],
+  };
+}
+
+/**
+ * Save execution state to disk. Sets `last_updated` and creates the
+ * parent dir if missing.
+ */
+export function saveExecutionState(state: ExecutionState, stateFile?: string): void {
+  const filePath = stateFile ?? DEFAULT_EXECUTION_FILE;
+  const dir = dirname(filePath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  state.last_updated = new Date().toISOString();
+  writeFileSync(filePath, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
+}
+
+/**
+ * Parse implementation plan markdown into executable jobs. Detects:
+ *   - Milestone headings: `## Milestone N: ...` or `## MNN: ...`
+ *   - Task headings/list items: `### MNN-TNN — ...` or `- MNN-TNN: ...`
+ *   - Story refs (auto-extracted): `EN-SN`
+ *   - Dependencies: `depends on: MNN-TNN`
+ */
+export function parsePlanToJobs(planContent: string): Job[] {
+  const jobs: Job[] = [];
+  const lines = planContent.split('\n');
+  let currentMilestone: string | null = null;
+
+  for (const line of lines) {
+    const milestoneMatch = line.match(
+      /^#{2,3}\s+(?:Milestone\s+)?(\d+|M\d+)[:\s—–-]+\s*(.+)$/i
+    );
+    if (milestoneMatch) {
+      const captured = milestoneMatch[1] ?? '';
+      currentMilestone = captured.startsWith('M')
+        ? captured
+        : `M${captured.padStart(2, '0')}`;
+      continue;
+    }
+
+    const taskMatch = line.match(
+      /(?:^#{2,4}\s+|^[-*]\s+\*{0,2})(M\d+-T\d+)(?:\*{0,2})[:\s—–-]+\s*(.+)/i
+    );
+    if (taskMatch) {
+      const taskId = taskMatch[1] ?? '';
+      const titleRaw = taskMatch[2] ?? '';
+      const title = titleRaw.trim().replace(/\*{1,2}/g, '');
+
+      const storyRefs = line.match(/E\d+-S\d+/g) ?? [];
+
+      const depMatch = line.match(/depends?\s+on[:\s]+([^.]+)/i);
+      const dependencies = depMatch?.[1] ? (depMatch[1].match(/M\d+-T\d+/g) ?? []) : [];
+
+      jobs.push({
+        id: taskId,
+        title,
+        milestone: currentMilestone ?? (taskId.split('-')[0] ?? taskId),
+        status: 'pending',
+        story_refs: [...new Set(storyRefs)],
+        dependencies,
+        started_at: null,
+        completed_at: null,
+        verification: null,
+        output_files: [],
+        error: null,
+      });
+    }
+  }
+
+  return jobs;
+}
+
+/**
+ * Initialize execution from implementation plan markdown. Reads the
+ * plan, parses it into jobs, and persists a fresh state file.
+ */
+export function initializeExecution(root: string, options: InitOptions = {}): InitResult {
+  // Path-safety: gate root before any fs probe.
+  assertInsideRoot(root, root, { schemaId: 'plan-executor:initializeExecution:root' });
+
+  const planPath = options.planPath ?? join(root, 'specs', 'implementation-plan.md');
+  const stateFile = options.stateFile ?? join(root, DEFAULT_EXECUTION_FILE);
+
+  if (!existsSync(planPath)) {
+    return { success: false, error: `Implementation plan not found: ${planPath}` };
+  }
+
+  const planContent = readFileSync(planPath, 'utf8');
+  const jobs = parsePlanToJobs(planContent);
+
+  if (jobs.length === 0) {
+    return { success: false, error: 'No tasks found in implementation plan' };
+  }
+
+  const state = defaultExecutionState();
+  state.plan_source = relative(root, planPath);
+  state.jobs = jobs;
+  state.execution_log.push({
+    event: 'initialized',
+    timestamp: new Date().toISOString(),
+    total_jobs: jobs.length,
+  });
+
+  saveExecutionState(state, stateFile);
+
+  return {
+    success: true,
+    total_jobs: jobs.length,
+    milestones: [...new Set(jobs.map((j) => j.milestone))],
+    jobs: jobs.map((j) => ({
+      id: j.id,
+      title: j.title,
+      milestone: j.milestone,
+      dependencies: j.dependencies,
+    })),
+  };
+}
+
+/**
+ * Get execution status snapshot. Returns `initialized: false` when no
+ * jobs have been loaded.
+ */
+export function getExecutionStatus(options: StatusOptions = {}): StatusResult {
+  const stateFile = options.stateFile ?? DEFAULT_EXECUTION_FILE;
+  const state = loadExecutionState(stateFile);
+
+  if (state.jobs.length === 0) {
+    return { success: true, initialized: false, message: 'No execution plan loaded' };
+  }
+
+  const statusCounts: Record<string, number> = {};
+  for (const status of TASK_STATUSES) {
+    statusCounts[status] = state.jobs.filter((j) => j.status === status).length;
+  }
+
+  const completed = statusCounts['completed'] ?? 0;
+  const completedPct =
+    state.jobs.length > 0 ? Math.round((completed / state.jobs.length) * 100) : 0;
+
+  const completedIds = new Set(
+    state.jobs.filter((j) => j.status === 'completed').map((j) => j.id)
+  );
+  const nextTasks = state.jobs.filter(
+    (j) => j.status === 'pending' && j.dependencies.every((dep) => completedIds.has(dep))
+  );
+
+  return {
+    success: true,
+    initialized: true,
+    plan_source: state.plan_source,
+    total_jobs: state.jobs.length,
+    progress: completedPct,
+    status_counts: statusCounts,
+    next_tasks: nextTasks.map((j) => ({ id: j.id, title: j.title, milestone: j.milestone })),
+    jobs: state.jobs.map((j) => ({
+      id: j.id,
+      title: j.title,
+      status: j.status,
+      milestone: j.milestone,
+    })),
+  };
+}
+
+/**
+ * Update a job's status. Tracks started_at / completed_at / error
+ * timestamps and appends a status_change log entry.
+ */
+export function updateJobStatus(
+  jobId: string,
+  status: string,
+  options: UpdateOptions = {}
+): UpdateResult {
+  if (!(TASK_STATUSES as readonly string[]).includes(status)) {
+    return {
+      success: false,
+      error: `Invalid status: ${status}. Must be one of: ${TASK_STATUSES.join(', ')}`,
+    };
+  }
+
+  const stateFile = options.stateFile ?? DEFAULT_EXECUTION_FILE;
+  const state = loadExecutionState(stateFile);
+  const job = state.jobs.find((j) => j.id === jobId);
+
+  if (!job) {
+    return { success: false, error: `Job not found: ${jobId}` };
+  }
+
+  const previousStatus = job.status;
+  job.status = status;
+
+  if (status === 'in_progress' && !job.started_at) {
+    job.started_at = new Date().toISOString();
+  }
+  if (status === 'completed') {
+    job.completed_at = new Date().toISOString();
+  }
+  if (status === 'failed' && options.error) {
+    job.error = options.error;
+  }
+  if (options.output_files) {
+    job.output_files = options.output_files;
+  }
+
+  state.execution_log.push({
+    event: 'status_change',
+    job_id: jobId,
+    from: previousStatus,
+    to: status,
+    timestamp: new Date().toISOString(),
+  });
+
+  saveExecutionState(state, stateFile);
+
+  return {
+    success: true,
+    job_id: jobId,
+    previous_status: previousStatus,
+    new_status: status,
+    started_at: job.started_at,
+    completed_at: job.completed_at,
+  };
+}
+
+/**
+ * Verify a job. Checks output-file existence, completion status, and
+ * error-free state. Persists verification result on the job.
+ *
+ * Path-safety: re-asserts each `output_files` entry resolves inside
+ * `root` before fs.existsSync — defends against a malicious state file
+ * injecting `../../../etc/passwd`.
+ */
+export function verifyJob(
+  jobId: string,
+  root: string,
+  options: VerifyOptions = {}
+): VerifyResult {
+  // Path-safety: gate root before any fs probe.
+  assertInsideRoot(root, root, { schemaId: 'plan-executor:verifyJob:root' });
+
+  const stateFile = options.stateFile ?? join(root, DEFAULT_EXECUTION_FILE);
+  const state = loadExecutionState(stateFile);
+  const job = state.jobs.find((j) => j.id === jobId);
+
+  if (!job) {
+    return { success: false, error: `Job not found: ${jobId}` };
+  }
+
+  const checks: VerificationCheck[] = [];
+
+  if (job.output_files && job.output_files.length > 0) {
+    for (const file of job.output_files) {
+      // Defense in depth: re-validate each path resolves inside root.
+      // A malicious state file might inject `../../../etc/passwd`.
+      let exists = false;
+      try {
+        assertInsideRoot(file, root, {
+          schemaId: 'plan-executor:verifyJob:output_files',
+        });
+        exists = existsSync(join(root, file));
+      } catch (err) {
+        if (err instanceof ValidationError) {
+          // Reject traversal-shaped path: report check as failed.
+          exists = false;
+        } else {
+          throw err;
+        }
+      }
+      checks.push({ check: `file_exists: ${file}`, passed: exists });
+    }
+  }
+
+  checks.push({ check: 'status_completed', passed: job.status === 'completed' });
+  checks.push({ check: 'has_completion_time', passed: !!job.completed_at });
+  checks.push({ check: 'no_errors', passed: !job.error });
+
+  const allPassed = checks.every((c) => c.passed);
+
+  job.verification = {
+    verified_at: new Date().toISOString(),
+    passed: allPassed,
+    checks,
+  };
+
+  saveExecutionState(state, stateFile);
+
+  return {
+    success: true,
+    job_id: jobId,
+    verified: allPassed,
+    checks,
+    summary: {
+      total_checks: checks.length,
+      passed: checks.filter((c) => c.passed).length,
+      failed: checks.filter((c) => !c.passed).length,
+    },
+  };
+}
+
+/**
+ * Reset all jobs to `pending` and clear progress timestamps.
+ */
+export function resetExecution(options: ResetOptions = {}): ResetResult {
+  const stateFile = options.stateFile ?? DEFAULT_EXECUTION_FILE;
+  const state = loadExecutionState(stateFile);
+  const previousCount = state.jobs.length;
+
+  for (const job of state.jobs) {
+    job.status = 'pending';
+    job.started_at = null;
+    job.completed_at = null;
+    job.verification = null;
+    job.error = null;
+  }
+
+  state.execution_log.push({
+    event: 'reset',
+    timestamp: new Date().toISOString(),
+    jobs_reset: previousCount,
+  });
+
+  saveExecutionState(state, stateFile);
+
+  return { success: true, jobs_reset: previousCount };
+}

--- a/src/lib/proactive-validator.ts
+++ b/src/lib/proactive-validator.ts
@@ -1,0 +1,642 @@
+/**
+ * proactive-validator.ts — Proactive Validation & Suggestion Engine port (M11 batch 5).
+ *
+ * Pure-library port of `bin/lib/proactive-validator.js` (CJS) to a typed
+ * ES module. Public surface preserved verbatim by name + signature:
+ *
+ *   - `DIAGNOSTIC_CODES` (frozen-shape constant)
+ *   - `validateArtifactProactive(filePath, options?)` => FileValidationResult
+ *   - `validateAllArtifacts(specsDir, options?)` => Promise<ValidateAllResult>
+ *   - `formatDiagnostic(diag, file?)` => string
+ *   - `renderValidationReport(result)` => string
+ *   - `inferSchemaName(basename)` => string | null
+ *
+ * Behavior parity:
+ *   - Single-file pipeline: spec-tester (5 checks) → smell-detector →
+ *     validator (schema + approval).
+ *   - Cross-file pipeline: spec-drift, crossref, coverage, traceability.
+ *   - Pass threshold: 70 (default) or 100 (strict).
+ *   - All diagnostics conform to LSP-style `{line, column, severity,
+ *     code, message, suggestion, source}`.
+ *
+ * Module dependencies:
+ *   - `spec-tester`: still legacy CJS (`bin/lib/spec-tester.js`); loaded
+ *     via `createRequire` since no TS port exists yet.
+ *   - `coverage`: still legacy CJS (`bin/lib/coverage.js`); same.
+ *   - `smell-detector`, `validator`, `spec-drift`, `crossref`,
+ *     `traceability`: all TS-ported, imported as ES modules.
+ *
+ * Path-safety per ADR-009:
+ *   - `validateArtifactProactive(filePath, opts)` accepts a caller-supplied
+ *     filePath that the cluster constructs via `safeJoin(deps, ...)`.
+ *     The library does not gate again — paths are pre-validated upstream.
+ *   - `validateAllArtifacts(specsDir, opts)` walks one directory level
+ *     using `fs.readdirSync` then `path.join(specsDir, entry)`. The
+ *     `specsDir` is gated by the cluster.
+ *
+ * No JSON parse path in this module — all checks operate on Markdown
+ * content. M3 hardening notes are documented per-helper for the rare
+ * cases where we serialize an issue payload.
+ *
+ * @see bin/lib/proactive-validator.js (legacy reference)
+ * @see specs/implementation-plan.md M11 strangler cleanup
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { basename as pathBasename, dirname, join } from 'node:path';
+import { validateCrossRefs } from './crossref.js';
+import { detectSmells } from './smell-detector.js';
+import { checkSpecDrift } from './spec-drift.js';
+import { buildNFRMap } from './traceability.js';
+import { checkApproval, validateArtifact } from './validator.js';
+
+const require = createRequire(import.meta.url);
+
+// ─── Sibling-loader for legacy CJS modules without TS ports ──────────────────
+
+interface SpecTesterModule {
+  checkAmbiguity(content: string): {
+    issues: { word: string; line: number; context: string }[];
+    count: number;
+  };
+  checkPassiveVoice(content: string): {
+    issues: { pattern: string; line: number; context: string }[];
+    count: number;
+  };
+  checkGuessingLanguage(content: string): {
+    issues: { word: string; line: number; context: string }[];
+    count: number;
+  };
+  checkGWTFormat(content: string): {
+    issues: { line: number; criterion: string }[];
+    count: number;
+  };
+  checkMetricCoverage(content: string): {
+    gaps: { line?: number; requirement?: string }[];
+    coverage: number;
+  };
+  runAllChecks(
+    content: string,
+    options?: Record<string, unknown>
+  ): { score: number; [key: string]: unknown };
+}
+
+interface CoverageModule {
+  computeCoverage(
+    prdPath: string,
+    planPath: string
+  ): {
+    covered: string[];
+    uncovered: string[];
+    total_stories: number;
+    total_tasks: number;
+    coverage_pct: number;
+  };
+}
+
+let _specTester: SpecTesterModule | null = null;
+function loadSpecTester(): SpecTesterModule {
+  if (_specTester) return _specTester;
+  // The legacy CJS module has no TS port; we load via createRequire.
+  _specTester = require('../../bin/lib/spec-tester.js') as SpecTesterModule;
+  return _specTester;
+}
+
+let _coverage: CoverageModule | null = null;
+function loadCoverage(): CoverageModule {
+  if (_coverage) return _coverage;
+  _coverage = require('../../bin/lib/coverage.js') as CoverageModule;
+  return _coverage;
+}
+
+// ─── Diagnostic codes ────────────────────────────────────────────────────────
+
+export type DiagnosticSeverity = 'error' | 'warning' | 'info';
+
+export interface DiagnosticCodeEntry {
+  severity: DiagnosticSeverity;
+  description: string;
+}
+
+export const DIAGNOSTIC_CODES: Record<string, DiagnosticCodeEntry> = {
+  VAGUE_ADJ: { severity: 'warning', description: 'Vague adjective without measurable metric' },
+  PASSIVE_VOICE: {
+    severity: 'info',
+    description: 'Passive voice construction — prefer active voice',
+  },
+  GUESSING_LANG: { severity: 'warning', description: 'Hedging/guessing language detected' },
+  GWT_FORMAT: {
+    severity: 'info',
+    description: 'Acceptance criteria not in Given/When/Then format',
+  },
+  METRIC_GAP: {
+    severity: 'warning',
+    description: 'Requirement lacks quantified acceptance metric',
+  },
+  SPEC_SMELL: { severity: 'warning', description: 'Spec smell detected' },
+  SCHEMA_ERROR: { severity: 'error', description: 'Schema/structural validation error' },
+  MISSING_SECTION: { severity: 'error', description: 'Required Markdown section missing' },
+  APPROVAL_PENDING: {
+    severity: 'info',
+    description: 'Artifact Phase Gate not yet approved',
+  },
+  PLACEHOLDER: { severity: 'warning', description: 'Unresolved placeholder found' },
+  BROKEN_LINK: { severity: 'error', description: 'Cross-reference link target not found' },
+  SPEC_DRIFT: { severity: 'warning', description: 'Specification drift between artifacts' },
+  COVERAGE_GAP: {
+    severity: 'warning',
+    description: 'User story not covered by implementation tasks',
+  },
+  UNMAPPED_NFR: {
+    severity: 'warning',
+    description: 'Non-functional requirement not mapped to architecture',
+  },
+};
+
+// ─── Diagnostic shape ────────────────────────────────────────────────────────
+
+export interface Diagnostic {
+  line: number;
+  column: number;
+  severity: DiagnosticSeverity;
+  code: string;
+  message: string;
+  suggestion: string | null;
+  source: string;
+}
+
+export interface FileValidationResult {
+  file: string;
+  score: number;
+  pass: boolean;
+  diagnostics: Diagnostic[];
+}
+
+export interface CrossFileFinding {
+  severity: DiagnosticSeverity;
+  code: string;
+  message: string;
+  source: string;
+}
+
+export interface CrossFileResults {
+  drift: CrossFileFinding[] | null;
+  broken_links: CrossFileFinding[] | null;
+  coverage_gaps: CrossFileFinding[] | null;
+  unmapped_nfrs: CrossFileFinding[] | null;
+}
+
+export interface ValidateSummary {
+  total_files: number;
+  total_diagnostics: number;
+  pass_count: number;
+  fail_count: number;
+  avg_score: number | null;
+}
+
+export interface ValidateAllResult {
+  files: FileValidationResult[];
+  cross_file: CrossFileResults;
+  summary: ValidateSummary;
+}
+
+export interface ValidateArtifactOptions {
+  schema?: string | undefined;
+  schemas_dir?: string | undefined;
+  strict?: boolean | undefined;
+}
+
+export interface ValidateAllOptions extends ValidateArtifactOptions {
+  root?: string | undefined;
+}
+
+// ─── Schema name inference ───────────────────────────────────────────────────
+
+const SCHEMA_NAME_MAP: Record<string, string> = {
+  'challenger-brief.md': 'challenger-brief',
+  'product-brief.md': 'product-brief',
+  'prd.md': 'prd',
+  'architecture.md': 'architecture',
+  'implementation-plan.md': 'implementation-plan',
+  'codebase-context.md': 'codebase-context',
+};
+
+/**
+ * Infer schema name from artifact filename. Returns null for unknown
+ * filenames.
+ */
+export function inferSchemaName(basename: string): string | null {
+  return SCHEMA_NAME_MAP[basename] ?? null;
+}
+
+// ─── Single-file validation ──────────────────────────────────────────────────
+
+/**
+ * Run all relevant checks on a single artifact file and return
+ * diagnostics in a unified LSP-style format.
+ */
+export function validateArtifactProactive(
+  filePath: string,
+  options: ValidateArtifactOptions = {}
+): FileValidationResult {
+  const diagnostics: Diagnostic[] = [];
+  const basename = pathBasename(filePath);
+  const relPath = filePath; // Caller can pass relative.
+
+  if (!existsSync(filePath)) {
+    return {
+      file: relPath,
+      score: 0,
+      pass: false,
+      diagnostics: [
+        {
+          line: 0,
+          column: 0,
+          severity: 'error',
+          code: 'SCHEMA_ERROR',
+          message: `File not found: ${filePath}`,
+          suggestion: 'Create the artifact using the appropriate template.',
+          source: 'validator',
+        },
+      ],
+    };
+  }
+
+  const content = readFileSync(filePath, 'utf8');
+  if (!content.trim()) {
+    return {
+      file: relPath,
+      score: 0,
+      pass: false,
+      diagnostics: [
+        {
+          line: 0,
+          column: 0,
+          severity: 'error',
+          code: 'SCHEMA_ERROR',
+          message: 'Artifact is empty.',
+          suggestion: 'Populate using the template from .jumpstart/templates/.',
+          source: 'validator',
+        },
+      ],
+    };
+  }
+
+  const specTester = loadSpecTester();
+
+  // 1. Spec-tester checks
+  const ambiguity = specTester.checkAmbiguity(content);
+  for (const issue of ambiguity.issues) {
+    diagnostics.push({
+      line: issue.line,
+      column: 0,
+      severity: 'warning',
+      code: 'VAGUE_ADJ',
+      message: `Vague adjective "${issue.word}" without measurable metric`,
+      suggestion: `Add a quantified metric after "${issue.word}" (e.g., "${issue.word} — under 200ms p95").`,
+      source: 'spec-tester',
+    });
+  }
+
+  const passive = specTester.checkPassiveVoice(content);
+  for (const issue of passive.issues) {
+    diagnostics.push({
+      line: issue.line,
+      column: 0,
+      severity: 'info',
+      code: 'PASSIVE_VOICE',
+      message: `Passive voice: "${issue.context.substring(0, 80)}"`,
+      suggestion: 'Rewrite in active voice with a clear subject.',
+      source: 'spec-tester',
+    });
+  }
+
+  const guessing = specTester.checkGuessingLanguage(content);
+  for (const issue of guessing.issues) {
+    diagnostics.push({
+      line: issue.line,
+      column: 0,
+      severity: 'warning',
+      code: 'GUESSING_LANG',
+      message: `Guessing language: "${issue.word}"`,
+      suggestion: 'Replace with researched facts or tag with [NEEDS CLARIFICATION].',
+      source: 'spec-tester',
+    });
+  }
+
+  const gwt = specTester.checkGWTFormat(content);
+  for (const issue of gwt.issues) {
+    diagnostics.push({
+      line: issue.line,
+      column: 0,
+      severity: 'info',
+      code: 'GWT_FORMAT',
+      message: 'Acceptance criterion not in Given/When/Then format',
+      suggestion: 'Rewrite as: Given [context], When [action], Then [outcome].',
+      source: 'spec-tester',
+    });
+  }
+
+  const metrics = specTester.checkMetricCoverage(content);
+  for (const gap of metrics.gaps ?? []) {
+    diagnostics.push({
+      line: gap.line ?? 0,
+      column: 0,
+      severity: 'warning',
+      code: 'METRIC_GAP',
+      message: gap.requirement
+        ? `Requirement missing metric: "${gap.requirement.substring(0, 80)}"`
+        : 'Requirement missing quantified metric',
+      suggestion: 'Add a measurable acceptance criterion with numeric targets.',
+      source: 'spec-tester',
+    });
+  }
+
+  // Quality score from spec-tester
+  const allChecks = specTester.runAllChecks(content);
+  const score = allChecks.score;
+  const passThreshold = options.strict ? 100 : 70;
+
+  // 2. Smell detection
+  const smells = detectSmells(content);
+  for (const smell of smells.smells) {
+    diagnostics.push({
+      line: smell.line,
+      column: 0,
+      severity: smell.severity === 'major' ? 'warning' : 'info',
+      code: 'SPEC_SMELL',
+      message: `Spec smell (${smell.type}): "${smell.text.substring(0, 80)}"`,
+      suggestion: smell.description || `Address the ${smell.type} pattern.`,
+      source: 'smell-detector',
+    });
+  }
+
+  // 3. Schema/structural validation
+  const schemaName = options.schema ?? inferSchemaName(basename);
+  if (schemaName) {
+    try {
+      const vResult = validateArtifact(filePath, schemaName, options.schemas_dir);
+      for (const err of vResult.errors) {
+        diagnostics.push({
+          line: 0,
+          column: 0,
+          severity: 'error',
+          code: 'SCHEMA_ERROR',
+          // Validator error shape: ValidationOutcome.errors is string[]
+          message: typeof err === 'string' ? err : JSON.stringify(err),
+          suggestion: 'Fix the frontmatter or structure to match the schema.',
+          source: 'validator',
+        });
+      }
+      for (const warn of vResult.warnings) {
+        const code = warn.includes('placeholder')
+          ? 'PLACEHOLDER'
+          : warn.includes('Phase Gate')
+            ? 'MISSING_SECTION'
+            : 'SCHEMA_ERROR';
+        diagnostics.push({
+          line: 0,
+          column: 0,
+          severity: 'warning',
+          code,
+          message: warn,
+          suggestion: warn.includes('placeholder')
+            ? 'Replace all [PLACEHOLDER] tags with real content.'
+            : 'Add the missing section.',
+          source: 'validator',
+        });
+      }
+    } catch {
+      // Schema not available — skip
+    }
+  }
+
+  // 4. Approval check
+  const approval = checkApproval(filePath);
+  if (!approval.approved) {
+    diagnostics.push({
+      line: 0,
+      column: 0,
+      severity: 'info',
+      code: 'APPROVAL_PENDING',
+      message:
+        'Artifact has not been approved (Phase Gate checkboxes incomplete or approver pending).',
+      suggestion: 'Complete the Phase Gate Approval section and mark checkboxes [x].',
+      source: 'validator',
+    });
+  }
+
+  return {
+    file: relPath,
+    score,
+    pass: score >= passThreshold,
+    diagnostics,
+  };
+}
+
+// ─── Directory-wide validation ───────────────────────────────────────────────
+
+/**
+ * Validate all artifacts in a specs directory plus cross-file checks.
+ */
+export async function validateAllArtifacts(
+  specsDir: string,
+  options: ValidateAllOptions = {}
+): Promise<ValidateAllResult> {
+  const root = options.root ?? dirname(specsDir);
+  const files: FileValidationResult[] = [];
+  const crossFile: CrossFileResults = {
+    drift: null,
+    broken_links: null,
+    coverage_gaps: null,
+    unmapped_nfrs: null,
+  };
+
+  // Per-file validation
+  if (existsSync(specsDir)) {
+    const entries = readdirSync(specsDir).filter((f) => f.endsWith('.md'));
+    for (const entry of entries) {
+      const filePath = join(specsDir, entry);
+      const opts: ValidateArtifactOptions = {};
+      if (options.schemas_dir !== undefined) opts.schemas_dir = options.schemas_dir;
+      if (options.strict !== undefined) opts.strict = options.strict;
+      const result = validateArtifactProactive(filePath, opts);
+      // Normalize the file path to relative
+      result.file = `specs/${entry}`;
+      files.push(result);
+    }
+  }
+
+  // Cross-file: Spec drift
+  try {
+    const driftResult = checkSpecDrift(specsDir);
+    if (driftResult.drifts.length > 0) {
+      crossFile.drift = driftResult.drifts.map((d) => ({
+        severity: 'warning',
+        code: 'SPEC_DRIFT',
+        message: d.detail || `${d.type}: ${d.source} → ${d.target}`,
+        source: 'spec-drift',
+      }));
+    }
+  } catch {
+    // spec-drift not applicable
+  }
+
+  // Cross-file: Broken links
+  try {
+    const crossResult = validateCrossRefs(specsDir, root);
+    if (crossResult.broken_links.length > 0) {
+      crossFile.broken_links = crossResult.broken_links.map((link) => ({
+        severity: 'error',
+        code: 'BROKEN_LINK',
+        message: `Broken link to ${link.target} in ${link.source}:${link.line}`,
+        source: 'crossref',
+      }));
+    }
+  } catch {
+    // crossref not applicable
+  }
+
+  // Cross-file: Coverage gaps
+  const prdPath = join(specsDir, 'prd.md');
+  const planPath = join(specsDir, 'implementation-plan.md');
+  if (existsSync(prdPath) && existsSync(planPath)) {
+    try {
+      const coverageMod = loadCoverage();
+      const covResult = coverageMod.computeCoverage(prdPath, planPath);
+      if (covResult.uncovered && covResult.uncovered.length > 0) {
+        crossFile.coverage_gaps = covResult.uncovered.map((id) => ({
+          severity: 'warning',
+          code: 'COVERAGE_GAP',
+          message: `User story ${id} is not covered by any implementation task`,
+          source: 'coverage',
+        }));
+      }
+    } catch {
+      // coverage not applicable
+    }
+  }
+
+  // Cross-file: Unmapped NFRs
+  try {
+    const nfrResult = buildNFRMap(root);
+    if (nfrResult.mapping) {
+      // The TS-ported traceability uses `status: 'unmapped'`; the legacy
+      // module used `mapped_to`. Either way, we filter "unmapped" entries.
+      const unmapped = nfrResult.mapping.filter((m) => m.status === 'unmapped');
+      if (unmapped.length > 0) {
+        crossFile.unmapped_nfrs = unmapped.map((m) => ({
+          severity: 'warning',
+          code: 'UNMAPPED_NFR',
+          message: `NFR ${m.nfr} is not mapped to any architecture component`,
+          source: 'traceability',
+        }));
+      }
+    }
+  } catch {
+    // traceability not applicable
+  }
+
+  // Summary
+  const totalDiagnostics =
+    files.reduce((sum, f) => sum + f.diagnostics.length, 0) +
+    (crossFile.drift?.length ?? 0) +
+    (crossFile.broken_links?.length ?? 0) +
+    (crossFile.coverage_gaps?.length ?? 0) +
+    (crossFile.unmapped_nfrs?.length ?? 0);
+
+  const passCount = files.filter((f) => f.pass).length;
+  const failCount = files.filter((f) => !f.pass).length;
+  const avgScore =
+    files.length > 0
+      ? Math.round(files.reduce((sum, f) => sum + f.score, 0) / files.length)
+      : null;
+
+  return {
+    files,
+    cross_file: crossFile,
+    summary: {
+      total_files: files.length,
+      total_diagnostics: totalDiagnostics,
+      pass_count: passCount,
+      fail_count: failCount,
+      avg_score: avgScore,
+    },
+  };
+}
+
+// ─── Formatting ──────────────────────────────────────────────────────────────
+
+/**
+ * Format a single diagnostic as an LSP-style string.
+ */
+export function formatDiagnostic(diag: Diagnostic, file?: string): string {
+  const loc = file ? `${file}:${diag.line}:${diag.column}` : `line ${diag.line}`;
+  const sev = diag.severity.toUpperCase().padEnd(7);
+  const suggest = diag.suggestion ? ` — ${diag.suggestion}` : '';
+  return `${loc} ${sev} [${diag.code}] ${diag.message}${suggest}`;
+}
+
+/**
+ * Render a full validation report as Markdown.
+ */
+export function renderValidationReport(result: ValidateAllResult): string {
+  const lines: string[] = [];
+  lines.push('# Proactive Validation Report\n');
+  lines.push(`**Files scanned:** ${result.summary.total_files}`);
+  lines.push(`**Total diagnostics:** ${result.summary.total_diagnostics}`);
+  lines.push(
+    `**Passing:** ${result.summary.pass_count} | **Failing:** ${result.summary.fail_count}`
+  );
+  if (result.summary.avg_score !== null) {
+    lines.push(`**Average quality score:** ${result.summary.avg_score}/100`);
+  }
+  lines.push('');
+
+  // Per-file sections
+  for (const file of result.files) {
+    const statusIcon = file.pass ? '✅' : '❌';
+    lines.push(`## ${statusIcon} ${file.file} (score: ${file.score}/100)\n`);
+    if (file.diagnostics.length === 0) {
+      lines.push('No issues found.\n');
+    } else {
+      lines.push('| Line | Severity | Code | Message | Suggestion |');
+      lines.push('|------|----------|------|---------|------------|');
+      for (const d of file.diagnostics) {
+        lines.push(
+          `| ${d.line} | ${d.severity} | ${d.code} | ${d.message.substring(0, 80)} | ${(d.suggestion ?? '').substring(0, 60)} |`
+        );
+      }
+      lines.push('');
+    }
+  }
+
+  // Cross-file section
+  const crossEntries: { key: string; items: CrossFileFinding[] }[] = [];
+  if (result.cross_file.drift?.length) {
+    crossEntries.push({ key: 'drift', items: result.cross_file.drift });
+  }
+  if (result.cross_file.broken_links?.length) {
+    crossEntries.push({ key: 'broken_links', items: result.cross_file.broken_links });
+  }
+  if (result.cross_file.coverage_gaps?.length) {
+    crossEntries.push({ key: 'coverage_gaps', items: result.cross_file.coverage_gaps });
+  }
+  if (result.cross_file.unmapped_nfrs?.length) {
+    crossEntries.push({ key: 'unmapped_nfrs', items: result.cross_file.unmapped_nfrs });
+  }
+  if (crossEntries.length > 0) {
+    lines.push('## Cross-File Analysis\n');
+    for (const { key, items } of crossEntries) {
+      const heading = key.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+      lines.push(`### ${heading} (${items.length})\n`);
+      for (const item of items) {
+        lines.push(`- **[${item.code}]** ${item.message}`);
+      }
+      lines.push('');
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/src/lib/proactive-validator.ts
+++ b/src/lib/proactive-validator.ts
@@ -44,7 +44,7 @@
 
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { basename as pathBasename, dirname, join } from 'node:path';
+import { dirname, join, basename as pathBasename } from 'node:path';
 import { validateCrossRefs } from './crossref.js';
 import { detectSmells } from './smell-detector.js';
 import { checkSpecDrift } from './spec-drift.js';
@@ -549,9 +549,7 @@ export async function validateAllArtifacts(
   const passCount = files.filter((f) => f.pass).length;
   const failCount = files.filter((f) => !f.pass).length;
   const avgScore =
-    files.length > 0
-      ? Math.round(files.reduce((sum, f) => sum + f.score, 0) / files.length)
-      : null;
+    files.length > 0 ? Math.round(files.reduce((sum, f) => sum + f.score, 0) / files.length) : null;
 
   return {
     files,

--- a/src/lib/reference-architectures.ts
+++ b/src/lib/reference-architectures.ts
@@ -149,14 +149,7 @@ export const BUILTIN_PATTERNS: Pattern[] = [
     name: 'Agent Application',
     category: 'agent-app',
     description: 'Multi-agent application with tool use, memory, and planning capabilities.',
-    components: [
-      'agent-core',
-      'tool-registry',
-      'memory-store',
-      'planner',
-      'executor',
-      'api-layer',
-    ],
+    components: ['agent-core', 'tool-registry', 'memory-store', 'planner', 'executor', 'api-layer'],
     tech_stack: { suggested: ['openai', 'langchain', 'redis', 'express'] },
     structure: {
       'src/agents/': 'Agent definitions and personas',
@@ -166,11 +159,7 @@ export const BUILTIN_PATTERNS: Pattern[] = [
       'src/api/': 'API endpoints',
       'tests/': 'Test suites',
     },
-    nfrs: [
-      'response time < 5s',
-      'tool execution timeout 30s',
-      'conversation history management',
-    ],
+    nfrs: ['response time < 5s', 'tool execution timeout 30s', 'conversation history management'],
   },
   {
     id: 'api-platform',
@@ -200,8 +189,7 @@ export const BUILTIN_PATTERNS: Pattern[] = [
     id: 'event-driven',
     name: 'Event-Driven System',
     category: 'event-driven',
-    description:
-      'Event-driven microservice architecture with message broker and event sourcing.',
+    description: 'Event-driven microservice architecture with message broker and event sourcing.',
     components: [
       'event-producer',
       'message-broker',
@@ -219,11 +207,7 @@ export const BUILTIN_PATTERNS: Pattern[] = [
       'src/api/': 'Query API',
       'tests/': 'Test suites',
     },
-    nfrs: [
-      'event processing < 100ms',
-      'at-least-once delivery',
-      'event ordering guarantees',
-    ],
+    nfrs: ['event processing < 100ms', 'at-least-once delivery', 'event ordering guarantees'],
   },
 ];
 
@@ -319,21 +303,19 @@ export function loadRegistry(registryFile?: string): Registry {
   if (!isPlainObject(parsed)) return defaultRegistry();
   if (hasForbiddenKey(parsed)) return defaultRegistry();
   const base = defaultRegistry();
-  const patterns = Array.isArray(parsed['patterns'])
-    ? (parsed['patterns'] as Pattern[])
+  const patterns = Array.isArray(parsed.patterns)
+    ? (parsed.patterns as Pattern[])
     : BUILTIN_PATTERNS.map((p) => ({ ...p }));
   return {
-    version: typeof parsed['version'] === 'string' ? (parsed['version'] as string) : base.version,
+    version: typeof parsed.version === 'string' ? (parsed.version as string) : base.version,
     created_at:
-      typeof parsed['created_at'] === 'string'
-        ? (parsed['created_at'] as string)
-        : base.created_at,
+      typeof parsed.created_at === 'string' ? (parsed.created_at as string) : base.created_at,
     patterns,
-    custom_patterns: Array.isArray(parsed['custom_patterns'])
-      ? (parsed['custom_patterns'] as Pattern[])
+    custom_patterns: Array.isArray(parsed.custom_patterns)
+      ? (parsed.custom_patterns as Pattern[])
       : [],
-    instantiation_history: Array.isArray(parsed['instantiation_history'])
-      ? (parsed['instantiation_history'] as InstantiationHistoryEntry[])
+    instantiation_history: Array.isArray(parsed.instantiation_history)
+      ? (parsed.instantiation_history as InstantiationHistoryEntry[])
       : [],
   };
 }
@@ -352,10 +334,7 @@ export function saveRegistry(registry: Registry, registryFile?: string): void {
  * List available reference architectures (built-in + custom). Returns
  * compact summaries with `components` reduced to a count.
  */
-export function listPatterns(
-  filter: ListFilter = {},
-  options: CommonOptions = {}
-): ListResult {
+export function listPatterns(filter: ListFilter = {}, options: CommonOptions = {}): ListResult {
   const registryFile = options.registryFile ?? DEFAULT_REGISTRY_FILE;
   const registry = loadRegistry(registryFile);
 
@@ -404,7 +383,7 @@ export function registerPattern(
   pattern: RegisterPatternInput | null | undefined,
   options: CommonOptions = {}
 ): RegisterResult {
-  if (!pattern || !pattern.name || !pattern.description) {
+  if (!pattern?.name || !pattern.description) {
     return { success: false, error: 'name and description are required' };
   }
 

--- a/src/lib/reference-architectures.ts
+++ b/src/lib/reference-architectures.ts
@@ -1,0 +1,521 @@
+/**
+ * reference-architectures.ts — Org-wide Reference Architectures port (M11 batch 5).
+ *
+ * Pure-library port of `bin/lib/reference-architectures.js` (CJS) to a
+ * typed ES module. Public surface preserved verbatim by name + signature:
+ *
+ *   - `defaultRegistry()` => Registry
+ *   - `loadRegistry(registryFile?)` => Registry
+ *   - `saveRegistry(registry, registryFile?)` => void
+ *   - `listPatterns(filter?, options?)` => ListResult
+ *   - `getPattern(patternId, options?)` => GetResult
+ *   - `registerPattern(pattern, options?)` => RegisterResult
+ *   - `instantiatePattern(patternId, root, options?)` => InstantiateResult
+ *   - `BUILTIN_PATTERNS` (frozen-shape array of 4 default patterns)
+ *   - `PATTERN_CATEGORIES` (frozen list)
+ *
+ * Behavior parity:
+ *   - Default registry file: `.jumpstart/reference-architectures.json`.
+ *   - Built-in patterns: rag-pipeline, agent-app, api-platform,
+ *     event-driven (4 entries, identical components/tech_stack/structure
+ *     to legacy).
+ *   - Pattern IDs auto-generated from name (`name.toLowerCase()
+ *     .replace(/\s+/g, '-')`) when not supplied.
+ *   - Custom patterns persist under `registry.custom_patterns[]`.
+ *   - Unknown categories normalize to `'other'`.
+ *   - `instantiatePattern` walks the pattern's structure map and creates
+ *     each directory; writes a `README.md` in each new directory; skips
+ *     pre-existing directories.
+ *
+ * M3 hardening: every JSON parse path runs through a recursive shape
+ * check that rejects __proto__/constructor/prototype keys; falls back
+ * to `defaultRegistry()` on parse failure or pollution detection. This
+ * also guards against an attacker-controlled registry file injecting a
+ * `structure: { '__proto__': '...' }` payload into instantiatePattern
+ * (which would otherwise iterate Object.entries that includes the
+ * polluted key and create a directory named `__proto__`).
+ *
+ * Path-safety per ADR-009:
+ *   - `instantiatePattern(patternId, root, opts)` gates `root` through
+ *     `assertInsideRoot` before any fs probe. Each directory key from
+ *     `pattern.structure` is also re-asserted to resolve inside `root`
+ *     before mkdirSync — defends against a custom pattern injecting
+ *     `'../../../etc/'` or absolute paths.
+ *
+ * @see bin/lib/reference-architectures.js (legacy reference)
+ * @see specs/implementation-plan.md M11 strangler cleanup
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { ValidationError } from './errors.js';
+import { assertInsideRoot } from './path-safety.js';
+
+const DEFAULT_REGISTRY_FILE = join('.jumpstart', 'reference-architectures.json');
+
+export const PATTERN_CATEGORIES = [
+  'api-platform',
+  'event-driven',
+  'rag',
+  'agent-app',
+  'microservices',
+  'monolith',
+  'serverless',
+  'data-pipeline',
+  'other',
+] as const;
+
+export type PatternCategory = (typeof PATTERN_CATEGORIES)[number];
+
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function hasForbiddenKey(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    for (const item of value) if (hasForbiddenKey(item)) return true;
+    return false;
+  }
+  if (!isPlainObject(value)) return false;
+  for (const key of Object.keys(value)) {
+    if (FORBIDDEN_KEYS.has(key)) return true;
+    if (hasForbiddenKey(value[key])) return true;
+  }
+  return false;
+}
+
+export interface TechStack {
+  suggested: string[];
+}
+
+export interface Pattern {
+  id: string;
+  name: string;
+  category: string;
+  description: string;
+  components: string[];
+  tech_stack: TechStack;
+  structure: Record<string, string>;
+  nfrs: string[];
+  custom?: boolean;
+  created_at?: string;
+}
+
+export interface InstantiationHistoryEntry {
+  pattern_id: string;
+  instantiated_at: string;
+  root: string;
+  directories_created: number;
+}
+
+export interface Registry {
+  version: string;
+  created_at: string;
+  patterns: Pattern[];
+  custom_patterns: Pattern[];
+  instantiation_history: InstantiationHistoryEntry[];
+}
+
+export const BUILTIN_PATTERNS: Pattern[] = [
+  {
+    id: 'rag-pipeline',
+    name: 'RAG Pipeline',
+    category: 'rag',
+    description:
+      'Retrieval-Augmented Generation pipeline with vector store, embeddings, and LLM orchestration.',
+    components: [
+      'document-ingestion',
+      'embedding-service',
+      'vector-store',
+      'retrieval-engine',
+      'llm-orchestrator',
+      'api-gateway',
+    ],
+    tech_stack: { suggested: ['langchain', 'pinecone', 'openai', 'fastapi'] },
+    structure: {
+      'src/ingestion/': 'Document ingestion and chunking',
+      'src/embeddings/': 'Embedding generation',
+      'src/retrieval/': 'Vector search and retrieval',
+      'src/orchestrator/': 'LLM orchestration and prompt management',
+      'src/api/': 'API endpoints',
+      'tests/': 'Test suites',
+    },
+    nfrs: ['latency < 2s p95', 'embedding refresh < 1h', 'context window management'],
+  },
+  {
+    id: 'agent-app',
+    name: 'Agent Application',
+    category: 'agent-app',
+    description: 'Multi-agent application with tool use, memory, and planning capabilities.',
+    components: [
+      'agent-core',
+      'tool-registry',
+      'memory-store',
+      'planner',
+      'executor',
+      'api-layer',
+    ],
+    tech_stack: { suggested: ['openai', 'langchain', 'redis', 'express'] },
+    structure: {
+      'src/agents/': 'Agent definitions and personas',
+      'src/tools/': 'Tool implementations',
+      'src/memory/': 'Memory and state management',
+      'src/planner/': 'Planning and orchestration',
+      'src/api/': 'API endpoints',
+      'tests/': 'Test suites',
+    },
+    nfrs: [
+      'response time < 5s',
+      'tool execution timeout 30s',
+      'conversation history management',
+    ],
+  },
+  {
+    id: 'api-platform',
+    name: 'API Platform',
+    category: 'api-platform',
+    description: 'RESTful API platform with authentication, rate limiting, and monitoring.',
+    components: [
+      'api-gateway',
+      'auth-service',
+      'rate-limiter',
+      'business-logic',
+      'data-layer',
+      'monitoring',
+    ],
+    tech_stack: { suggested: ['express', 'postgresql', 'redis', 'jwt'] },
+    structure: {
+      'src/routes/': 'API route definitions',
+      'src/middleware/': 'Auth, rate limiting, validation',
+      'src/services/': 'Business logic',
+      'src/models/': 'Data models',
+      'src/config/': 'Configuration',
+      'tests/': 'Test suites',
+    },
+    nfrs: ['latency < 200ms p95', 'rate limit 1000 req/min', '99.9% availability'],
+  },
+  {
+    id: 'event-driven',
+    name: 'Event-Driven System',
+    category: 'event-driven',
+    description:
+      'Event-driven microservice architecture with message broker and event sourcing.',
+    components: [
+      'event-producer',
+      'message-broker',
+      'event-consumer',
+      'event-store',
+      'projection-service',
+      'api-layer',
+    ],
+    tech_stack: { suggested: ['kafka', 'nodejs', 'postgresql', 'elasticsearch'] },
+    structure: {
+      'src/events/': 'Event definitions and schemas',
+      'src/producers/': 'Event producers',
+      'src/consumers/': 'Event consumers and handlers',
+      'src/projections/': 'Read model projections',
+      'src/api/': 'Query API',
+      'tests/': 'Test suites',
+    },
+    nfrs: [
+      'event processing < 100ms',
+      'at-least-once delivery',
+      'event ordering guarantees',
+    ],
+  },
+];
+
+export interface ListFilter {
+  category?: string | undefined;
+}
+
+export interface CommonOptions {
+  registryFile?: string | undefined;
+}
+
+export interface PatternSummary {
+  id: string;
+  name: string;
+  category: string;
+  description: string;
+  components: number;
+}
+
+export interface ListResult {
+  success: true;
+  patterns: PatternSummary[];
+  total: number;
+  categories: string[];
+}
+
+export type GetResult = { success: true; pattern: Pattern } | { success: false; error: string };
+
+export interface RegisterPatternInput {
+  id?: string;
+  name?: string;
+  category?: string;
+  description?: string;
+  components?: string[];
+  tech_stack?: TechStack;
+  structure?: Record<string, string>;
+  nfrs?: string[];
+}
+
+export type RegisterResult =
+  | { success: true; pattern: Pattern }
+  | { success: false; error: string };
+
+export type InstantiateResult =
+  | {
+      success: true;
+      pattern: string;
+      pattern_name: string;
+      directories_created: string[];
+      directories_skipped: string[];
+      components: string[];
+      suggested_tech_stack: TechStack;
+      nfrs: string[];
+    }
+  | { success: false; error: string };
+
+/**
+ * Default registry shape. Always includes the 4 built-in patterns.
+ */
+export function defaultRegistry(): Registry {
+  return {
+    version: '1.0.0',
+    created_at: new Date().toISOString(),
+    patterns: BUILTIN_PATTERNS.map((p) => ({ ...p })),
+    custom_patterns: [],
+    instantiation_history: [],
+  };
+}
+
+/**
+ * Load registry from disk. On any failure path (file missing, parse
+ * error, shape mismatch, M3 pollution detection) returns
+ * `defaultRegistry()`.
+ *
+ * Legacy parity: if `data.patterns` is missing, the legacy module
+ * back-fills with `BUILTIN_PATTERNS`. We preserve that.
+ */
+export function loadRegistry(registryFile?: string): Registry {
+  const filePath = registryFile ?? DEFAULT_REGISTRY_FILE;
+  if (!existsSync(filePath)) return defaultRegistry();
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, 'utf8');
+  } catch {
+    return defaultRegistry();
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return defaultRegistry();
+  }
+  if (!isPlainObject(parsed)) return defaultRegistry();
+  if (hasForbiddenKey(parsed)) return defaultRegistry();
+  const base = defaultRegistry();
+  const patterns = Array.isArray(parsed['patterns'])
+    ? (parsed['patterns'] as Pattern[])
+    : BUILTIN_PATTERNS.map((p) => ({ ...p }));
+  return {
+    version: typeof parsed['version'] === 'string' ? (parsed['version'] as string) : base.version,
+    created_at:
+      typeof parsed['created_at'] === 'string'
+        ? (parsed['created_at'] as string)
+        : base.created_at,
+    patterns,
+    custom_patterns: Array.isArray(parsed['custom_patterns'])
+      ? (parsed['custom_patterns'] as Pattern[])
+      : [],
+    instantiation_history: Array.isArray(parsed['instantiation_history'])
+      ? (parsed['instantiation_history'] as InstantiationHistoryEntry[])
+      : [],
+  };
+}
+
+/**
+ * Save registry to disk. Creates the parent dir if missing.
+ */
+export function saveRegistry(registry: Registry, registryFile?: string): void {
+  const filePath = registryFile ?? DEFAULT_REGISTRY_FILE;
+  const dir = dirname(filePath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(registry, null, 2)}\n`, 'utf8');
+}
+
+/**
+ * List available reference architectures (built-in + custom). Returns
+ * compact summaries with `components` reduced to a count.
+ */
+export function listPatterns(
+  filter: ListFilter = {},
+  options: CommonOptions = {}
+): ListResult {
+  const registryFile = options.registryFile ?? DEFAULT_REGISTRY_FILE;
+  const registry = loadRegistry(registryFile);
+
+  let allPatterns = [...registry.patterns, ...registry.custom_patterns];
+
+  if (filter.category !== undefined) {
+    allPatterns = allPatterns.filter((p) => p.category === filter.category);
+  }
+
+  return {
+    success: true,
+    patterns: allPatterns.map((p) => ({
+      id: p.id,
+      name: p.name,
+      category: p.category,
+      description: p.description,
+      components: p.components.length,
+    })),
+    total: allPatterns.length,
+    categories: [...new Set(allPatterns.map((p) => p.category))],
+  };
+}
+
+/**
+ * Get a detailed reference architecture by id.
+ */
+export function getPattern(patternId: string, options: CommonOptions = {}): GetResult {
+  const registryFile = options.registryFile ?? DEFAULT_REGISTRY_FILE;
+  const registry = loadRegistry(registryFile);
+
+  const allPatterns = [...registry.patterns, ...registry.custom_patterns];
+  const pattern = allPatterns.find((p) => p.id === patternId);
+
+  if (!pattern) {
+    return { success: false, error: `Pattern not found: ${patternId}` };
+  }
+
+  return { success: true, pattern };
+}
+
+/**
+ * Register a custom reference architecture pattern. Persists into
+ * `registry.custom_patterns[]`.
+ */
+export function registerPattern(
+  pattern: RegisterPatternInput | null | undefined,
+  options: CommonOptions = {}
+): RegisterResult {
+  if (!pattern || !pattern.name || !pattern.description) {
+    return { success: false, error: 'name and description are required' };
+  }
+
+  const registryFile = options.registryFile ?? DEFAULT_REGISTRY_FILE;
+  const registry = loadRegistry(registryFile);
+
+  const id = pattern.id ?? pattern.name.toLowerCase().replace(/\s+/g, '-');
+  const allPatterns = [...registry.patterns, ...registry.custom_patterns];
+  if (allPatterns.find((p) => p.id === id)) {
+    return { success: false, error: `Pattern "${id}" already exists` };
+  }
+
+  const isKnownCategory =
+    pattern.category !== undefined &&
+    (PATTERN_CATEGORIES as readonly string[]).includes(pattern.category);
+
+  const newPattern: Pattern = {
+    id,
+    name: pattern.name.trim(),
+    category: isKnownCategory ? (pattern.category as string) : 'other',
+    description: pattern.description.trim(),
+    components: pattern.components ?? [],
+    tech_stack: pattern.tech_stack ?? { suggested: [] },
+    structure: pattern.structure ?? {},
+    nfrs: pattern.nfrs ?? [],
+    custom: true,
+    created_at: new Date().toISOString(),
+  };
+
+  registry.custom_patterns.push(newPattern);
+  saveRegistry(registry, registryFile);
+
+  return { success: true, pattern: newPattern };
+}
+
+/**
+ * Instantiate a pattern in a project: walks the pattern.structure map
+ * and creates each directory plus a README.md describing its purpose.
+ *
+ * Path-safety: gates `root` through `assertInsideRoot` and re-asserts
+ * each structure key resolves inside root before mkdirSync. Defends
+ * against a custom pattern injecting `'../../../etc/'` or absolute-path
+ * keys.
+ */
+export function instantiatePattern(
+  patternId: string,
+  root: string,
+  options: CommonOptions = {}
+): InstantiateResult {
+  // Path-safety: gate root before any fs probe.
+  assertInsideRoot(root, root, { schemaId: 'reference-architectures:instantiatePattern:root' });
+
+  const registryFile = options.registryFile ?? join(root, DEFAULT_REGISTRY_FILE);
+  const registry = loadRegistry(registryFile);
+  const allPatterns = [...registry.patterns, ...registry.custom_patterns];
+  const pattern = allPatterns.find((p) => p.id === patternId);
+
+  if (!pattern) {
+    return { success: false, error: `Pattern not found: ${patternId}` };
+  }
+
+  const created: string[] = [];
+  const skipped: string[] = [];
+
+  for (const [dir, description] of Object.entries(pattern.structure)) {
+    // Defense in depth: re-validate each path resolves inside root. A
+    // custom pattern (or polluted registry) might inject `'../../etc/'`.
+    try {
+      assertInsideRoot(dir, root, {
+        schemaId: 'reference-architectures:instantiatePattern:structure',
+      });
+    } catch (err) {
+      if (err instanceof ValidationError) {
+        // Reject traversal-shaped key — record as skipped, continue.
+        skipped.push(dir);
+        continue;
+      }
+      throw err;
+    }
+    const fullDir = join(root, dir);
+    if (!existsSync(fullDir)) {
+      mkdirSync(fullDir, { recursive: true });
+      const leaf = dir.replace(/\/$/, '').split('/').pop() ?? dir;
+      const readmePath = join(fullDir, 'README.md');
+      writeFileSync(
+        readmePath,
+        `# ${leaf}\n\n${description}\n\nPart of the **${pattern.name}** reference architecture.\n`,
+        'utf8'
+      );
+      created.push(dir);
+    } else {
+      skipped.push(dir);
+    }
+  }
+
+  registry.instantiation_history.push({
+    pattern_id: patternId,
+    instantiated_at: new Date().toISOString(),
+    root: resolve(root),
+    directories_created: created.length,
+  });
+  saveRegistry(registry, registryFile);
+
+  return {
+    success: true,
+    pattern: patternId,
+    pattern_name: pattern.name,
+    directories_created: created,
+    directories_skipped: skipped,
+    components: pattern.components,
+    suggested_tech_stack: pattern.tech_stack,
+    nfrs: pattern.nfrs,
+  };
+}

--- a/tests/test-finops-planner.test.ts
+++ b/tests/test-finops-planner.test.ts
@@ -1,0 +1,437 @@
+/**
+ * test-finops-planner.test.ts — M11 batch 5 port coverage.
+ *
+ * Verifies the TS port at `src/lib/finops-planner.ts` matches the
+ * legacy `bin/lib/finops-planner.js` public surface:
+ *   - defaultState shape
+ *   - loadState / saveState round-trip + defaultState fallback
+ *   - createEstimate validation, breakdown math, persistence
+ *   - getOptimizations heuristics (compute/storage/ai-ml thresholds)
+ *   - generateReport totals + by-category aggregation
+ *   - COST_CATEGORIES + CLOUD_PRICING_ESTIMATES constants
+ *   - M3 hardening: pollution-key state payloads fall back to default
+ *
+ * @see src/lib/finops-planner.ts
+ * @see bin/lib/finops-planner.js (legacy reference)
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  CLOUD_PRICING_ESTIMATES,
+  COST_CATEGORIES,
+  createEstimate,
+  defaultState,
+  generateReport,
+  getOptimizations,
+  loadState,
+  saveState,
+} from '../src/lib/finops-planner.js';
+
+let tmpDir: string;
+let stateFile: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'finops-'));
+  mkdirSync(join(tmpDir, '.jumpstart', 'state'), { recursive: true });
+  stateFile = join(tmpDir, '.jumpstart', 'state', 'finops.json');
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('finops-planner — constants', () => {
+  it('exports COST_CATEGORIES with 8 entries', () => {
+    expect(COST_CATEGORIES.length).toBe(8);
+    expect(COST_CATEGORIES).toContain('compute');
+    expect(COST_CATEGORIES).toContain('storage');
+    expect(COST_CATEGORIES).toContain('ai-ml');
+    expect(COST_CATEGORIES).toContain('licensing');
+  });
+
+  it('exports CLOUD_PRICING_ESTIMATES with low/medium/high tiers', () => {
+    expect(CLOUD_PRICING_ESTIMATES['compute']).toEqual({
+      unit: 'vCPU-hour',
+      low: 0.02,
+      medium: 0.05,
+      high: 0.1,
+    });
+    expect(CLOUD_PRICING_ESTIMATES['storage']?.medium).toBe(0.023);
+    expect(CLOUD_PRICING_ESTIMATES['ai-ml']?.high).toBe(0.06);
+  });
+});
+
+describe('finops-planner — defaultState', () => {
+  it('returns canonical default shape', () => {
+    const s = defaultState();
+    expect(s.version).toBe('1.0.0');
+    expect(s.estimates).toEqual([]);
+    expect(s.budgets).toEqual([]);
+    expect(s.optimizations).toEqual([]);
+    expect(s.last_updated).toBeNull();
+    expect(typeof s.created_at).toBe('string');
+  });
+});
+
+describe('finops-planner — loadState / saveState', () => {
+  it('returns defaultState when file missing', () => {
+    const s = loadState(stateFile);
+    expect(s.version).toBe('1.0.0');
+    expect(s.estimates).toEqual([]);
+  });
+
+  it('round-trips a saved state', () => {
+    const s = defaultState();
+    s.estimates.push({
+      id: 'FIN-TEST',
+      name: 'X',
+      breakdown: [],
+      monthly_total: 0,
+      annual_total: 0,
+      created_at: 'now',
+    });
+    saveState(s, stateFile);
+    const loaded = loadState(stateFile);
+    expect(loaded.estimates).toHaveLength(1);
+    expect(loaded.estimates[0]?.id).toBe('FIN-TEST');
+    expect(loaded.last_updated).toBeTruthy();
+  });
+
+  it('falls back to defaultState on corrupt JSON', () => {
+    writeFileSync(stateFile, '{not json', 'utf8');
+    const s = loadState(stateFile);
+    expect(s.estimates).toEqual([]);
+  });
+
+  it('falls back to defaultState on top-level array', () => {
+    writeFileSync(stateFile, '[]', 'utf8');
+    expect(loadState(stateFile).estimates).toEqual([]);
+  });
+
+  it('M3 hardening: rejects raw __proto__ payload, returns default', () => {
+    writeFileSync(stateFile, '{"__proto__":{"polluted":true},"version":"1.0.0"}', 'utf8');
+    const s = loadState(stateFile);
+    expect(s.estimates).toEqual([]);
+  });
+
+  it('M3 hardening: rejects raw constructor payload', () => {
+    writeFileSync(stateFile, '{"constructor":{"polluted":true},"version":"1.0.0"}', 'utf8');
+    const s = loadState(stateFile);
+    expect(s.estimates).toEqual([]);
+  });
+
+  it('M3 hardening: rejects nested __proto__ in estimates', () => {
+    writeFileSync(
+      stateFile,
+      '{"version":"1.0.0","estimates":[{"__proto__":{"x":1}}]}',
+      'utf8'
+    );
+    const s = loadState(stateFile);
+    expect(s.estimates).toEqual([]);
+  });
+
+  it('saveState creates parent dir if missing', () => {
+    const nested = join(tmpDir, 'deep', 'nested', 'finops.json');
+    saveState(defaultState(), nested);
+    expect(existsSync(nested)).toBe(true);
+  });
+
+  it('saveState updates last_updated timestamp', () => {
+    const s = defaultState();
+    saveState(s, stateFile);
+    expect(s.last_updated).toBeTruthy();
+    const reloaded = loadState(stateFile);
+    expect(reloaded.last_updated).toBe(s.last_updated);
+  });
+});
+
+describe('finops-planner — createEstimate', () => {
+  it('rejects without estimate name', () => {
+    const r = createEstimate({}, { stateFile });
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error).toMatch(/name/);
+  });
+
+  it('rejects null estimate', () => {
+    const r = createEstimate(null, { stateFile });
+    expect(r.success).toBe(false);
+  });
+
+  it('creates estimate with compute components (rate * quantity * hours)', () => {
+    const r = createEstimate(
+      {
+        name: 'API',
+        components: [{ name: 'srv', category: 'compute', tier: 'medium', quantity: 2 }],
+      },
+      { stateFile }
+    );
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.estimate.id).toMatch(/^FIN-/);
+      // medium=0.05, qty=2, hours=730 → 73 monthly
+      expect(r.estimate.breakdown[0]?.monthly_cost).toBe(73);
+      expect(r.estimate.monthly_total).toBe(73);
+      expect(r.estimate.annual_total).toBe(876);
+    }
+  });
+
+  it('storage uses rate * quantity (no hours multiplier)', () => {
+    const r = createEstimate(
+      {
+        name: 'Data',
+        components: [{ name: 's3', category: 'storage', tier: 'low', quantity: 100 }],
+      },
+      { stateFile }
+    );
+    expect(r.success).toBe(true);
+    if (r.success) {
+      // low=0.01, qty=100 → 1.00
+      expect(r.estimate.breakdown[0]?.monthly_cost).toBe(1);
+    }
+  });
+
+  it('monitoring uses rate * quantity (no hours multiplier)', () => {
+    const r = createEstimate(
+      {
+        name: 'Mon',
+        components: [{ name: 'logs', category: 'monitoring', tier: 'low', quantity: 10 }],
+      },
+      { stateFile }
+    );
+    expect(r.success).toBe(true);
+    if (r.success) {
+      // low=0.25, qty=10 → 2.50
+      expect(r.estimate.breakdown[0]?.monthly_cost).toBe(2.5);
+    }
+  });
+
+  it('uses manual monthly_cost for unknown categories', () => {
+    const r = createEstimate(
+      {
+        name: 'Custom',
+        components: [{ name: 'saas', category: 'third-party', monthly_cost: 99.99 }],
+      },
+      { stateFile }
+    );
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.estimate.breakdown[0]?.monthly_cost).toBe(99.99);
+  });
+
+  it('falls back to 0 for unknown category with no manual cost', () => {
+    const r = createEstimate(
+      { name: 'X', components: [{ name: 'opaque', category: 'third-party' }] },
+      { stateFile }
+    );
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.estimate.breakdown[0]?.monthly_cost).toBe(0);
+  });
+
+  it('persists estimate to state file', () => {
+    createEstimate({ name: 'Svc1', components: [] }, { stateFile });
+    const s = loadState(stateFile);
+    expect(s.estimates).toHaveLength(1);
+    expect(s.estimates[0]?.name).toBe('Svc1');
+  });
+
+  it('coerces unknown tier to medium', () => {
+    const r = createEstimate(
+      {
+        name: 'X',
+        // biome-ignore lint/suspicious/noExplicitAny: testing legacy fallback
+        components: [{ name: 'srv', category: 'compute', tier: 'bogus' as any, quantity: 1 }],
+      },
+      { stateFile }
+    );
+    expect(r.success).toBe(true);
+    if (r.success) {
+      // medium=0.05, qty=1, hours=730 → 36.5
+      expect(r.estimate.breakdown[0]?.monthly_cost).toBe(36.5);
+    }
+  });
+
+  it('defaults quantity to 1 when omitted', () => {
+    const r = createEstimate(
+      { name: 'X', components: [{ name: 'srv', category: 'compute', tier: 'medium' }] },
+      { stateFile }
+    );
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.estimate.breakdown[0]?.quantity).toBe(1);
+  });
+
+  it('defaults hours_per_month to 730 when omitted', () => {
+    const r = createEstimate(
+      {
+        name: 'X',
+        components: [{ name: 'srv', category: 'compute', tier: 'medium', quantity: 1 }],
+      },
+      { stateFile }
+    );
+    expect(r.success).toBe(true);
+    // 0.05 * 1 * 730 = 36.5
+    if (r.success) expect(r.estimate.breakdown[0]?.monthly_cost).toBe(36.5);
+  });
+
+  it('rounds monthly_total to 2 decimals', () => {
+    const r = createEstimate(
+      {
+        name: 'X',
+        components: [
+          { name: 'a', category: 'compute', tier: 'low', quantity: 3 },
+          { name: 'b', category: 'compute', tier: 'low', quantity: 7 },
+        ],
+      },
+      { stateFile }
+    );
+    expect(r.success).toBe(true);
+    if (r.success) {
+      // The total should always be expressible in 2 decimals.
+      const dec = (r.estimate.monthly_total.toString().split('.')[1] ?? '').length;
+      expect(dec).toBeLessThanOrEqual(2);
+    }
+  });
+});
+
+describe('finops-planner — getOptimizations', () => {
+  it('returns empty recommendations when no estimates', () => {
+    const r = getOptimizations({ stateFile });
+    expect(r.total).toBe(0);
+    expect(r.recommendations).toEqual([]);
+  });
+
+  it('recommends reserved/spot for expensive compute (>$500)', () => {
+    const s = defaultState();
+    s.estimates.push({
+      id: 'FIN-1',
+      name: 'API',
+      breakdown: [{ name: 'srv', category: 'compute', quantity: 1, monthly_cost: 600 }],
+      monthly_total: 600,
+      annual_total: 7200,
+      created_at: 'now',
+    });
+    saveState(s, stateFile);
+    const r = getOptimizations({ stateFile });
+    expect(r.total).toBe(1);
+    expect(r.recommendations[0]?.recommendation).toMatch(/reserved/);
+    expect(r.recommendations[0]?.potential_savings).toBe('30-60%');
+  });
+
+  it('does NOT recommend for compute at exactly $500', () => {
+    const s = defaultState();
+    s.estimates.push({
+      id: 'FIN-1',
+      name: 'API',
+      breakdown: [{ name: 'srv', category: 'compute', quantity: 1, monthly_cost: 500 }],
+      monthly_total: 500,
+      annual_total: 6000,
+      created_at: 'now',
+    });
+    saveState(s, stateFile);
+    const r = getOptimizations({ stateFile });
+    expect(r.total).toBe(0);
+  });
+
+  it('recommends storage tiering for expensive storage (>$100)', () => {
+    const s = defaultState();
+    s.estimates.push({
+      id: 'FIN-2',
+      name: 'Data',
+      breakdown: [{ name: 'blob', category: 'storage', quantity: 1, monthly_cost: 150 }],
+      monthly_total: 150,
+      annual_total: 1800,
+      created_at: 'now',
+    });
+    saveState(s, stateFile);
+    const r = getOptimizations({ stateFile });
+    expect(r.total).toBe(1);
+    expect(r.recommendations[0]?.recommendation).toMatch(/tiering/);
+  });
+
+  it('recommends batching for expensive ai-ml (>$200)', () => {
+    const s = defaultState();
+    s.estimates.push({
+      id: 'FIN-3',
+      name: 'LLM',
+      breakdown: [{ name: 'gpt', category: 'ai-ml', quantity: 1, monthly_cost: 300 }],
+      monthly_total: 300,
+      annual_total: 3600,
+      created_at: 'now',
+    });
+    saveState(s, stateFile);
+    const r = getOptimizations({ stateFile });
+    expect(r.total).toBe(1);
+    expect(r.recommendations[0]?.recommendation).toMatch(/batch/);
+    expect(r.recommendations[0]?.potential_savings).toBe('40-70%');
+  });
+
+  it('recommends multiple components in one estimate', () => {
+    const s = defaultState();
+    s.estimates.push({
+      id: 'FIN-4',
+      name: 'BigSvc',
+      breakdown: [
+        { name: 'srv', category: 'compute', quantity: 1, monthly_cost: 800 },
+        { name: 'blob', category: 'storage', quantity: 1, monthly_cost: 200 },
+      ],
+      monthly_total: 1000,
+      annual_total: 12000,
+      created_at: 'now',
+    });
+    saveState(s, stateFile);
+    const r = getOptimizations({ stateFile });
+    expect(r.total).toBe(2);
+  });
+});
+
+describe('finops-planner — generateReport', () => {
+  it('returns zeroed report with no estimates', () => {
+    const r = generateReport({ stateFile });
+    expect(r.total_estimates).toBe(0);
+    expect(r.total_monthly).toBe(0);
+    expect(r.total_annual).toBe(0);
+    expect(r.by_category).toEqual({});
+  });
+
+  it('aggregates by category across multiple estimates', () => {
+    createEstimate(
+      {
+        name: 'A',
+        components: [{ name: 'cpu', category: 'compute', tier: 'low', quantity: 1 }],
+      },
+      { stateFile }
+    );
+    createEstimate(
+      {
+        name: 'B',
+        components: [{ name: 'disk', category: 'storage', tier: 'low', quantity: 10 }],
+      },
+      { stateFile }
+    );
+    const r = generateReport({ stateFile });
+    expect(r.total_estimates).toBe(2);
+    expect(r.by_category).toHaveProperty('compute');
+    expect(r.by_category).toHaveProperty('storage');
+    expect(r.total_monthly).toBeGreaterThan(0);
+  });
+
+  it('total_annual = total_monthly * 12', () => {
+    createEstimate(
+      {
+        name: 'A',
+        components: [{ name: 'cpu', category: 'compute', tier: 'medium', quantity: 1 }],
+      },
+      { stateFile }
+    );
+    const r = generateReport({ stateFile });
+    expect(r.total_annual).toBe(Math.round(r.total_monthly * 12 * 100) / 100);
+  });
+
+  it('returns the underlying estimates array', () => {
+    createEstimate({ name: 'X', components: [] }, { stateFile });
+    const r = generateReport({ stateFile });
+    expect(r.estimates).toHaveLength(1);
+    expect(r.estimates[0]?.name).toBe('X');
+  });
+});

--- a/tests/test-finops-planner.test.ts
+++ b/tests/test-finops-planner.test.ts
@@ -53,13 +53,13 @@ describe('finops-planner — constants', () => {
   });
 
   it('exports CLOUD_PRICING_ESTIMATES with low/medium/high tiers', () => {
-    expect(CLOUD_PRICING_ESTIMATES['compute']).toEqual({
+    expect(CLOUD_PRICING_ESTIMATES.compute).toEqual({
       unit: 'vCPU-hour',
       low: 0.02,
       medium: 0.05,
       high: 0.1,
     });
-    expect(CLOUD_PRICING_ESTIMATES['storage']?.medium).toBe(0.023);
+    expect(CLOUD_PRICING_ESTIMATES.storage?.medium).toBe(0.023);
     expect(CLOUD_PRICING_ESTIMATES['ai-ml']?.high).toBe(0.06);
   });
 });
@@ -124,11 +124,7 @@ describe('finops-planner — loadState / saveState', () => {
   });
 
   it('M3 hardening: rejects nested __proto__ in estimates', () => {
-    writeFileSync(
-      stateFile,
-      '{"version":"1.0.0","estimates":[{"__proto__":{"x":1}}]}',
-      'utf8'
-    );
+    writeFileSync(stateFile, '{"version":"1.0.0","estimates":[{"__proto__":{"x":1}}]}', 'utf8');
     const s = loadState(stateFile);
     expect(s.estimates).toEqual([]);
   });
@@ -240,8 +236,7 @@ describe('finops-planner — createEstimate', () => {
     const r = createEstimate(
       {
         name: 'X',
-        // biome-ignore lint/suspicious/noExplicitAny: testing legacy fallback
-        components: [{ name: 'srv', category: 'compute', tier: 'bogus' as any, quantity: 1 }],
+        components: [{ name: 'srv', category: 'compute', tier: 'bogus' as 'low', quantity: 1 }],
       },
       { stateFile }
     );

--- a/tests/test-fitness-functions.test.ts
+++ b/tests/test-fitness-functions.test.ts
@@ -116,7 +116,7 @@ describe('fitness-functions — loadRegistry / saveRegistry', () => {
     const r = loadRegistry(registryFile);
     expect(r.functions).toEqual([]);
     // Pollution should not have leaked into the default shape.
-    expect((r as unknown as Record<string, unknown>)['polluted']).toBeUndefined();
+    expect((r as unknown as Record<string, unknown>).polluted).toBeUndefined();
   });
 
   it('M3 hardening: rejects raw constructor payload, returns default', () => {
@@ -421,10 +421,7 @@ describe('fitness-functions — evaluateFitness', () => {
   });
 
   it('records last_evaluated timestamp', () => {
-    addFitnessFunction(
-      { name: 'X', description: 'd', category: 'structure' },
-      { registryFile }
-    );
+    addFitnessFunction({ name: 'X', description: 'd', category: 'structure' }, { registryFile });
     evaluateFitness(tmpDir, { registryFile });
     const reloaded = loadRegistry(registryFile);
     expect(typeof reloaded.last_evaluated).toBe('string');
@@ -440,27 +437,15 @@ describe('fitness-functions — evaluateFitness', () => {
 
 describe('fitness-functions — listFitnessFunctions', () => {
   it('lists all when no filter', () => {
-    addFitnessFunction(
-      { name: 'A', description: 'd', category: 'structure' },
-      { registryFile }
-    );
-    addFitnessFunction(
-      { name: 'B', description: 'd', category: 'security' },
-      { registryFile }
-    );
+    addFitnessFunction({ name: 'A', description: 'd', category: 'structure' }, { registryFile });
+    addFitnessFunction({ name: 'B', description: 'd', category: 'security' }, { registryFile });
     const r = listFitnessFunctions({}, { registryFile });
     expect(r.total).toBe(2);
   });
 
   it('filters by category', () => {
-    addFitnessFunction(
-      { name: 'A', description: 'd', category: 'structure' },
-      { registryFile }
-    );
-    addFitnessFunction(
-      { name: 'B', description: 'd', category: 'security' },
-      { registryFile }
-    );
+    addFitnessFunction({ name: 'A', description: 'd', category: 'structure' }, { registryFile });
+    addFitnessFunction({ name: 'B', description: 'd', category: 'security' }, { registryFile });
     const r = listFitnessFunctions({ category: 'security' }, { registryFile });
     expect(r.total).toBe(1);
     expect(r.functions[0]?.name).toBe('B');
@@ -501,10 +486,7 @@ describe('fitness-functions — listFitnessFunctions', () => {
   });
 
   it('persists across save+load round-trip', () => {
-    addFitnessFunction(
-      { name: 'A', description: 'd', category: 'structure' },
-      { registryFile }
-    );
+    addFitnessFunction({ name: 'A', description: 'd', category: 'structure' }, { registryFile });
     const raw = readFileSync(registryFile, 'utf8');
     expect(raw).toContain('"name": "A"');
   });

--- a/tests/test-fitness-functions.test.ts
+++ b/tests/test-fitness-functions.test.ts
@@ -1,0 +1,511 @@
+/**
+ * test-fitness-functions.test.ts — M11 batch 5 port coverage.
+ *
+ * Verifies the TS port at `src/lib/fitness-functions.ts` matches the
+ * legacy `bin/lib/fitness-functions.js` public surface:
+ *   - defaultRegistry shape
+ *   - loadRegistry / saveRegistry round-trip + defaultState fallback
+ *   - addFitnessFunction validation, category normalization, dup-id
+ *   - evaluateFitness walk + violation detection + history capping
+ *   - listFitnessFunctions filters
+ *   - BUILTIN_CHECKS (max_file_length, max_function_params, pattern_match,
+ *     no_circular_imports)
+ *   - M3 hardening: pollution-key registry payloads fall back to default
+ *
+ * @see src/lib/fitness-functions.ts
+ * @see bin/lib/fitness-functions.js (legacy reference)
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  addFitnessFunction,
+  BUILTIN_CHECKS,
+  defaultRegistry,
+  evaluateFitness,
+  FITNESS_CATEGORIES,
+  listFitnessFunctions,
+  loadRegistry,
+  saveRegistry,
+} from '../src/lib/fitness-functions.js';
+
+let tmpDir: string;
+let registryFile: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'fitness-functions-'));
+  mkdirSync(join(tmpDir, '.jumpstart'), { recursive: true });
+  mkdirSync(join(tmpDir, 'src'), { recursive: true });
+  registryFile = join(tmpDir, '.jumpstart', 'fitness-functions.json');
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('fitness-functions — defaultRegistry', () => {
+  it('returns canonical default shape', () => {
+    const r = defaultRegistry();
+    expect(r.version).toBe('1.0.0');
+    expect(r.functions).toEqual([]);
+    expect(r.evaluation_history).toEqual([]);
+    expect(r.last_evaluated).toBeNull();
+    expect(typeof r.created_at).toBe('string');
+  });
+});
+
+describe('fitness-functions — FITNESS_CATEGORIES', () => {
+  it('contains the canonical category list', () => {
+    expect(FITNESS_CATEGORIES).toContain('dependency');
+    expect(FITNESS_CATEGORIES).toContain('structure');
+    expect(FITNESS_CATEGORIES).toContain('complexity');
+    expect(FITNESS_CATEGORIES).toContain('naming');
+    expect(FITNESS_CATEGORIES).toContain('security');
+    expect(FITNESS_CATEGORIES).toContain('performance');
+    expect(FITNESS_CATEGORIES).toContain('testing');
+    expect(FITNESS_CATEGORIES.length).toBe(7);
+  });
+});
+
+describe('fitness-functions — loadRegistry / saveRegistry', () => {
+  it('returns defaultRegistry when file is missing', () => {
+    const r = loadRegistry(registryFile);
+    expect(r.version).toBe('1.0.0');
+    expect(r.functions).toEqual([]);
+  });
+
+  it('round-trips a saved registry', () => {
+    const r = defaultRegistry();
+    r.functions.push({
+      id: 't1',
+      name: 'Test',
+      category: 'structure',
+      description: 'd',
+      check_type: 'pattern',
+      pattern: 'foo',
+      threshold: null,
+      target_dirs: ['src'],
+      enabled: true,
+      created_at: new Date().toISOString(),
+    });
+    saveRegistry(r, registryFile);
+    const loaded = loadRegistry(registryFile);
+    expect(loaded.functions.length).toBe(1);
+    expect(loaded.functions[0]?.id).toBe('t1');
+  });
+
+  it('defaults on malformed JSON', () => {
+    writeFileSync(registryFile, '{not json', 'utf8');
+    const r = loadRegistry(registryFile);
+    expect(r.functions).toEqual([]);
+    expect(r.version).toBe('1.0.0');
+  });
+
+  it('defaults on top-level array (shape mismatch)', () => {
+    writeFileSync(registryFile, '[]', 'utf8');
+    const r = loadRegistry(registryFile);
+    expect(r.functions).toEqual([]);
+  });
+
+  it('M3 hardening: rejects raw __proto__ payload, returns default', () => {
+    // Cannot use JSON.stringify({__proto__: ...}) — the literal becomes a
+    // prototype set, not a key. Write the bytes directly.
+    writeFileSync(registryFile, '{"__proto__":{"polluted":true},"version":"1.0.0"}', 'utf8');
+    const r = loadRegistry(registryFile);
+    expect(r.functions).toEqual([]);
+    // Pollution should not have leaked into the default shape.
+    expect((r as unknown as Record<string, unknown>)['polluted']).toBeUndefined();
+  });
+
+  it('M3 hardening: rejects raw constructor payload, returns default', () => {
+    writeFileSync(registryFile, '{"constructor":{"polluted":true},"version":"1.0.0"}', 'utf8');
+    const r = loadRegistry(registryFile);
+    expect(r.functions).toEqual([]);
+  });
+
+  it('M3 hardening: rejects nested __proto__ in functions array', () => {
+    writeFileSync(
+      registryFile,
+      '{"version":"1.0.0","functions":[{"__proto__":{"polluted":true}}]}',
+      'utf8'
+    );
+    const r = loadRegistry(registryFile);
+    expect(r.functions).toEqual([]);
+  });
+
+  it('saveRegistry creates the parent dir if missing', () => {
+    const nested = join(tmpDir, 'deep', 'nested', 'fitness.json');
+    saveRegistry(defaultRegistry(), nested);
+    expect(existsSync(nested)).toBe(true);
+  });
+});
+
+describe('fitness-functions — BUILTIN_CHECKS', () => {
+  it('max_file_length passes under threshold', () => {
+    const r = BUILTIN_CHECKS.max_file_length('a\nb\nc\n', 5);
+    expect(r.passed).toBe(true);
+    expect(r.value).toBe(4);
+    expect(r.threshold).toBe(5);
+  });
+
+  it('max_file_length fails when exceeded', () => {
+    const long = Array(600).fill('line').join('\n');
+    const r = BUILTIN_CHECKS.max_file_length(long, 500);
+    expect(r.passed).toBe(false);
+  });
+
+  it('max_file_length default threshold is 500', () => {
+    const r = BUILTIN_CHECKS.max_file_length('one line');
+    expect(r.threshold).toBe(500);
+  });
+
+  it('max_function_params counts named function params', () => {
+    const r = BUILTIN_CHECKS.max_function_params('function test(a, b, c) {}', 5);
+    expect(r.passed).toBe(true);
+    expect(r.value).toBe(3);
+  });
+
+  it('max_function_params fails when threshold exceeded', () => {
+    const r = BUILTIN_CHECKS.max_function_params('function test(a, b, c, d, e, f, g) {}', 5);
+    expect(r.passed).toBe(false);
+  });
+
+  it('max_function_params default threshold is 5', () => {
+    const r = BUILTIN_CHECKS.max_function_params('function test(a) {}');
+    expect(r.threshold).toBe(5);
+  });
+
+  it('pattern_match flags console.log usage', () => {
+    const r = BUILTIN_CHECKS.pattern_match('console.log("x")', null, 'console\\.log');
+    expect(r.passed).toBe(false);
+    expect(r.value).toBeGreaterThan(0);
+  });
+
+  it('pattern_match passes on clean content', () => {
+    const r = BUILTIN_CHECKS.pattern_match('clean code here', null, 'console\\.log');
+    expect(r.passed).toBe(true);
+  });
+
+  it('pattern_match returns passed on empty pattern', () => {
+    const r = BUILTIN_CHECKS.pattern_match('content', null, null);
+    expect(r.passed).toBe(true);
+    expect(r.value).toBe(0);
+  });
+
+  it('pattern_match returns passed=true with error on bad regex', () => {
+    const r = BUILTIN_CHECKS.pattern_match('text', null, '(unclosed');
+    expect(r.passed).toBe(true);
+    expect(r.error).toBe('invalid regex');
+  });
+
+  it('no_circular_imports counts require()-style imports', () => {
+    // Legacy regex `(?:require|import)\s*\(?['"]([^'"]+)['"]\)?` only catches
+    // function-call-shape imports. `import x from "a"` (named import) does
+    // not match because `x from ` sits between `import` and the literal.
+    const r = BUILTIN_CHECKS.no_circular_imports('require("a")\nrequire("b")');
+    expect(r.passed).toBe(true);
+    expect(r.value).toBe(2);
+    expect(r.note).toBe('static check only');
+  });
+});
+
+describe('fitness-functions — addFitnessFunction', () => {
+  it('adds a function with all required fields', () => {
+    const r = addFitnessFunction(
+      {
+        name: 'No console.log',
+        category: 'structure',
+        description: 'Disallow console.log',
+        check_type: 'pattern',
+        pattern: 'console\\.log',
+      },
+      { registryFile }
+    );
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.function.name).toBe('No console.log');
+      expect(r.function.category).toBe('structure');
+      expect(r.total).toBe(1);
+    }
+  });
+
+  it('rejects without name', () => {
+    const r = addFitnessFunction({ description: 'd' }, { registryFile });
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error).toMatch(/name and description/);
+  });
+
+  it('rejects without description', () => {
+    const r = addFitnessFunction({ name: 'X' }, { registryFile });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects null input', () => {
+    const r = addFitnessFunction(null, { registryFile });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects unknown category', () => {
+    const r = addFitnessFunction(
+      { name: 'X', description: 'd', category: 'invalid' },
+      { registryFile }
+    );
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error).toMatch(/category must be one of/);
+  });
+
+  it('lower-cases category before lookup', () => {
+    const r = addFitnessFunction(
+      { name: 'X', description: 'd', category: 'STRUCTURE' },
+      { registryFile }
+    );
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.function.category).toBe('structure');
+  });
+
+  it('rejects duplicate id', () => {
+    addFitnessFunction(
+      { id: 'dup-1', name: 'A', description: 'd', category: 'structure' },
+      { registryFile }
+    );
+    const r = addFitnessFunction(
+      { id: 'dup-1', name: 'A2', description: 'd2', category: 'structure' },
+      { registryFile }
+    );
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error).toMatch(/already exists/);
+  });
+
+  it('auto-generates id when none provided', () => {
+    const r = addFitnessFunction(
+      { name: 'X', description: 'd', category: 'structure' },
+      { registryFile }
+    );
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.function.id).toMatch(/^ff-\d+-[a-z0-9]+$/);
+  });
+
+  it('defaults category to structure when omitted', () => {
+    const r = addFitnessFunction({ name: 'X', description: 'd' }, { registryFile });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.function.category).toBe('structure');
+  });
+
+  it('trims name + description', () => {
+    const r = addFitnessFunction(
+      { name: '  hello  ', description: '  world  ', category: 'structure' },
+      { registryFile }
+    );
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.function.name).toBe('hello');
+      expect(r.function.description).toBe('world');
+    }
+  });
+});
+
+describe('fitness-functions — evaluateFitness', () => {
+  it('returns success even with empty registry', () => {
+    const r = evaluateFitness(tmpDir, { registryFile });
+    expect(r.success).toBe(true);
+    expect(r.all_passed).toBe(true);
+    expect(r.results).toEqual([]);
+  });
+
+  it('detects pattern violations in src/', () => {
+    addFitnessFunction(
+      {
+        name: 'No console.log',
+        category: 'structure',
+        description: 'd',
+        check_type: 'pattern',
+        pattern: 'console\\.log',
+      },
+      { registryFile }
+    );
+    writeFileSync(join(tmpDir, 'src', 'app.js'), 'console.log("hi")\n', 'utf8');
+    const r = evaluateFitness(tmpDir, { registryFile });
+    expect(r.all_passed).toBe(false);
+    expect(r.results[0]?.violations).toBeGreaterThan(0);
+    expect(r.summary.failed).toBe(1);
+  });
+
+  it('passes when no violations', () => {
+    addFitnessFunction(
+      {
+        name: 'No console.log',
+        category: 'structure',
+        description: 'd',
+        check_type: 'pattern',
+        pattern: 'console\\.log',
+      },
+      { registryFile }
+    );
+    writeFileSync(join(tmpDir, 'src', 'app.js'), 'const x = 1\n', 'utf8');
+    const r = evaluateFitness(tmpDir, { registryFile });
+    expect(r.all_passed).toBe(true);
+    expect(r.summary.passed).toBe(1);
+  });
+
+  it('skips dotfiles + node_modules', () => {
+    addFitnessFunction(
+      {
+        name: 'No TODO',
+        category: 'structure',
+        description: 'd',
+        check_type: 'pattern',
+        pattern: 'TODO',
+      },
+      { registryFile }
+    );
+    mkdirSync(join(tmpDir, 'src', 'node_modules', 'lib'), { recursive: true });
+    writeFileSync(join(tmpDir, 'src', 'node_modules', 'lib', 'noisy.js'), 'TODO\n', 'utf8');
+    mkdirSync(join(tmpDir, 'src', '.cache'), { recursive: true });
+    writeFileSync(join(tmpDir, 'src', '.cache', 'noisy.js'), 'TODO\n', 'utf8');
+    const r = evaluateFitness(tmpDir, { registryFile });
+    expect(r.all_passed).toBe(true);
+  });
+
+  it('skips disabled functions', () => {
+    addFitnessFunction(
+      {
+        name: 'Off check',
+        category: 'structure',
+        description: 'd',
+        check_type: 'pattern',
+        pattern: 'TODO',
+        enabled: false,
+      },
+      { registryFile }
+    );
+    writeFileSync(join(tmpDir, 'src', 'app.js'), 'TODO\n', 'utf8');
+    const r = evaluateFitness(tmpDir, { registryFile });
+    expect(r.results.length).toBe(0);
+    expect(r.all_passed).toBe(true);
+  });
+
+  it('handles non-existent target dirs', () => {
+    addFitnessFunction(
+      {
+        name: 'in-missing-dir',
+        category: 'structure',
+        description: 'd',
+        check_type: 'pattern',
+        pattern: 'TODO',
+        target_dirs: ['nonexistent-dir'],
+      },
+      { registryFile }
+    );
+    const r = evaluateFitness(tmpDir, { registryFile });
+    expect(r.all_passed).toBe(true);
+  });
+
+  it('appends to evaluation_history and caps at 50', () => {
+    const reg = defaultRegistry();
+    // Pre-populate with 50 history entries
+    for (let i = 0; i < 50; i++) {
+      reg.evaluation_history.push({
+        evaluated_at: new Date(2020, 0, i + 1).toISOString(),
+        total_functions: 0,
+        passed: 0,
+        failed: 0,
+        all_passed: true,
+      });
+    }
+    saveRegistry(reg, registryFile);
+    evaluateFitness(tmpDir, { registryFile });
+    const reloaded = loadRegistry(registryFile);
+    expect(reloaded.evaluation_history.length).toBe(50);
+  });
+
+  it('records last_evaluated timestamp', () => {
+    addFitnessFunction(
+      { name: 'X', description: 'd', category: 'structure' },
+      { registryFile }
+    );
+    evaluateFitness(tmpDir, { registryFile });
+    const reloaded = loadRegistry(registryFile);
+    expect(typeof reloaded.last_evaluated).toBe('string');
+  });
+
+  it('uses default registryFile path under root when no opt given', () => {
+    // No file created -> evaluation runs against default registry (empty).
+    const r = evaluateFitness(tmpDir);
+    expect(r.success).toBe(true);
+    expect(r.all_passed).toBe(true);
+  });
+});
+
+describe('fitness-functions — listFitnessFunctions', () => {
+  it('lists all when no filter', () => {
+    addFitnessFunction(
+      { name: 'A', description: 'd', category: 'structure' },
+      { registryFile }
+    );
+    addFitnessFunction(
+      { name: 'B', description: 'd', category: 'security' },
+      { registryFile }
+    );
+    const r = listFitnessFunctions({}, { registryFile });
+    expect(r.total).toBe(2);
+  });
+
+  it('filters by category', () => {
+    addFitnessFunction(
+      { name: 'A', description: 'd', category: 'structure' },
+      { registryFile }
+    );
+    addFitnessFunction(
+      { name: 'B', description: 'd', category: 'security' },
+      { registryFile }
+    );
+    const r = listFitnessFunctions({ category: 'security' }, { registryFile });
+    expect(r.total).toBe(1);
+    expect(r.functions[0]?.name).toBe('B');
+  });
+
+  it('filters by enabled=true', () => {
+    addFitnessFunction(
+      { name: 'A', description: 'd', category: 'structure', enabled: true },
+      { registryFile }
+    );
+    addFitnessFunction(
+      { name: 'B', description: 'd', category: 'structure', enabled: false },
+      { registryFile }
+    );
+    const r = listFitnessFunctions({ enabled: true }, { registryFile });
+    expect(r.total).toBe(1);
+    expect(r.functions[0]?.name).toBe('A');
+  });
+
+  it('filters by enabled=false', () => {
+    addFitnessFunction(
+      { name: 'A', description: 'd', category: 'structure', enabled: true },
+      { registryFile }
+    );
+    addFitnessFunction(
+      { name: 'B', description: 'd', category: 'structure', enabled: false },
+      { registryFile }
+    );
+    const r = listFitnessFunctions({ enabled: false }, { registryFile });
+    expect(r.total).toBe(1);
+    expect(r.functions[0]?.name).toBe('B');
+  });
+
+  it('returns empty list when no functions registered', () => {
+    const r = listFitnessFunctions({}, { registryFile });
+    expect(r.total).toBe(0);
+    expect(r.functions).toEqual([]);
+  });
+
+  it('persists across save+load round-trip', () => {
+    addFitnessFunction(
+      { name: 'A', description: 'd', category: 'structure' },
+      { registryFile }
+    );
+    const raw = readFileSync(registryFile, 'utf8');
+    expect(raw).toContain('"name": "A"');
+  });
+});

--- a/tests/test-plan-executor.test.ts
+++ b/tests/test-plan-executor.test.ts
@@ -1,0 +1,430 @@
+/**
+ * test-plan-executor.test.ts — M11 batch 5 port coverage.
+ *
+ * Verifies the TS port at `src/lib/plan-executor.ts` matches the legacy
+ * `bin/lib/plan-executor.js` public surface:
+ *   - defaultExecutionState shape
+ *   - loadExecutionState / saveExecutionState round-trip + defaultState
+ *     fallback
+ *   - parsePlanToJobs (milestones, tasks, story refs, dependencies)
+ *   - initializeExecution validation + persistence
+ *   - getExecutionStatus next-task computation + progress calc
+ *   - updateJobStatus transitions, started_at/completed_at tracking,
+ *     invalid-status/unknown-job rejection
+ *   - verifyJob output_files existence + status checks +
+ *     traversal-path defense
+ *   - resetExecution clears progress
+ *   - TASK_STATUSES constant
+ *   - M3 hardening: pollution-key state payloads fall back to default
+ *
+ * @see src/lib/plan-executor.ts
+ * @see bin/lib/plan-executor.js (legacy reference)
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  defaultExecutionState,
+  getExecutionStatus,
+  initializeExecution,
+  loadExecutionState,
+  parsePlanToJobs,
+  resetExecution,
+  saveExecutionState,
+  TASK_STATUSES,
+  updateJobStatus,
+  verifyJob,
+} from '../src/lib/plan-executor.js';
+
+let tmpDir: string;
+let stateFile: string;
+let planPath: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'plan-executor-'));
+  mkdirSync(join(tmpDir, '.jumpstart', 'state'), { recursive: true });
+  mkdirSync(join(tmpDir, 'specs'), { recursive: true });
+  stateFile = join(tmpDir, '.jumpstart', 'state', 'plan-execution.json');
+  planPath = join(tmpDir, 'specs', 'implementation-plan.md');
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('plan-executor — defaultExecutionState', () => {
+  it('returns canonical default shape', () => {
+    const s = defaultExecutionState();
+    expect(s.version).toBe('1.0.0');
+    expect(s.jobs).toEqual([]);
+    expect(s.execution_log).toEqual([]);
+    expect(s.last_updated).toBeNull();
+    expect(s.plan_source).toBeNull();
+  });
+});
+
+describe('plan-executor — TASK_STATUSES', () => {
+  it('contains the canonical 6 statuses', () => {
+    expect(TASK_STATUSES).toContain('pending');
+    expect(TASK_STATUSES).toContain('in_progress');
+    expect(TASK_STATUSES).toContain('completed');
+    expect(TASK_STATUSES).toContain('failed');
+    expect(TASK_STATUSES).toContain('skipped');
+    expect(TASK_STATUSES).toContain('blocked');
+    expect(TASK_STATUSES.length).toBe(6);
+  });
+});
+
+describe('plan-executor — loadExecutionState / saveExecutionState', () => {
+  it('returns defaultExecutionState when file missing', () => {
+    const s = loadExecutionState(stateFile);
+    expect(s.version).toBe('1.0.0');
+    expect(s.jobs).toEqual([]);
+  });
+
+  it('round-trips a saved state', () => {
+    const s = defaultExecutionState();
+    s.jobs.push({
+      id: 'M01-T01',
+      title: 'X',
+      milestone: 'M01',
+      status: 'pending',
+      story_refs: [],
+      dependencies: [],
+      started_at: null,
+      completed_at: null,
+      verification: null,
+      output_files: [],
+      error: null,
+    });
+    saveExecutionState(s, stateFile);
+    const reloaded = loadExecutionState(stateFile);
+    expect(reloaded.jobs[0]?.id).toBe('M01-T01');
+    expect(reloaded.last_updated).toBeTruthy();
+  });
+
+  it('falls back to default on corrupt JSON', () => {
+    writeFileSync(stateFile, '{not json', 'utf8');
+    expect(loadExecutionState(stateFile).jobs).toEqual([]);
+  });
+
+  it('M3 hardening: rejects raw __proto__ payload', () => {
+    writeFileSync(stateFile, '{"__proto__":{"polluted":true},"version":"1.0.0"}', 'utf8');
+    expect(loadExecutionState(stateFile).jobs).toEqual([]);
+  });
+
+  it('M3 hardening: rejects raw constructor payload', () => {
+    writeFileSync(stateFile, '{"constructor":{"polluted":true},"version":"1.0.0"}', 'utf8');
+    expect(loadExecutionState(stateFile).jobs).toEqual([]);
+  });
+
+  it('M3 hardening: rejects nested __proto__ in jobs', () => {
+    writeFileSync(stateFile, '{"version":"1.0.0","jobs":[{"__proto__":{"x":1}}]}', 'utf8');
+    expect(loadExecutionState(stateFile).jobs).toEqual([]);
+  });
+
+  it('saveExecutionState creates parent dir if missing', () => {
+    const nested = join(tmpDir, 'deep', 'nested', 'plan.json');
+    saveExecutionState(defaultExecutionState(), nested);
+    expect(existsSync(nested)).toBe(true);
+  });
+});
+
+describe('plan-executor — parsePlanToJobs', () => {
+  it('parses milestones + tasks', () => {
+    const content =
+      '## Milestone 1: Setup\n\n- **M01-T01**: Scaffold\n- **M01-T02**: DB\n\n## Milestone 2: Features\n\n- **M02-T01**: Auth\n';
+    const jobs = parsePlanToJobs(content);
+    expect(jobs).toHaveLength(3);
+    expect(jobs[0]?.id).toBe('M01-T01');
+    expect(jobs[0]?.milestone).toBe('M01');
+    expect(jobs[2]?.milestone).toBe('M02');
+  });
+
+  it('returns empty for no tasks', () => {
+    expect(parsePlanToJobs('no tasks here')).toEqual([]);
+  });
+
+  it('extracts story refs', () => {
+    const content = '- **M01-T01**: Build (E01-S01, E01-S02)\n';
+    const jobs = parsePlanToJobs(content);
+    expect(jobs[0]?.story_refs).toContain('E01-S01');
+    expect(jobs[0]?.story_refs).toContain('E01-S02');
+  });
+
+  it('extracts dependency refs', () => {
+    const content = '- **M01-T02**: Build, depends on M01-T01\n';
+    const jobs = parsePlanToJobs(content);
+    expect(jobs[0]?.dependencies).toContain('M01-T01');
+  });
+
+  it('handles task heading style under a milestone heading (#### MNN-TNN — title)', () => {
+    // The milestone regex `^#{2,3}` only matches 2-3 hash levels; tasks
+    // need `^#{2,4}` headers so 4-hash lines bypass the milestone branch
+    // and fall into the task branch.
+    const content = '## Milestone 1: Setup\n#### M01-T01 — Scaffold\n';
+    const jobs = parsePlanToJobs(content);
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0]?.id).toBe('M01-T01');
+  });
+
+  it('falls back to taskId-prefix when no milestone heading', () => {
+    const content = '- **M03-T05**: orphan task\n';
+    const jobs = parsePlanToJobs(content);
+    expect(jobs[0]?.milestone).toBe('M03');
+  });
+
+  it('strips bold markdown markers from title', () => {
+    const content = '- **M01-T01**: **Bold** title\n';
+    const jobs = parsePlanToJobs(content);
+    expect(jobs[0]?.title).not.toContain('**');
+  });
+});
+
+describe('plan-executor — initializeExecution', () => {
+  it('initializes from a valid plan', () => {
+    writeFileSync(planPath, '## Milestone 1: Setup\n\n- **M01-T01**: x\n- **M01-T02**: y\n');
+    const r = initializeExecution(tmpDir, { stateFile });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.total_jobs).toBe(2);
+      expect(r.milestones).toContain('M01');
+    }
+  });
+
+  it('fails when plan file does not exist', () => {
+    const r = initializeExecution(tmpDir, { stateFile });
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error).toMatch(/Implementation plan not found/);
+  });
+
+  it('fails when plan has no parseable tasks', () => {
+    writeFileSync(planPath, '# heading\nno tasks\n');
+    const r = initializeExecution(tmpDir, { stateFile });
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error).toMatch(/No tasks found/);
+  });
+
+  it('persists initial state', () => {
+    writeFileSync(planPath, '- **M01-T01**: Task\n');
+    initializeExecution(tmpDir, { stateFile });
+    const s = loadExecutionState(stateFile);
+    expect(s.jobs).toHaveLength(1);
+    expect(s.execution_log[0]?.event).toBe('initialized');
+  });
+});
+
+describe('plan-executor — getExecutionStatus', () => {
+  it('reports uninitialized state', () => {
+    const r = getExecutionStatus({ stateFile });
+    expect(r.initialized).toBe(false);
+  });
+
+  it('reports progress after init', () => {
+    writeFileSync(planPath, '- **M01-T01**: x\n- **M01-T02**: y\n');
+    initializeExecution(tmpDir, { stateFile });
+    const r = getExecutionStatus({ stateFile });
+    expect(r.initialized).toBe(true);
+    if (r.initialized) {
+      expect(r.total_jobs).toBe(2);
+      expect(r.progress).toBe(0);
+      expect(r.next_tasks.length).toBe(2);
+    }
+  });
+
+  it('progresses to 50% on one of two completed', () => {
+    writeFileSync(planPath, '- **M01-T01**: x\n- **M01-T02**: y\n');
+    initializeExecution(tmpDir, { stateFile });
+    updateJobStatus('M01-T01', 'completed', { stateFile });
+    const r = getExecutionStatus({ stateFile });
+    if (r.initialized) {
+      expect(r.progress).toBe(50);
+    }
+  });
+
+  it('next_tasks excludes tasks blocked by uncompleted dependencies', () => {
+    writeFileSync(
+      planPath,
+      '- **M01-T01**: x\n- **M01-T02**: y, depends on M01-T01\n'
+    );
+    initializeExecution(tmpDir, { stateFile });
+    const r = getExecutionStatus({ stateFile });
+    if (r.initialized) {
+      expect(r.next_tasks.find((t) => t.id === 'M01-T02')).toBeUndefined();
+      expect(r.next_tasks.find((t) => t.id === 'M01-T01')).toBeDefined();
+    }
+  });
+});
+
+describe('plan-executor — updateJobStatus', () => {
+  it('updates status pending → in_progress and sets started_at', () => {
+    writeFileSync(planPath, '- **M01-T01**: x\n');
+    initializeExecution(tmpDir, { stateFile });
+    const r = updateJobStatus('M01-T01', 'in_progress', { stateFile });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.previous_status).toBe('pending');
+      expect(r.new_status).toBe('in_progress');
+      expect(r.started_at).toBeTruthy();
+    }
+  });
+
+  it('sets completed_at on completed', () => {
+    writeFileSync(planPath, '- **M01-T01**: x\n');
+    initializeExecution(tmpDir, { stateFile });
+    const r = updateJobStatus('M01-T01', 'completed', { stateFile });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.completed_at).toBeTruthy();
+  });
+
+  it('rejects invalid status', () => {
+    writeFileSync(planPath, '- **M01-T01**: x\n');
+    initializeExecution(tmpDir, { stateFile });
+    const r = updateJobStatus('M01-T01', 'bogus', { stateFile });
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error).toMatch(/Invalid status/);
+  });
+
+  it('rejects unknown job', () => {
+    writeFileSync(planPath, '- **M01-T01**: x\n');
+    initializeExecution(tmpDir, { stateFile });
+    const r = updateJobStatus('M99-T99', 'completed', { stateFile });
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error).toMatch(/Job not found/);
+  });
+
+  it('records error message on failed status', () => {
+    writeFileSync(planPath, '- **M01-T01**: x\n');
+    initializeExecution(tmpDir, { stateFile });
+    updateJobStatus('M01-T01', 'failed', { stateFile, error: 'boom' });
+    const s = loadExecutionState(stateFile);
+    expect(s.jobs[0]?.error).toBe('boom');
+  });
+
+  it('records output_files when supplied', () => {
+    writeFileSync(planPath, '- **M01-T01**: x\n');
+    initializeExecution(tmpDir, { stateFile });
+    updateJobStatus('M01-T01', 'completed', { stateFile, output_files: ['src/x.ts'] });
+    const s = loadExecutionState(stateFile);
+    expect(s.jobs[0]?.output_files).toEqual(['src/x.ts']);
+  });
+
+  it('appends a status_change log entry', () => {
+    writeFileSync(planPath, '- **M01-T01**: x\n');
+    initializeExecution(tmpDir, { stateFile });
+    updateJobStatus('M01-T01', 'in_progress', { stateFile });
+    const s = loadExecutionState(stateFile);
+    const lastLog = s.execution_log[s.execution_log.length - 1];
+    expect(lastLog?.event).toBe('status_change');
+  });
+});
+
+describe('plan-executor — verifyJob', () => {
+  it('verifies a completed job with no output files', () => {
+    writeFileSync(planPath, '- **M01-T01**: x\n');
+    initializeExecution(tmpDir, { stateFile });
+    updateJobStatus('M01-T01', 'completed', { stateFile });
+    const r = verifyJob('M01-T01', tmpDir, { stateFile });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.verified).toBe(true);
+  });
+
+  it('rejects unknown job', () => {
+    const r = verifyJob('M99-T99', tmpDir, { stateFile });
+    expect(r.success).toBe(false);
+  });
+
+  it('fails verification when output_file missing', () => {
+    writeFileSync(planPath, '- **M01-T01**: x\n');
+    initializeExecution(tmpDir, { stateFile });
+    updateJobStatus('M01-T01', 'completed', {
+      stateFile,
+      output_files: ['nonexistent/file.ts'],
+    });
+    const r = verifyJob('M01-T01', tmpDir, { stateFile });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.verified).toBe(false);
+      expect(r.checks.find((c) => c.check.includes('file_exists') && !c.passed)).toBeDefined();
+    }
+  });
+
+  it('passes verification when output file exists', () => {
+    writeFileSync(planPath, '- **M01-T01**: x\n');
+    initializeExecution(tmpDir, { stateFile });
+    writeFileSync(join(tmpDir, 'output.ts'), '');
+    updateJobStatus('M01-T01', 'completed', {
+      stateFile,
+      output_files: ['output.ts'],
+    });
+    const r = verifyJob('M01-T01', tmpDir, { stateFile });
+    if (r.success) expect(r.verified).toBe(true);
+  });
+
+  it('rejects traversal-shaped output_files (defense in depth)', () => {
+    writeFileSync(planPath, '- **M01-T01**: x\n');
+    initializeExecution(tmpDir, { stateFile });
+    // Inject a malicious output_files via direct state-file write.
+    const s = loadExecutionState(stateFile);
+    if (s.jobs[0]) {
+      s.jobs[0].status = 'completed';
+      s.jobs[0].completed_at = new Date().toISOString();
+      s.jobs[0].output_files = ['../../../etc/passwd'];
+    }
+    saveExecutionState(s, stateFile);
+    const r = verifyJob('M01-T01', tmpDir, { stateFile });
+    expect(r.success).toBe(true);
+    // The traversal path should be reported as failed (file_exists: false).
+    if (r.success) {
+      const traversalCheck = r.checks.find((c) =>
+        c.check.startsWith('file_exists: ../')
+      );
+      expect(traversalCheck?.passed).toBe(false);
+    }
+  });
+});
+
+describe('plan-executor — resetExecution', () => {
+  it('resets all jobs to pending', () => {
+    writeFileSync(planPath, '- **M01-T01**: x\n- **M01-T02**: y\n');
+    initializeExecution(tmpDir, { stateFile });
+    updateJobStatus('M01-T01', 'completed', { stateFile });
+    updateJobStatus('M01-T02', 'in_progress', { stateFile });
+
+    const r = resetExecution({ stateFile });
+    expect(r.jobs_reset).toBe(2);
+
+    const status = getExecutionStatus({ stateFile });
+    if (status.initialized) {
+      expect(status.status_counts['completed']).toBe(0);
+      expect(status.status_counts['in_progress']).toBe(0);
+      expect(status.status_counts['pending']).toBe(2);
+    }
+  });
+
+  it('clears started_at and completed_at', () => {
+    writeFileSync(planPath, '- **M01-T01**: x\n');
+    initializeExecution(tmpDir, { stateFile });
+    updateJobStatus('M01-T01', 'completed', { stateFile });
+    resetExecution({ stateFile });
+    const s = loadExecutionState(stateFile);
+    expect(s.jobs[0]?.started_at).toBeNull();
+    expect(s.jobs[0]?.completed_at).toBeNull();
+  });
+
+  it('appends a reset log entry', () => {
+    writeFileSync(planPath, '- **M01-T01**: x\n');
+    initializeExecution(tmpDir, { stateFile });
+    resetExecution({ stateFile });
+    const s = loadExecutionState(stateFile);
+    const lastLog = s.execution_log[s.execution_log.length - 1];
+    expect(lastLog?.event).toBe('reset');
+  });
+
+  it('handles reset on empty state (0 jobs)', () => {
+    const r = resetExecution({ stateFile });
+    expect(r.jobs_reset).toBe(0);
+  });
+});

--- a/tests/test-plan-executor.test.ts
+++ b/tests/test-plan-executor.test.ts
@@ -245,10 +245,7 @@ describe('plan-executor — getExecutionStatus', () => {
   });
 
   it('next_tasks excludes tasks blocked by uncompleted dependencies', () => {
-    writeFileSync(
-      planPath,
-      '- **M01-T01**: x\n- **M01-T02**: y, depends on M01-T01\n'
-    );
+    writeFileSync(planPath, '- **M01-T01**: x\n- **M01-T02**: y, depends on M01-T01\n');
     initializeExecution(tmpDir, { stateFile });
     const r = getExecutionStatus({ stateFile });
     if (r.initialized) {
@@ -378,9 +375,7 @@ describe('plan-executor — verifyJob', () => {
     expect(r.success).toBe(true);
     // The traversal path should be reported as failed (file_exists: false).
     if (r.success) {
-      const traversalCheck = r.checks.find((c) =>
-        c.check.startsWith('file_exists: ../')
-      );
+      const traversalCheck = r.checks.find((c) => c.check.startsWith('file_exists: ../'));
       expect(traversalCheck?.passed).toBe(false);
     }
   });
@@ -398,9 +393,9 @@ describe('plan-executor — resetExecution', () => {
 
     const status = getExecutionStatus({ stateFile });
     if (status.initialized) {
-      expect(status.status_counts['completed']).toBe(0);
-      expect(status.status_counts['in_progress']).toBe(0);
-      expect(status.status_counts['pending']).toBe(2);
+      expect(status.status_counts.completed).toBe(0);
+      expect(status.status_counts.in_progress).toBe(0);
+      expect(status.status_counts.pending).toBe(2);
     }
   });
 

--- a/tests/test-proactive-validator.test.ts
+++ b/tests/test-proactive-validator.test.ts
@@ -285,9 +285,7 @@ describe('proactive-validator — validateAllArtifacts', () => {
     writeSpec('vague.md', makeVagueArtifact());
     const result = await validateAllArtifacts(join(tmpDir, 'specs'), { root: tmpDir });
     expect(typeof result.summary.avg_score).toBe('number');
-    expect(result.summary.pass_count + result.summary.fail_count).toBe(
-      result.summary.total_files
-    );
+    expect(result.summary.pass_count + result.summary.fail_count).toBe(result.summary.total_files);
   });
 
   it('skips non-md files in specs dir', async () => {

--- a/tests/test-proactive-validator.test.ts
+++ b/tests/test-proactive-validator.test.ts
@@ -1,0 +1,465 @@
+/**
+ * test-proactive-validator.test.ts — M11 batch 5 port coverage.
+ *
+ * Verifies the TS port at `src/lib/proactive-validator.ts` matches the
+ * legacy `bin/lib/proactive-validator.js` public surface:
+ *   - DIAGNOSTIC_CODES shape
+ *   - inferSchemaName mapping
+ *   - validateArtifactProactive: clean, vague, smelly, missing-section,
+ *     non-existent + empty edge cases, strict threshold
+ *   - validateAllArtifacts: empty + populated + cross_file structure
+ *   - formatDiagnostic with/without file context
+ *   - renderValidationReport: per-file sections + cross-file
+ *
+ * @see src/lib/proactive-validator.ts
+ * @see bin/lib/proactive-validator.js (legacy reference)
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  DIAGNOSTIC_CODES,
+  formatDiagnostic,
+  inferSchemaName,
+  renderValidationReport,
+  validateAllArtifacts,
+  validateArtifactProactive,
+} from '../src/lib/proactive-validator.js';
+
+let tmpDir: string;
+
+function writeSpec(name: string, content: string): string {
+  const filePath = join(tmpDir, 'specs', name);
+  writeFileSync(filePath, content, 'utf8');
+  return filePath;
+}
+
+function makeCleanArtifact(): string {
+  return [
+    '---',
+    'id: test-artifact',
+    'phase: 0',
+    'status: approved',
+    '---',
+    '',
+    '# Test Artifact',
+    '',
+    'The system processes 100 requests per second with 99.9% uptime.',
+    'Response time is under 200ms at the 95th percentile.',
+    '',
+    '## Requirements',
+    '',
+    'Users can log in within 2 seconds.',
+    '',
+    '## Phase Gate Approval',
+    '',
+    '- [x] All criteria met',
+    '- [x] Quality gates passed',
+    '',
+    '**Approved by:** Human',
+    '**Approval date:** 2026-01-01',
+  ].join('\n');
+}
+
+function makeVagueArtifact(): string {
+  return [
+    '# Vague Artifact',
+    '',
+    'The system should be fast and scalable.',
+    'It needs to be robust and user-friendly.',
+    'We probably need a flexible architecture.',
+    '',
+    '## Phase Gate Approval',
+    '',
+    '- [ ] All criteria met',
+    '',
+    '**Approved by:** Pending',
+  ].join('\n');
+}
+
+function makeSmellyArtifact(): string {
+  return [
+    '# Smelly Artifact',
+    '',
+    'The system should handle many requests, etc.',
+    'Various components will be implemented and so on.',
+    'Several different services will communicate somehow.',
+    '',
+    '## Phase Gate Approval',
+    '',
+    '- [ ] All criteria met',
+    '',
+    '**Approved by:** Pending',
+  ].join('\n');
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'proactive-validator-'));
+  mkdirSync(join(tmpDir, 'specs'), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('proactive-validator — DIAGNOSTIC_CODES', () => {
+  it('contains the canonical 14 codes', () => {
+    const expected = [
+      'VAGUE_ADJ',
+      'PASSIVE_VOICE',
+      'GUESSING_LANG',
+      'GWT_FORMAT',
+      'METRIC_GAP',
+      'SPEC_SMELL',
+      'SCHEMA_ERROR',
+      'MISSING_SECTION',
+      'APPROVAL_PENDING',
+      'PLACEHOLDER',
+      'BROKEN_LINK',
+      'SPEC_DRIFT',
+      'COVERAGE_GAP',
+      'UNMAPPED_NFR',
+    ];
+    for (const code of expected) {
+      expect(DIAGNOSTIC_CODES).toHaveProperty(code);
+      expect(DIAGNOSTIC_CODES[code]).toHaveProperty('severity');
+      expect(DIAGNOSTIC_CODES[code]).toHaveProperty('description');
+    }
+  });
+
+  it('every severity is one of error|warning|info', () => {
+    const valid = new Set(['error', 'warning', 'info']);
+    for (const entry of Object.values(DIAGNOSTIC_CODES)) {
+      expect(valid.has(entry.severity)).toBe(true);
+    }
+  });
+});
+
+describe('proactive-validator — inferSchemaName', () => {
+  it('maps known artifact filenames to schema names', () => {
+    expect(inferSchemaName('prd.md')).toBe('prd');
+    expect(inferSchemaName('architecture.md')).toBe('architecture');
+    expect(inferSchemaName('challenger-brief.md')).toBe('challenger-brief');
+    expect(inferSchemaName('product-brief.md')).toBe('product-brief');
+    expect(inferSchemaName('implementation-plan.md')).toBe('implementation-plan');
+    expect(inferSchemaName('codebase-context.md')).toBe('codebase-context');
+  });
+
+  it('returns null for unknown filenames', () => {
+    expect(inferSchemaName('random.md')).toBeNull();
+    expect(inferSchemaName('notes.md')).toBeNull();
+  });
+});
+
+describe('proactive-validator — validateArtifactProactive (clean)', () => {
+  it('returns a high score with few diagnostics', () => {
+    const filePath = writeSpec('clean.md', makeCleanArtifact());
+    const result = validateArtifactProactive(filePath);
+    expect(result.file).toBe(filePath);
+    expect(typeof result.score).toBe('number');
+    expect(result.score).toBeGreaterThanOrEqual(60);
+    expect(result.pass).toBe(true);
+  });
+});
+
+describe('proactive-validator — validateArtifactProactive (vague)', () => {
+  it('produces VAGUE_ADJ diagnostics', () => {
+    const filePath = writeSpec('vague.md', makeVagueArtifact());
+    const result = validateArtifactProactive(filePath);
+    const issues = result.diagnostics.filter((d) => d.code === 'VAGUE_ADJ');
+    expect(issues.length).toBeGreaterThan(0);
+    expect(issues[0]?.severity).toBe('warning');
+    expect(issues[0]?.suggestion).toBeTruthy();
+  });
+
+  it('produces GUESSING_LANG diagnostics', () => {
+    const filePath = writeSpec('vague.md', makeVagueArtifact());
+    const result = validateArtifactProactive(filePath);
+    const issues = result.diagnostics.filter((d) => d.code === 'GUESSING_LANG');
+    expect(issues.length).toBeGreaterThan(0);
+  });
+
+  it('produces APPROVAL_PENDING for unapproved artifact', () => {
+    const filePath = writeSpec('vague.md', makeVagueArtifact());
+    const result = validateArtifactProactive(filePath);
+    const issues = result.diagnostics.filter((d) => d.code === 'APPROVAL_PENDING');
+    expect(issues.length).toBe(1);
+  });
+});
+
+describe('proactive-validator — validateArtifactProactive (smelly)', () => {
+  it('produces SPEC_SMELL diagnostics', () => {
+    const filePath = writeSpec('smelly.md', makeSmellyArtifact());
+    const result = validateArtifactProactive(filePath);
+    const issues = result.diagnostics.filter((d) => d.code === 'SPEC_SMELL');
+    expect(issues.length).toBeGreaterThan(0);
+  });
+});
+
+describe('proactive-validator — validateArtifactProactive (edge cases)', () => {
+  it('handles non-existent file gracefully', () => {
+    const result = validateArtifactProactive(join(tmpDir, 'nonexistent.md'));
+    expect(result.score).toBe(0);
+    expect(result.pass).toBe(false);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.code).toBe('SCHEMA_ERROR');
+    expect(result.diagnostics[0]?.message).toMatch(/File not found/);
+  });
+
+  it('handles empty file', () => {
+    const filePath = writeSpec('empty.md', '');
+    const result = validateArtifactProactive(filePath);
+    expect(result.score).toBe(0);
+    expect(result.pass).toBe(false);
+  });
+
+  it('handles whitespace-only file', () => {
+    const filePath = writeSpec('whitespace.md', '   \n\n   \n');
+    const result = validateArtifactProactive(filePath);
+    expect(result.score).toBe(0);
+    expect(result.pass).toBe(false);
+  });
+
+  it('strict threshold rejects sub-100 scores', () => {
+    const filePath = writeSpec('vague.md', makeVagueArtifact());
+    const normal = validateArtifactProactive(filePath, { strict: false });
+    const strict = validateArtifactProactive(filePath, { strict: true });
+    expect(normal.score).toBe(strict.score);
+    if (strict.score < 100) {
+      expect(strict.pass).toBe(false);
+    }
+  });
+});
+
+describe('proactive-validator — diagnostic shape', () => {
+  it('every diagnostic has required LSP-style fields', () => {
+    const filePath = writeSpec('vague.md', makeVagueArtifact());
+    const result = validateArtifactProactive(filePath);
+    for (const d of result.diagnostics) {
+      expect(typeof d.line).toBe('number');
+      expect(typeof d.column).toBe('number');
+      expect(['error', 'warning', 'info']).toContain(d.severity);
+      expect(typeof d.code).toBe('string');
+      expect(typeof d.message).toBe('string');
+      expect(typeof d.source).toBe('string');
+    }
+  });
+});
+
+describe('proactive-validator — validateAllArtifacts', () => {
+  it('returns zero files for empty specs directory', async () => {
+    const result = await validateAllArtifacts(join(tmpDir, 'specs'));
+    expect(result.files).toEqual([]);
+    expect(result.summary.total_files).toBe(0);
+    expect(result.summary.total_diagnostics).toBe(0);
+  });
+
+  it('aggregates multiple artifacts', async () => {
+    writeSpec('clean.md', makeCleanArtifact());
+    writeSpec('vague.md', makeVagueArtifact());
+    const result = await validateAllArtifacts(join(tmpDir, 'specs'), { root: tmpDir });
+    expect(result.files).toHaveLength(2);
+    expect(result.summary.total_files).toBe(2);
+    expect(result.summary.total_diagnostics).toBeGreaterThan(0);
+  });
+
+  it('normalizes file paths to specs/ relative', async () => {
+    writeSpec('test.md', makeCleanArtifact());
+    const result = await validateAllArtifacts(join(tmpDir, 'specs'), { root: tmpDir });
+    expect(result.files[0]?.file).toBe('specs/test.md');
+  });
+
+  it('returns canonical cross_file structure', async () => {
+    writeSpec('prd.md', makeCleanArtifact());
+    const result = await validateAllArtifacts(join(tmpDir, 'specs'), { root: tmpDir });
+    expect(result.cross_file).toHaveProperty('drift');
+    expect(result.cross_file).toHaveProperty('broken_links');
+    expect(result.cross_file).toHaveProperty('coverage_gaps');
+    expect(result.cross_file).toHaveProperty('unmapped_nfrs');
+  });
+
+  it('computes summary averages', async () => {
+    writeSpec('clean.md', makeCleanArtifact());
+    writeSpec('vague.md', makeVagueArtifact());
+    const result = await validateAllArtifacts(join(tmpDir, 'specs'), { root: tmpDir });
+    expect(typeof result.summary.avg_score).toBe('number');
+    expect(result.summary.pass_count + result.summary.fail_count).toBe(
+      result.summary.total_files
+    );
+  });
+
+  it('skips non-md files in specs dir', async () => {
+    writeFileSync(join(tmpDir, 'specs', 'not-md.txt'), 'ignored');
+    writeSpec('included.md', makeCleanArtifact());
+    const result = await validateAllArtifacts(join(tmpDir, 'specs'), { root: tmpDir });
+    expect(result.files).toHaveLength(1);
+  });
+
+  it('avg_score is null when no files', async () => {
+    const result = await validateAllArtifacts(join(tmpDir, 'specs'));
+    expect(result.summary.avg_score).toBeNull();
+  });
+});
+
+describe('proactive-validator — formatDiagnostic', () => {
+  it('formats with file context', () => {
+    const formatted = formatDiagnostic(
+      {
+        line: 10,
+        column: 5,
+        severity: 'warning',
+        code: 'VAGUE_ADJ',
+        message: 'Vague word "fast"',
+        suggestion: 'Add metric',
+        source: 'spec-tester',
+      },
+      'specs/prd.md'
+    );
+    expect(formatted).toContain('specs/prd.md:10:5');
+    expect(formatted).toContain('WARNING');
+    expect(formatted).toContain('[VAGUE_ADJ]');
+    expect(formatted).toContain('Vague word');
+    expect(formatted).toContain('Add metric');
+  });
+
+  it('formats without file context', () => {
+    const formatted = formatDiagnostic({
+      line: 5,
+      column: 0,
+      severity: 'error',
+      code: 'SCHEMA_ERROR',
+      message: 'Missing field',
+      suggestion: null,
+      source: 'validator',
+    });
+    expect(formatted).toContain('line 5');
+    expect(formatted).toContain('ERROR');
+    expect(formatted).toContain('[SCHEMA_ERROR]');
+  });
+
+  it('omits suggestion section when null', () => {
+    const formatted = formatDiagnostic({
+      line: 1,
+      column: 0,
+      severity: 'info',
+      code: 'GWT_FORMAT',
+      message: 'm',
+      suggestion: null,
+      source: 's',
+    });
+    expect(formatted).not.toContain(' — ');
+  });
+});
+
+describe('proactive-validator — renderValidationReport', () => {
+  it('renders header + per-file sections', () => {
+    const report = renderValidationReport({
+      files: [
+        { file: 'specs/prd.md', score: 75, pass: true, diagnostics: [] },
+        {
+          file: 'specs/vague.md',
+          score: 45,
+          pass: false,
+          diagnostics: [
+            {
+              line: 3,
+              column: 0,
+              severity: 'warning',
+              code: 'VAGUE_ADJ',
+              message: 'Vague',
+              suggestion: 'Add metric',
+              source: 'spec-tester',
+            },
+          ],
+        },
+      ],
+      cross_file: {
+        drift: null,
+        broken_links: null,
+        coverage_gaps: null,
+        unmapped_nfrs: null,
+      },
+      summary: {
+        total_files: 2,
+        total_diagnostics: 1,
+        pass_count: 1,
+        fail_count: 1,
+        avg_score: 60,
+      },
+    });
+    expect(report).toContain('# Proactive Validation Report');
+    expect(report).toContain('specs/prd.md');
+    expect(report).toContain('specs/vague.md');
+    expect(report).toContain('60/100');
+  });
+
+  it('includes cross-file section when findings exist', () => {
+    const report = renderValidationReport({
+      files: [],
+      cross_file: {
+        drift: [
+          {
+            severity: 'warning',
+            code: 'SPEC_DRIFT',
+            message: 'Story drifted',
+            source: 'spec-drift',
+          },
+        ],
+        broken_links: null,
+        coverage_gaps: null,
+        unmapped_nfrs: null,
+      },
+      summary: {
+        total_files: 0,
+        total_diagnostics: 1,
+        pass_count: 0,
+        fail_count: 0,
+        avg_score: null,
+      },
+    });
+    expect(report).toContain('Cross-File');
+    expect(report).toContain('SPEC_DRIFT');
+  });
+
+  it('omits average score line when null', () => {
+    const report = renderValidationReport({
+      files: [],
+      cross_file: {
+        drift: null,
+        broken_links: null,
+        coverage_gaps: null,
+        unmapped_nfrs: null,
+      },
+      summary: {
+        total_files: 0,
+        total_diagnostics: 0,
+        pass_count: 0,
+        fail_count: 0,
+        avg_score: null,
+      },
+    });
+    expect(report).not.toContain('Average quality score');
+  });
+
+  it('renders "No issues found" for clean files', () => {
+    const report = renderValidationReport({
+      files: [{ file: 'specs/clean.md', score: 100, pass: true, diagnostics: [] }],
+      cross_file: {
+        drift: null,
+        broken_links: null,
+        coverage_gaps: null,
+        unmapped_nfrs: null,
+      },
+      summary: {
+        total_files: 1,
+        total_diagnostics: 0,
+        pass_count: 1,
+        fail_count: 0,
+        avg_score: 100,
+      },
+    });
+    expect(report).toContain('No issues found.');
+  });
+});

--- a/tests/test-reference-architectures.test.ts
+++ b/tests/test-reference-architectures.test.ts
@@ -1,0 +1,388 @@
+/**
+ * test-reference-architectures.test.ts — M11 batch 5 port coverage.
+ *
+ * Verifies the TS port at `src/lib/reference-architectures.ts` matches
+ * the legacy `bin/lib/reference-architectures.js` public surface:
+ *   - BUILTIN_PATTERNS shape (4 entries with required fields)
+ *   - PATTERN_CATEGORIES list
+ *   - defaultRegistry includes built-ins
+ *   - loadRegistry / saveRegistry round-trip + defaultState fallback
+ *   - listPatterns: all + by-category filter
+ *   - getPattern: built-in + unknown
+ *   - registerPattern: validation, duplicate-id, category-normalize
+ *   - instantiatePattern: directory creation, README writes,
+ *     skip-existing, traversal-defense
+ *   - M3 hardening: pollution-key registry payloads fall back to default
+ *
+ * @see src/lib/reference-architectures.ts
+ * @see bin/lib/reference-architectures.js (legacy reference)
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  BUILTIN_PATTERNS,
+  defaultRegistry,
+  getPattern,
+  instantiatePattern,
+  listPatterns,
+  loadRegistry,
+  PATTERN_CATEGORIES,
+  registerPattern,
+  saveRegistry,
+} from '../src/lib/reference-architectures.js';
+
+let tmpDir: string;
+let registryFile: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'reference-architectures-'));
+  mkdirSync(join(tmpDir, '.jumpstart'), { recursive: true });
+  registryFile = join(tmpDir, '.jumpstart', 'reference-architectures.json');
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('reference-architectures — BUILTIN_PATTERNS', () => {
+  it('exposes 4 built-in patterns', () => {
+    expect(BUILTIN_PATTERNS.length).toBe(4);
+  });
+
+  it('includes rag-pipeline, agent-app, api-platform, event-driven', () => {
+    const ids = BUILTIN_PATTERNS.map((p) => p.id);
+    expect(ids).toContain('rag-pipeline');
+    expect(ids).toContain('agent-app');
+    expect(ids).toContain('api-platform');
+    expect(ids).toContain('event-driven');
+  });
+
+  it('each pattern has required fields', () => {
+    for (const p of BUILTIN_PATTERNS) {
+      expect(p.id).toBeTruthy();
+      expect(p.name).toBeTruthy();
+      expect(p.description).toBeTruthy();
+      expect(Array.isArray(p.components)).toBe(true);
+      expect(Array.isArray(p.tech_stack.suggested)).toBe(true);
+      expect(Array.isArray(p.nfrs)).toBe(true);
+    }
+  });
+});
+
+describe('reference-architectures — PATTERN_CATEGORIES', () => {
+  it('contains 9 canonical categories', () => {
+    expect(PATTERN_CATEGORIES.length).toBe(9);
+    expect(PATTERN_CATEGORIES).toContain('api-platform');
+    expect(PATTERN_CATEGORIES).toContain('event-driven');
+    expect(PATTERN_CATEGORIES).toContain('rag');
+    expect(PATTERN_CATEGORIES).toContain('agent-app');
+    expect(PATTERN_CATEGORIES).toContain('other');
+  });
+});
+
+describe('reference-architectures — defaultRegistry', () => {
+  it('includes all built-in patterns', () => {
+    const r = defaultRegistry();
+    expect(r.patterns.length).toBe(4);
+    expect(r.custom_patterns).toEqual([]);
+    expect(r.instantiation_history).toEqual([]);
+  });
+});
+
+describe('reference-architectures — loadRegistry / saveRegistry', () => {
+  it('returns defaultRegistry when file missing', () => {
+    const r = loadRegistry(registryFile);
+    expect(r.patterns.length).toBe(4);
+  });
+
+  it('round-trips a saved registry', () => {
+    const r = defaultRegistry();
+    r.custom_patterns.push({
+      id: 'custom-x',
+      name: 'X',
+      category: 'other',
+      description: 'd',
+      components: [],
+      tech_stack: { suggested: [] },
+      structure: {},
+      nfrs: [],
+      custom: true,
+      created_at: new Date().toISOString(),
+    });
+    saveRegistry(r, registryFile);
+    const reloaded = loadRegistry(registryFile);
+    expect(reloaded.custom_patterns).toHaveLength(1);
+    expect(reloaded.custom_patterns[0]?.id).toBe('custom-x');
+  });
+
+  it('falls back to default on corrupt JSON', () => {
+    writeFileSync(registryFile, '{not json', 'utf8');
+    expect(loadRegistry(registryFile).patterns.length).toBe(4);
+  });
+
+  it('back-fills missing patterns array with built-ins', () => {
+    writeFileSync(registryFile, '{"version":"1.0.0","custom_patterns":[]}', 'utf8');
+    const r = loadRegistry(registryFile);
+    expect(r.patterns.length).toBe(4);
+  });
+
+  it('M3 hardening: rejects raw __proto__ payload', () => {
+    writeFileSync(registryFile, '{"__proto__":{"polluted":true},"version":"1.0.0"}', 'utf8');
+    expect(loadRegistry(registryFile).custom_patterns).toEqual([]);
+  });
+
+  it('M3 hardening: rejects raw constructor payload', () => {
+    writeFileSync(registryFile, '{"constructor":{"polluted":true},"version":"1.0.0"}', 'utf8');
+    expect(loadRegistry(registryFile).custom_patterns).toEqual([]);
+  });
+
+  it('M3 hardening: rejects nested __proto__ in custom_patterns', () => {
+    writeFileSync(
+      registryFile,
+      '{"version":"1.0.0","custom_patterns":[{"__proto__":{"x":1}}]}',
+      'utf8'
+    );
+    expect(loadRegistry(registryFile).custom_patterns).toEqual([]);
+  });
+
+  it('saveRegistry creates parent dir if missing', () => {
+    const nested = join(tmpDir, 'deep', 'nested', 'refarch.json');
+    saveRegistry(defaultRegistry(), nested);
+    expect(existsSync(nested)).toBe(true);
+  });
+});
+
+describe('reference-architectures — listPatterns', () => {
+  it('lists all patterns (built-in + custom)', () => {
+    const r = listPatterns({}, { registryFile });
+    expect(r.total).toBe(4); // No custom patterns yet
+  });
+
+  it('reduces components to a count in the summary', () => {
+    const r = listPatterns({}, { registryFile });
+    for (const p of r.patterns) {
+      expect(typeof p.components).toBe('number');
+    }
+  });
+
+  it('filters by category', () => {
+    const r = listPatterns({ category: 'rag' }, { registryFile });
+    expect(r.total).toBe(1);
+    expect(r.patterns[0]?.id).toBe('rag-pipeline');
+  });
+
+  it('includes custom patterns alongside built-ins', () => {
+    registerPattern(
+      { name: 'Custom A', description: 'd', category: 'other' },
+      { registryFile }
+    );
+    const r = listPatterns({}, { registryFile });
+    expect(r.total).toBe(5);
+  });
+
+  it('returns deduped categories', () => {
+    const r = listPatterns({}, { registryFile });
+    const categories = r.categories;
+    expect(new Set(categories).size).toBe(categories.length);
+  });
+});
+
+describe('reference-architectures — getPattern', () => {
+  it('returns a built-in pattern', () => {
+    const r = getPattern('rag-pipeline', { registryFile });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.pattern.name).toBe('RAG Pipeline');
+      expect(r.pattern.components.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('rejects unknown pattern', () => {
+    const r = getPattern('nope', { registryFile });
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error).toMatch(/not found/);
+  });
+
+  it('returns custom-registered patterns', () => {
+    registerPattern(
+      { name: 'Custom B', description: 'd', category: 'other', id: 'custom-b' },
+      { registryFile }
+    );
+    const r = getPattern('custom-b', { registryFile });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('reference-architectures — registerPattern', () => {
+  it('registers a custom pattern', () => {
+    const r = registerPattern(
+      {
+        name: 'Custom CMS',
+        description: 'A CMS',
+        category: 'other',
+        components: ['ui', 'api'],
+      },
+      { registryFile }
+    );
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.pattern.custom).toBe(true);
+      expect(r.pattern.id).toBe('custom-cms');
+    }
+  });
+
+  it('rejects without name', () => {
+    const r = registerPattern({ description: 'd' }, { registryFile });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects without description', () => {
+    const r = registerPattern({ name: 'X' }, { registryFile });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects null pattern', () => {
+    const r = registerPattern(null, { registryFile });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects duplicate id', () => {
+    registerPattern({ name: 'Test', description: 'd', id: 't1' }, { registryFile });
+    const r = registerPattern(
+      { name: 'Test 2', description: 'd2', id: 't1' },
+      { registryFile }
+    );
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error).toMatch(/already exists/);
+  });
+
+  it('rejects collision with built-in pattern id', () => {
+    const r = registerPattern(
+      { name: 'X', description: 'd', id: 'rag-pipeline' },
+      { registryFile }
+    );
+    expect(r.success).toBe(false);
+  });
+
+  it('normalizes unknown category to "other"', () => {
+    const r = registerPattern(
+      { name: 'Q', description: 'd', category: 'bogus' },
+      { registryFile }
+    );
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.pattern.category).toBe('other');
+  });
+
+  it('preserves known categories verbatim', () => {
+    const r = registerPattern(
+      { name: 'P', description: 'd', category: 'rag' },
+      { registryFile }
+    );
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.pattern.category).toBe('rag');
+  });
+
+  it('auto-generates id from name when not supplied', () => {
+    const r = registerPattern(
+      { name: 'My Custom Thing', description: 'd', category: 'other' },
+      { registryFile }
+    );
+    if (r.success) expect(r.pattern.id).toBe('my-custom-thing');
+  });
+
+  it('persists custom pattern across reload', () => {
+    registerPattern(
+      { name: 'Persistent', description: 'd', category: 'other', id: 'p1' },
+      { registryFile }
+    );
+    const reloaded = loadRegistry(registryFile);
+    expect(reloaded.custom_patterns.find((p) => p.id === 'p1')).toBeDefined();
+  });
+});
+
+describe('reference-architectures — instantiatePattern', () => {
+  it('creates pattern directory structure', () => {
+    const r = instantiatePattern('api-platform', tmpDir, { registryFile });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.directories_created.length).toBeGreaterThan(0);
+      expect(r.components.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('writes a README.md in each created dir', () => {
+    const r = instantiatePattern('rag-pipeline', tmpDir, { registryFile });
+    if (r.success) {
+      for (const dir of r.directories_created) {
+        const readmePath = join(tmpDir, dir, 'README.md');
+        expect(existsSync(readmePath)).toBe(true);
+        const content = readFileSync(readmePath, 'utf8');
+        expect(content).toContain('RAG Pipeline');
+      }
+    }
+  });
+
+  it('skips existing directories on re-run', () => {
+    instantiatePattern('api-platform', tmpDir, { registryFile });
+    const r = instantiatePattern('api-platform', tmpDir, { registryFile });
+    if (r.success) {
+      expect(r.directories_skipped.length).toBeGreaterThan(0);
+      expect(r.directories_created.length).toBe(0);
+    }
+  });
+
+  it('rejects unknown pattern', () => {
+    const r = instantiatePattern('nope', tmpDir, { registryFile });
+    expect(r.success).toBe(false);
+  });
+
+  it('records instantiation history', () => {
+    instantiatePattern('api-platform', tmpDir, { registryFile });
+    const reloaded = loadRegistry(registryFile);
+    expect(reloaded.instantiation_history.length).toBe(1);
+    expect(reloaded.instantiation_history[0]?.pattern_id).toBe('api-platform');
+  });
+
+  it('skips traversal-shaped structure keys (defense in depth)', () => {
+    // Inject a malicious custom pattern whose structure tries to escape
+    // the project root.
+    const reg = loadRegistry(registryFile);
+    reg.custom_patterns.push({
+      id: 'evil',
+      name: 'Evil',
+      category: 'other',
+      description: 'd',
+      components: [],
+      tech_stack: { suggested: [] },
+      structure: {
+        '../../../tmp-evil-dir/': 'should be rejected',
+        'safe/': 'should be created',
+      },
+      nfrs: [],
+      custom: true,
+      created_at: 'now',
+    });
+    saveRegistry(reg, registryFile);
+    const r = instantiatePattern('evil', tmpDir, { registryFile });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      // The traversal key should be in skipped, not created.
+      expect(r.directories_skipped).toContain('../../../tmp-evil-dir/');
+      expect(r.directories_created).toContain('safe/');
+    }
+    // The escape target must not exist.
+    expect(existsSync(join(tmpDir, '..', '..', '..', 'tmp-evil-dir'))).toBe(false);
+  });
+
+  it('returns the pattern metadata in the result envelope', () => {
+    const r = instantiatePattern('api-platform', tmpDir, { registryFile });
+    if (r.success) {
+      expect(r.pattern).toBe('api-platform');
+      expect(r.pattern_name).toBe('API Platform');
+      expect(r.suggested_tech_stack.suggested).toContain('express');
+    }
+  });
+});

--- a/tests/test-reference-architectures.test.ts
+++ b/tests/test-reference-architectures.test.ts
@@ -175,10 +175,7 @@ describe('reference-architectures — listPatterns', () => {
   });
 
   it('includes custom patterns alongside built-ins', () => {
-    registerPattern(
-      { name: 'Custom A', description: 'd', category: 'other' },
-      { registryFile }
-    );
+    registerPattern({ name: 'Custom A', description: 'd', category: 'other' }, { registryFile });
     const r = listPatterns({}, { registryFile });
     expect(r.total).toBe(5);
   });
@@ -251,10 +248,7 @@ describe('reference-architectures — registerPattern', () => {
 
   it('rejects duplicate id', () => {
     registerPattern({ name: 'Test', description: 'd', id: 't1' }, { registryFile });
-    const r = registerPattern(
-      { name: 'Test 2', description: 'd2', id: 't1' },
-      { registryFile }
-    );
+    const r = registerPattern({ name: 'Test 2', description: 'd2', id: 't1' }, { registryFile });
     expect(r.success).toBe(false);
     if (!r.success) expect(r.error).toMatch(/already exists/);
   });
@@ -268,19 +262,13 @@ describe('reference-architectures — registerPattern', () => {
   });
 
   it('normalizes unknown category to "other"', () => {
-    const r = registerPattern(
-      { name: 'Q', description: 'd', category: 'bogus' },
-      { registryFile }
-    );
+    const r = registerPattern({ name: 'Q', description: 'd', category: 'bogus' }, { registryFile });
     expect(r.success).toBe(true);
     if (r.success) expect(r.pattern.category).toBe('other');
   });
 
   it('preserves known categories verbatim', () => {
-    const r = registerPattern(
-      { name: 'P', description: 'd', category: 'rag' },
-      { registryFile }
-    );
+    const r = registerPattern({ name: 'P', description: 'd', category: 'rag' }, { registryFile });
     expect(r.success).toBe(true);
     if (r.success) expect(r.pattern.category).toBe('rag');
   });


### PR DESCRIPTION
## Summary
- **Completes** the strangler-fig migration started in M11 — after this lands, no pure-library JS legacy ports remain in `bin/lib/*`
- 5 modules ported (1 commit per module), 1606 LoC of legacy CJS replaced with 2321 LoC of typed TS + tests
- Full M3 hardening (recursive shape-validation rejecting `__proto__`/`constructor`/`prototype`), defaultState fallbacks, ADR-009 path-safety per ADR-006 typed errors

## Modules ported
| Module | Legacy LoC | TS LoC | Tests added | Latent bugs found |
|---|---|---|---|---|
| `fitness-functions.ts` | 279 | ~390 | ~25 | (see commit body) |
| `finops-planner.ts` | 182 | ~280 | ~22 | (see commit body) |
| `plan-executor.ts` | 366 | 497 | ~30 | (see commit body) |
| `proactive-validator.ts` | 475 | 511 | 28 | spec-tester + coverage still legacy CJS, loaded via createRequire |
| `reference-architectures.ts` | 304 | 467 | 38 | structure-key path traversal hardening (NEW defense) |

## Notable hardening
- `reference-architectures` re-asserts each `pattern.structure` key against `root` before `mkdirSync` — the legacy code didn't, leaving a polluted-registry traversal vulnerability
- `proactive-validator` rewrote unmapped-NFR cross-file branch to use the typed `status === 'unmapped'` enum rather than the legacy `mapping[].mapped_to` array
- `plan-executor` (see commit message)

## Cluster wiring
- `src/cli/commands/enterprise.ts` — switched `reference-architectures` to direct static import (was `legacyRequire`)
- `src/cli/commands/deferred.ts` — switched `proactive-validator` to direct static import (was `legacyRequire`)

## Test plan
- [x] `npm run verify-baseline` → 12/12 gates green (clean dist required)
- [x] `npx tsc --noEmit` → 0 errors
- [x] `npm run lint` (biome) → 0 errors, 0 warnings
- [x] All 5 new test files pass
- [ ] CI green on PR

Refs #34