### PR TITLE
feat(m11): enable noUncheckedIndexedAccess permanently — issue #31 phase 3

### DIFF
--- a/src/lib/ai-intake.ts
+++ b/src/lib/ai-intake.ts
@@ -185,7 +185,7 @@ export function createIntake(intake: IntakeInput, options: StateOptions = {}): C
     data_types: dataTypes,
     model_type: intake.model_type || null,
     risk_tier: riskTier,
-    risk_label: RISK_TIERS[riskTier - 1].label,
+    risk_label: RISK_TIERS[riskTier - 1]?.label ?? 'Unknown',
     status: 'draft',
     sections_completed: [],
     created_at: new Date().toISOString(),

--- a/src/lib/context-onboarding.ts
+++ b/src/lib/context-onboarding.ts
@@ -175,7 +175,7 @@ export function customizeForRole(
     qa: ['specs', 'getting_started', 'risks'],
   };
 
-  const focus = roleFocus[role] || roleFocus.engineer;
+  const focus = roleFocus[role] ?? roleFocus.engineer ?? [];
 
   return {
     success: true,

--- a/src/lib/data-classification.ts
+++ b/src/lib/data-classification.ts
@@ -225,7 +225,13 @@ export function classifyAsset(asset: AssetInput, options: StateOptions = {}): Cl
     type: asset.type || 'system',
     data_types: dataTypes,
     classification: level,
-    handling: HANDLING_REQUIREMENTS[level],
+    handling: HANDLING_REQUIREMENTS[level] ??
+      HANDLING_REQUIREMENTS.public ?? {
+        encryption_at_rest: false,
+        encryption_in_transit: false,
+        access_logging: false,
+        retention_policy: false,
+      },
     description: asset.description || '',
     classified_at: new Date().toISOString(),
   };

--- a/src/lib/dependency-upgrade.ts
+++ b/src/lib/dependency-upgrade.ts
@@ -266,6 +266,6 @@ export function generateReport(options: StateFileOption = {}): ReportResult {
     total_plans: state.upgrade_plans.length,
     total_scans: state.scans.length,
     plans: state.upgrade_plans,
-    last_scan: state.scans.length > 0 ? state.scans[state.scans.length - 1] : null,
+    last_scan: state.scans.length > 0 ? (state.scans[state.scans.length - 1] ?? null) : null,
   };
 }

--- a/src/lib/headless-runner.ts
+++ b/src/lib/headless-runner.ts
@@ -619,8 +619,8 @@ Be brief and supportive.`;
         }
 
         if (selected.length === 0) {
-          const rec = q.options.find((o) => o.recommended) || q.options[0];
-          selected = [rec.label];
+          const rec = q.options.find((o) => o.recommended) ?? q.options[0];
+          if (rec !== undefined) selected = [rec.label];
         }
 
         answers[q.header] = {

--- a/src/lib/persona-packs.ts
+++ b/src/lib/persona-packs.ts
@@ -112,12 +112,18 @@ export type ApplyPersonaResult = ApplyPersonaResultSuccess | ApplyPersonaResultF
 export function listPersonas(): ListPersonasResult {
   return {
     success: true,
-    personas: PERSONAS.map((p) => ({
-      id: p,
-      label: PERSONA_CATALOG[p].label,
-      focus_count: PERSONA_CATALOG[p].focus.length,
-      tools_count: PERSONA_CATALOG[p].tools.length,
-    })),
+    personas: PERSONAS.flatMap((p) => {
+      const entry = PERSONA_CATALOG[p];
+      if (entry === undefined) return [];
+      return [
+        {
+          id: p,
+          label: entry.label,
+          focus_count: entry.focus.length,
+          tools_count: entry.tools.length,
+        },
+      ];
+    }),
   };
 }
 

--- a/src/lib/project-memory.ts
+++ b/src/lib/project-memory.ts
@@ -286,7 +286,9 @@ export function deleteMemory(id: string, options: MemoryFileOptions = {}): Delet
   const [removed] = store.entries.splice(idx, 1);
   saveMemoryStore(store, memoryFile);
 
-  return { success: true, removed, total: store.entries.length };
+  const result: DeleteMemoryResult = { success: true, total: store.entries.length };
+  if (removed !== undefined) result.removed = removed;
+  return result;
 }
 
 /** Aggregated memory statistics grouped by type. */

--- a/src/lib/structured-elicitation.ts
+++ b/src/lib/structured-elicitation.ts
@@ -260,8 +260,9 @@ export function generateReport(sessionId: string, options: StateFileOption = {})
   const unanswered = session.questions.filter((q) => !q.answered);
   const byCategory: Record<string, Array<{ question: string; answer: string | null }>> = {};
   for (const q of answered) {
-    if (!byCategory[q.category]) byCategory[q.category] = [];
-    byCategory[q.category].push({ question: q.text, answer: q.answer });
+    const bucket = byCategory[q.category] ?? [];
+    bucket.push({ question: q.text, answer: q.answer });
+    byCategory[q.category] = bucket;
   }
 
   return {

--- a/tests/_helpers.ts
+++ b/tests/_helpers.ts
@@ -1,0 +1,11 @@
+/**
+ * tests/_helpers.ts — small test-only utilities.
+ */
+export function expectDefined<T>(
+  value: T | undefined | null,
+  message?: string
+): asserts value is NonNullable<T> {
+  if (value === undefined || value === null) {
+    throw new Error(message ?? `expected value to be defined, got: ${String(value)}`);
+  }
+}

--- a/tests/test-ambiguity-heatmap.test.ts
+++ b/tests/test-ambiguity-heatmap.test.ts
@@ -15,6 +15,7 @@ import {
   scanFile,
   VAGUE_TERMS,
 } from '../src/lib/ambiguity-heatmap.js';
+import { expectDefined } from './_helpers.js';
 
 let tmpDir: string;
 
@@ -59,6 +60,7 @@ describe('scanAmbiguity', () => {
     const r = scanAmbiguity('The system must be fast and secure.');
     const hits = r.findings?.filter((f) => f.type === 'missing_constraint') ?? [];
     expect(hits.length).toBeGreaterThan(0);
+    expectDefined(hits[0]);
     expect(hits[0].severity).toBe('high');
     expect(typeof hits[0].suggestion).toBe('string');
   });
@@ -106,6 +108,7 @@ describe('scanFile + generateHeatmap', () => {
     const r = generateHeatmap(tmpDir);
     expect(r.success).toBe(true);
     expect(r.files_scanned).toBe(2);
+    expectDefined(r.results[0]);
     expect(r.results[0].file).toBe('high.md');
     expect(r.overall.highest_density_file).toBe('high.md');
   });

--- a/tests/test-cli-dispatcher.test.ts
+++ b/tests/test-cli-dispatcher.test.ts
@@ -21,6 +21,7 @@ import versionTagCommand, {
 } from '../src/cli/commands/version-tag.js';
 import { type CliLogger, createRealDeps, createTestDeps } from '../src/cli/deps.js';
 import { main } from '../src/cli/main.js';
+import { expectDefined } from './_helpers.js';
 
 // ─────────────────────────────────────────────────────────────────────────
 // Deps seam
@@ -149,10 +150,10 @@ describe('src/cli/commands/version-tag.ts — seed command pure runImpl', () => 
       throw new Error('expected args definition on version-tag command');
     }
     const def = argsDef as Record<string, { type: string; required?: boolean }>;
-    expect(def['artifact-name']).toBeDefined();
+    expectDefined(def['artifact-name']);
     expect(def['artifact-name'].type).toBe('positional');
     expect(def['artifact-name'].required).toBe(true);
-    expect(def.version).toBeDefined();
+    expectDefined(def.version);
     expect(def.version.type).toBe('positional');
     expect(def.version.required).toBe(true);
   });

--- a/tests/test-codebase-intel-cluster.test.ts
+++ b/tests/test-codebase-intel-cluster.test.ts
@@ -54,6 +54,7 @@ import {
   validateRename,
 } from '../src/lib/safe-rename.js';
 import { detectTypeChecker, parseTypeErrors, runTypeCheck } from '../src/lib/type-checker.js';
+import { expectDefined } from './_helpers.js';
 
 let tmpRoot: string;
 
@@ -79,7 +80,9 @@ describe('ast-edit-engine', () => {
 
   it('SUPPORTED_LANGUAGES + STRUCTURE_PATTERNS catalog parity', () => {
     expect(SUPPORTED_LANGUAGES).toEqual(['javascript', 'typescript', 'json', 'yaml', 'markdown']);
+    expectDefined(STRUCTURE_PATTERNS.javascript);
     expect(STRUCTURE_PATTERNS.javascript.function_decl).toBeInstanceOf(RegExp);
+    expectDefined(STRUCTURE_PATTERNS.typescript);
     expect(STRUCTURE_PATTERNS.typescript.interface_decl).toBeInstanceOf(RegExp);
   });
 
@@ -135,10 +138,15 @@ describe('codebase-retrieval', () => {
 
     const r = indexProject(tmpRoot);
     expect(r.success).toBe(true);
+    expectDefined(r.index.adrs);
     expect(r.index.adrs.length).toBeGreaterThanOrEqual(1);
+    expectDefined(r.index.specs);
     expect(r.index.specs.length).toBeGreaterThanOrEqual(1);
+    expectDefined(r.index.implementations);
     expect(r.index.implementations.length).toBeGreaterThanOrEqual(1);
+    expectDefined(r.index.configs);
     expect(r.index.configs.length).toBeGreaterThanOrEqual(1);
+    expectDefined(r.index['test-patterns']);
     expect(r.index['test-patterns'].length).toBeGreaterThanOrEqual(1);
   });
 
@@ -371,6 +379,7 @@ describe('type-checker', () => {
       `src/main.py:20: error: Incompatible types  [assignment]\n`;
     const findings = parseTypeErrors(tsOut, 'TypeScript');
     expect(findings.length).toBeGreaterThanOrEqual(2);
+    expectDefined(findings[0]);
     expect(findings[0].code).toBe('TS2322');
     expect(findings[0].line).toBe(10);
   });

--- a/tests/test-collaboration-cluster.test.ts
+++ b/tests/test-collaboration-cluster.test.ts
@@ -30,6 +30,7 @@ import * as domainOnt from '../src/lib/domain-ontology.js';
 import * as eaReview from '../src/lib/ea-review-packet.js';
 import * as playback from '../src/lib/playback-summaries.js';
 import * as structElicit from '../src/lib/structured-elicitation.js';
+import { expectDefined } from './_helpers.js';
 
 let tmp: string;
 
@@ -81,6 +82,7 @@ describe('structured-elicitation', () => {
     const f = file('elicit.json');
     const start = structElicit.startElicitation('healthcare', { stateFile: f });
     expect(start.success).toBe(true);
+    expectDefined(start.session?.questions[0]);
     const qid = start.session?.questions[0].id || '';
     const a = structElicit.answerQuestion(start.session?.id || '', qid, 'yes', { stateFile: f });
     expect(a.success).toBe(true);
@@ -117,6 +119,7 @@ describe('contract-checker', () => {
     const md = `### Entity: User\n\n| \`id\` | string |\n| \`name\` | string |\n`;
     const ents = contractChk.extractModelEntities(md);
     expect(ents.length).toBe(1);
+    expectDefined(ents[0]);
     expect(ents[0].name).toBe('User');
   });
   it('validateContracts returns error for missing files', () => {
@@ -252,6 +255,7 @@ describe('dependency-upgrade', () => {
       { stateFile: file('upg.json') }
     );
     expect(ok.success).toBe(true);
+    expectDefined(ok.plan?.upgrades[0]);
     expect(ok.plan?.upgrades[0].risk).toBe('medium');
   });
   it('generateReport summarises plans and scans', () => {
@@ -343,6 +347,7 @@ describe('domain-ontology', () => {
     const r = domainOnt.generateReport({ stateFile: f });
     expect(r.success).toBe(true);
     expect(r.total_domains).toBe(1);
+    expectDefined(r.domains.orders);
     expect(r.domains.orders.by_type.aggregate).toBe(1);
   });
 });
@@ -369,7 +374,9 @@ describe('ea-review-packet', () => {
       '# Architecture\n## Overview\n```mermaid\nflowchart TD\n```\n'
     );
     const r = eaReview.generatePacket(tmp);
+    expectDefined(r.sections.diagrams);
     expect(r.sections.diagrams.present).toBe(true);
+    expectDefined(r.sections['architecture-overview']);
     expect(r.sections['architecture-overview'].present).toBe(true);
   });
   it('generatePacket counts ADR files in specs/decisions', () => {
@@ -379,6 +386,7 @@ describe('ea-review-packet', () => {
     writeFileSync(path.join(decDir, 'adr-002.md'), '# ADR 2\n');
     const r = eaReview.generatePacket(tmp);
     const ds = r.sections['decision-summary'];
+    expectDefined(ds);
     expect(ds.present).toBe(true);
     expect(ds.total_adrs).toBe(2);
   });

--- a/tests/test-config-loader.test.ts
+++ b/tests/test-config-loader.test.ts
@@ -20,6 +20,7 @@ import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ConfigLoaderInputSchema, deepMerge, loadConfig } from '../src/lib/config-loader.js';
+import { expectDefined } from './_helpers.js';
 
 let tmpRoot: string;
 
@@ -261,6 +262,7 @@ describe('runIpc(loadConfig, ConfigLoaderInputSchema) — e2e wiring (Pit Crew M
       /* exit spy throws — expected */
     });
     expect(exitCalls[0]).toBe(2);
+    expectDefined(stderr[0]);
     const env = JSON.parse(stderr[0]);
     expect(env.error.code).toBe('VALIDATION');
     expect(env.error.schemaId).toBe('runIpc.input');
@@ -301,6 +303,7 @@ describe('runIpc(loadConfig, ConfigLoaderInputSchema) — e2e wiring (Pit Crew M
       /* exit spy throws — expected */
     });
     expect(exitCalls[0]).toBe(0);
+    expectDefined(stdout[0]);
     const parsed = JSON.parse(stdout[0]);
     expect(parsed.ok).toBe(true);
     expect(parsed.config).toBeDefined();

--- a/tests/test-context-chunker.test.ts
+++ b/tests/test-context-chunker.test.ts
@@ -21,6 +21,7 @@ import {
   estimateTokens,
   MODEL_CONTEXT_LIMITS,
 } from '../src/lib/context-chunker.js';
+import { expectDefined } from './_helpers.js';
 
 let tmpDir: string;
 
@@ -42,8 +43,11 @@ describe('estimateTokens', () => {
 
 describe('MODEL_CONTEXT_LIMITS', () => {
   it('exports the canonical model budgets', () => {
+    expectDefined(MODEL_CONTEXT_LIMITS['gpt-4']);
     expect(MODEL_CONTEXT_LIMITS['gpt-4'].tokens).toBe(8192);
+    expectDefined(MODEL_CONTEXT_LIMITS['claude-3-opus']);
     expect(MODEL_CONTEXT_LIMITS['claude-3-opus'].tokens).toBe(200000);
+    expectDefined(MODEL_CONTEXT_LIMITS.default);
     expect(MODEL_CONTEXT_LIMITS.default.tokens).toBe(32000);
   });
 });
@@ -92,6 +96,7 @@ describe('chunkContent — v1.1.14 forward-progress invariants', () => {
   it('the last chunk ends at content.length (no truncation)', () => {
     const result = chunkContent('x'.repeat(10_000));
     const last = result.chunk_details[result.chunk_details.length - 1];
+    expectDefined(last);
     expect(last.end).toBe(10_000);
   });
 });
@@ -105,6 +110,7 @@ describe('chunkContent — natural-boundary preference', () => {
     const content = chunk1 + chunk2;
     const result = chunkContent(content, { max_tokens: 16 }); // 64 chars per chunk
     // First chunk should end at the newline (51) since 51 > 64 * 0.5.
+    expectDefined(result.chunk_details[0]);
     expect(result.chunk_details[0].end).toBe(51);
   });
 });

--- a/tests/test-diff.test.ts
+++ b/tests/test-diff.test.ts
@@ -10,6 +10,7 @@ import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { generateDiff, unifiedDiff } from '../src/lib/diff.js';
+import { expectDefined } from './_helpers.js';
 
 let tmpDir: string;
 
@@ -66,11 +67,13 @@ describe('generateDiff — create', () => {
     expect(result.summary.modified).toBe(0);
     expect(result.summary.deleted).toBe(0);
     expect(result.diffs).toHaveLength(1);
-    expect(result.diffs[0].diff).toContain('--- /dev/null');
-    expect(result.diffs[0].diff).toContain('+++ b/new.txt');
-    expect(result.diffs[0].diff).toContain('+one');
-    expect(result.diffs[0].diff).toContain('+two');
-    expect(result.diffs[0].diff).toContain('+three');
+    const [diff0] = result.diffs;
+    expectDefined(diff0);
+    expect(diff0.diff).toContain('--- /dev/null');
+    expect(diff0.diff).toContain('+++ b/new.txt');
+    expect(diff0.diff).toContain('+one');
+    expect(diff0.diff).toContain('+two');
+    expect(diff0.diff).toContain('+three');
   });
 
   it('handles empty content (1 line — the empty trailing string from split)', () => {
@@ -79,8 +82,10 @@ describe('generateDiff — create', () => {
       root: tmpDir,
     });
     expect(result.summary.lines_added).toBe(1);
-    if (result.diffs[0].type === 'create') {
-      expect(result.diffs[0].lines).toBe(1);
+    const [emptyDiff] = result.diffs;
+    expectDefined(emptyDiff);
+    if (emptyDiff.type === 'create') {
+      expect(emptyDiff.lines).toBe(1);
     }
   });
 });
@@ -92,8 +97,10 @@ describe('generateDiff — modify', () => {
       root: tmpDir,
     });
     expect(result.summary.modified).toBe(1);
-    expect(result.diffs[0].diff).toContain('-two');
-    expect(result.diffs[0].diff).toContain('+TWO');
+    const [modDiff0] = result.diffs;
+    expectDefined(modDiff0);
+    expect(modDiff0.diff).toContain('-two');
+    expect(modDiff0.diff).toContain('+TWO');
   });
 
   it('falls back to reading the current file content when change.old is absent', () => {
@@ -103,8 +110,10 @@ describe('generateDiff — modify', () => {
       changes: [{ type: 'modify', path: 'a.txt', new: 'on disk\nNEW' }],
       root: tmpDir,
     });
-    expect(result.diffs[0].diff).toContain('-old');
-    expect(result.diffs[0].diff).toContain('+NEW');
+    const [fbDiff0] = result.diffs;
+    expectDefined(fbDiff0);
+    expect(fbDiff0.diff).toContain('-old');
+    expect(fbDiff0.diff).toContain('+NEW');
   });
 
   it('counts net lines added/removed via Math.max(0, ...)', () => {
@@ -128,7 +137,9 @@ describe('generateDiff — modify', () => {
       changes: [{ type: 'modify', path: 'a.txt', old: 'old', content: 'new-via-content' }],
       root: tmpDir,
     });
-    expect(result.diffs[0].diff).toContain('+new-via-content');
+    const [cntDiff0] = result.diffs;
+    expectDefined(cntDiff0);
+    expect(cntDiff0.diff).toContain('+new-via-content');
   });
 });
 
@@ -142,11 +153,13 @@ describe('generateDiff — delete', () => {
     });
     expect(result.summary.deleted).toBe(1);
     expect(result.summary.lines_removed).toBe(3);
-    expect(result.diffs[0].diff).toContain('--- a/gone.txt');
-    expect(result.diffs[0].diff).toContain('+++ /dev/null');
-    expect(result.diffs[0].diff).toContain('-a');
-    expect(result.diffs[0].diff).toContain('-b');
-    expect(result.diffs[0].diff).toContain('-c');
+    const [delDiff0] = result.diffs;
+    expectDefined(delDiff0);
+    expect(delDiff0.diff).toContain('--- a/gone.txt');
+    expect(delDiff0.diff).toContain('+++ /dev/null');
+    expect(delDiff0.diff).toContain('-a');
+    expect(delDiff0.diff).toContain('-b');
+    expect(delDiff0.diff).toContain('-c');
   });
 
   it('handles deletion of a non-existent file gracefully', () => {
@@ -155,8 +168,10 @@ describe('generateDiff — delete', () => {
       root: tmpDir,
     });
     expect(result.summary.deleted).toBe(1);
-    if (result.diffs[0].type === 'delete') {
-      expect(result.diffs[0].lines).toBe(1); // empty string splits to one empty line
+    const [nonExistDiff] = result.diffs;
+    expectDefined(nonExistDiff);
+    if (nonExistDiff.type === 'delete') {
+      expect(nonExistDiff.lines).toBe(1); // empty string splits to one empty line
     }
   });
 });

--- a/tests/test-enterprise-search.test.ts
+++ b/tests/test-enterprise-search.test.ts
@@ -16,6 +16,7 @@ import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { indexProject, SEARCHABLE_TYPES, searchProject } from '../src/lib/enterprise-search.js';
+import { expectDefined } from './_helpers.js';
 
 let tmp: string;
 
@@ -100,6 +101,7 @@ describe('enterprise-search — indexProject', () => {
     const result = indexProject(tmp);
     const codeEntries = result.index.entries.filter((e) => e.type === 'code');
     expect(codeEntries.length).toBe(1);
+    expectDefined(codeEntries[0]);
     expect(codeEntries[0].path).toBe('src/real.ts');
   });
 
@@ -107,6 +109,7 @@ describe('enterprise-search — indexProject', () => {
     mkdirSync(path.join(tmp, 'specs'), { recursive: true });
     writeFileSync(path.join(tmp, 'specs', 'a.md'), 'hello', 'utf8');
     const result = indexProject(tmp);
+    expectDefined(result.index.entries[0]);
     expect(result.index.entries[0].size).toBe(5);
   });
 });
@@ -134,8 +137,10 @@ describe('enterprise-search — searchProject', () => {
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.total_results).toBe(1);
+      expectDefined(result.results[0]);
       expect(result.results[0].path).toBe('specs/prd.md');
       expect(result.results[0].preview.length).toBe(1);
+      expectDefined(result.results[0].preview[0]);
       expect(result.results[0].preview[0].text).toContain('rate-limiting');
     }
   });
@@ -152,6 +157,7 @@ describe('enterprise-search — searchProject', () => {
     writeFileSync(path.join(tmp, 'specs', 'a.md'), 'foo\nfoo\nfoo\nfoo\nfoo\n', 'utf8');
     const result = searchProject(tmp, 'foo');
     if (result.success) {
+      expectDefined(result.results[0]);
       expect(result.results[0].preview.length).toBe(3);
     }
   });

--- a/tests/test-event-modeling.test.ts
+++ b/tests/test-event-modeling.test.ts
@@ -27,6 +27,7 @@ import {
   PATTERNS,
   saveState,
 } from '../src/lib/event-modeling.js';
+import { expectDefined } from './_helpers.js';
 
 let tmpDir: string;
 let stateFile: string;
@@ -81,6 +82,7 @@ describe('event-modeling — loadState/saveState', () => {
     saveState(s, stateFile);
     const reloaded = loadState(stateFile);
     expect(reloaded.topics).toHaveLength(1);
+    expectDefined(reloaded.topics[0]);
     expect(reloaded.topics[0].name).toBe('orders');
   });
 
@@ -136,6 +138,7 @@ describe('event-modeling — defineTopic', () => {
     defineTopic('orders', { stateFile });
     const reloaded = loadState(stateFile);
     expect(reloaded.topics).toHaveLength(1);
+    expectDefined(reloaded.topics[0]);
     expect(reloaded.topics[0].name).toBe('orders');
   });
 });
@@ -182,7 +185,9 @@ describe('event-modeling — defineSaga', () => {
     expect(r.success).toBe(true);
     if (r.success) {
       expect(r.saga.steps).toHaveLength(3);
+      expectDefined(r.saga.steps[0]);
       expect(r.saga.steps[0].order).toBe(1);
+      expectDefined(r.saga.steps[2]);
       expect(r.saga.steps[2].order).toBe(3);
       expect(r.saga.compensation).toBe('manual'); // default
     }

--- a/tests/test-governance-cluster.test.ts
+++ b/tests/test-governance-cluster.test.ts
@@ -46,6 +46,7 @@ import * as roleAppr from '../src/lib/role-approval.js';
 import * as vendor from '../src/lib/vendor-risk.js';
 import * as waiver from '../src/lib/waiver-workflow.js';
 import * as wsOwn from '../src/lib/workstream-ownership.js';
+import { expectDefined } from './_helpers.js';
 
 let tmp: string;
 
@@ -132,6 +133,7 @@ describe('risk-register', () => {
       { stateFile: f }
     );
     const r = risk.generateReport({ stateFile: f });
+    expectDefined(r.top_risks[0]);
     expect(r.top_risks[0].score).toBe(25);
     expect(r.high_risks).toBe(1);
   });
@@ -239,6 +241,7 @@ describe('prompt-governance', () => {
     const ap = promptGov.approveVersion(id, '1.0.0', { stateFile: f, approver: 'me' });
     expect(ap.approved).toBe(true);
     const list = promptGov.listAssets({ stateFile: f });
+    expectDefined(list.assets[0]);
     expect(list.assets[0].latest_approved).toBe('1.0.0');
   });
   it('addVersion bumps current_version', () => {

--- a/tests/test-graph-cluster.test.ts
+++ b/tests/test-graph-cluster.test.ts
@@ -59,6 +59,7 @@ import {
   extractTasks,
   extractValidationCriteria,
 } from '../src/lib/traceability.js';
+import { expectDefined } from './_helpers.js';
 
 let tmpDir: string;
 
@@ -212,6 +213,7 @@ describe('graph — auditTaskDependencies', () => {
     const audit = auditTaskDependencies(graph);
     expect(audit.task_count).toBe(3);
     expect(audit.inversions.length).toBe(1);
+    expectDefined(audit.inversions[0]);
     expect(audit.inversions[0].task).toBe('M1-T02');
     expect(audit.has_issues).toBe(true);
   });
@@ -377,7 +379,7 @@ describe('bidirectional-trace — scanTraceLinks', () => {
     writeAt('tests/auth.test.ts', '// covers E1-S1\n');
     writeAt('specs/prd.md', 'NFR-P01 here\n');
     const tm = scanTraceLinks(tmpDir);
-    expect(tm.forward_map['E1-S1']).toBeDefined();
+    expectDefined(tm.forward_map['E1-S1']);
     expect(tm.forward_map['E1-S1'].length).toBeGreaterThanOrEqual(2);
     expect(tm.stats.total_spec_ids).toBeGreaterThan(0);
   });
@@ -519,10 +521,12 @@ describe('adr-index — buildIndex / searchIndex', () => {
 
     const byTag = searchIndex(tmpDir, { tag: 'postgres' });
     expect(byTag.total).toBe(1);
+    expectDefined(byTag.results[0]);
     expect(byTag.results[0].id).toBe('adr-001');
 
     const byStatus = searchIndex(tmpDir, { status: 'Proposed' });
     expect(byStatus.total).toBe(1);
+    expectDefined(byStatus.results[0]);
     expect(byStatus.results[0].id).toBe('adr-002');
 
     const byQuery = searchIndex(tmpDir, { query: 'database' });

--- a/tests/test-hashing.test.ts
+++ b/tests/test-hashing.test.ts
@@ -30,6 +30,7 @@ import {
   saveManifest,
   verifyAll,
 } from '../src/lib/hashing.js';
+import { expectDefined } from './_helpers.js';
 
 let tmpDir: string;
 
@@ -164,6 +165,7 @@ describe('registerArtifact — first time / unchanged / changed', () => {
 
     // Manifest persists the entry.
     const m = loadManifest(manifestPath);
+    expectDefined(m.artifacts['specs/spec.md']);
     expect(m.artifacts['specs/spec.md'].hash).toBe(result.hash);
     expect(m.artifacts['specs/spec.md'].size).toBe('first version'.length);
   });
@@ -218,6 +220,7 @@ describe('verifyAll — clean / tampered / missing', () => {
     const result = verifyAll(manifestPath, tmpDir);
     expect(result.verified).toBe(0);
     expect(result.tampered).toHaveLength(1);
+    expectDefined(result.tampered[0]);
     expect(result.tampered[0].path).toBe('a.md');
     expect(result.tampered[0].expectedHash).toBe(expectedHash);
     expect(result.tampered[0].actualHash).toBe(hashContent('tampered'));

--- a/tests/test-install-output-byte-identical.test.ts
+++ b/tests/test-install-output-byte-identical.test.ts
@@ -33,6 +33,7 @@ import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { _extractZipSafely_TEST_ONLY } from '../src/lib/install.js';
+import { expectDefined } from './_helpers.js';
 
 const FIXTURES_DIR = path.join(__dirname, 'fixtures', 'zipslip');
 const LEGITIMATE_ZIP = path.join(FIXTURES_DIR, 'legitimate.zip');
@@ -128,9 +129,13 @@ describe('T4.5.4 — byte-identical install-output regression', () => {
 
     expect(snapA.length).toBe(snapB.length);
     for (let i = 0; i < snapA.length; i++) {
-      expect(snapA[i].relPath).toBe(snapB[i].relPath);
+      const entryA = snapA[i];
+      const entryB = snapB[i];
+      expectDefined(entryA);
+      expectDefined(entryB);
+      expect(entryA.relPath).toBe(entryB.relPath);
       // Buffer.equals: byte-identical comparison.
-      expect(snapA[i].bytes.equals(snapB[i].bytes)).toBe(true);
+      expect(entryA.bytes.equals(entryB.bytes)).toBe(true);
     }
   });
 

--- a/tests/test-install.test.ts
+++ b/tests/test-install.test.ts
@@ -51,6 +51,7 @@ import {
   uninstallItem,
   writeInstalled,
 } from '../src/lib/install.js';
+import { expectDefined } from './_helpers.js';
 
 // Type-narrowing helpers — the install module is in transit so we re-import
 // the private extractor by reading the file. Instead of cracking it open
@@ -302,6 +303,7 @@ describe('searchItems', () => {
 
   it('scores exact matches higher', () => {
     const results = searchItems(MOCK_INDEX, 'Ignition');
+    expectDefined(results[0]);
     expect(results[0].id).toBe('skill.ignition');
   });
 
@@ -388,6 +390,7 @@ describe('install tracking', () => {
       },
     });
     const read = readInstalled(tmp);
+    expectDefined(read.items['skill.test']);
     expect(read.items['skill.test'].version).toBe('1.0.0');
     expect(read.items['skill.test'].remappedFiles).toEqual(['.github/agents/test.agent.md']);
   });
@@ -484,6 +487,7 @@ describe('readInstalled shape validation', () => {
 describe('resolveTargetPaths', () => {
   it('uses explicit targetPaths from item', () => {
     const item = MOCK_INDEX.items[0];
+    expectDefined(item);
     expect(resolveTargetPaths(item)).toEqual(['.jumpstart/skills/ignition']);
   });
 
@@ -608,6 +612,7 @@ describe('getStatus', () => {
     });
     const status = getStatus(tmp);
     expect(status.count).toBe(2);
+    expectDefined(status.items['skill.a']);
     expect(status.items['skill.a'].version).toBe('1.0.0');
   });
 });
@@ -626,6 +631,7 @@ describe('checkUpdates', () => {
     });
     const { updates } = checkUpdates(tmp, MOCK_INDEX);
     expect(updates.length).toBe(1);
+    expectDefined(updates[0]);
     expect(updates[0].id).toBe('skill.ignition');
     expect(updates[0].localVersion).toBe('0.9.0');
     expect(updates[0].registryVersion).toBe('1.0.0');

--- a/tests/test-io.test.ts
+++ b/tests/test-io.test.ts
@@ -21,6 +21,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { JumpstartError } from '../src/lib/errors.js';
 import { parseToolArgs, readStdin, wrapTool, writeError, writeResult } from '../src/lib/io.js';
+import { expectDefined } from './_helpers.js';
 
 interface CapturedIO {
   stdout: string[];
@@ -67,6 +68,7 @@ describe('writeResult — byte-identical envelope vs legacy bin/lib/io.js', () =
     const { stdout } = captureIO();
     writeResult({ x: 1, y: 'two' });
     expect(stdout).toHaveLength(1);
+    expectDefined(stdout[0]);
     const line = stdout[0];
     expect(line.endsWith('\n')).toBe(true);
     const parsed = JSON.parse(line);
@@ -82,6 +84,7 @@ describe('writeResult — byte-identical envelope vs legacy bin/lib/io.js', () =
   it('honors pretty=true by indenting with 2 spaces', () => {
     const { stdout } = captureIO();
     writeResult({ x: 1 }, { pretty: true });
+    expectDefined(stdout[0]);
     expect(stdout[0]).toContain('\n  "ok": true,');
     expect(stdout[0].endsWith('}\n')).toBe(true);
   });
@@ -91,6 +94,7 @@ describe('writeResult — byte-identical envelope vs legacy bin/lib/io.js', () =
     // Spreading after ok+timestamp means caller fields override —
     // matches legacy `{ ok: true, timestamp: ..., ...result }`.
     writeResult({ ok: false } as Record<string, unknown>);
+    expectDefined(stdout[0]);
     const parsed = JSON.parse(stdout[0]);
     expect(parsed.ok).toBe(false);
   });
@@ -102,6 +106,7 @@ describe('writeError — byte-identical envelope vs legacy bin/lib/io.js', () =>
     writeError('VALIDATION', 'bad input', { field: 'root' });
     expect(stdout).toHaveLength(0);
     expect(stderr).toHaveLength(1);
+    expectDefined(stderr[0]);
     const parsed = JSON.parse(stderr[0]);
     expect(parsed.ok).toBe(false);
     expect(typeof parsed.timestamp).toBe('string');
@@ -111,6 +116,7 @@ describe('writeError — byte-identical envelope vs legacy bin/lib/io.js', () =>
   it('terminates with a single newline (not two, not zero)', () => {
     const { stderr } = captureIO();
     writeError('X', 'y');
+    expectDefined(stderr[0]);
     expect(stderr[0].endsWith('\n')).toBe(true);
     expect(stderr[0].endsWith('\n\n')).toBe(false);
   });
@@ -203,6 +209,7 @@ describe('wrapTool — error contract divergence vs legacy', () => {
     }));
     setTTY(true);
     await tool({ name: 'Samuel' });
+    expectDefined(stdout[0]);
     const parsed = JSON.parse(stdout[0]);
     expect(parsed.ok).toBe(true);
     expect(parsed.greeting).toBe('hi Samuel');
@@ -222,6 +229,7 @@ describe('wrapTool — error contract divergence vs legacy', () => {
     await expect(tool({})).rejects.toBeInstanceOf(JumpstartError);
     expect(stdout).toHaveLength(0);
     expect(stderr).toHaveLength(1);
+    expectDefined(stderr[0]);
     const parsed = JSON.parse(stderr[0]);
     expect(parsed.ok).toBe(false);
     expect(parsed.error.code).toBe('TOOL_ERROR');
@@ -261,6 +269,7 @@ describe('wrapTool — error contract divergence vs legacy', () => {
       throw 'string-boom';
     });
     await expect(tool({})).rejects.toBeInstanceOf(JumpstartError);
+    expectDefined(stderr[0]);
     const parsed = JSON.parse(stderr[0]);
     expect(parsed.error.message).toBe('string-boom');
   });
@@ -297,6 +306,7 @@ describe('writeError — Adv-9 envelope shadow guard', () => {
     });
     // Pre-fix: details.code='OK' shadowed code='REAL_FAILURE'.
     writeError('REAL_FAILURE', 'real msg', { code: 'OK', message: 'wrong', extra: 'kept' });
+    expectDefined(stderr[0]);
     const parsed = JSON.parse(stderr[0]);
     expect(parsed.error.code).toBe('REAL_FAILURE');
     expect(parsed.error.message).toBe('real msg');

--- a/tests/test-ipc.test.ts
+++ b/tests/test-ipc.test.ts
@@ -18,6 +18,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { JumpstartError, ValidationError } from '../src/lib/errors.js';
 import { isDirectRun, runIpc } from '../src/lib/ipc.js';
+import { expectDefined } from './_helpers.js';
 
 const ORIGINAL_IS_TTY = process.stdin.isTTY;
 
@@ -84,7 +85,7 @@ describe('isDirectRun', () => {
   });
 
   it('returns false when argv[1] is undefined', () => {
-    const original = process.argv[1];
+    const original = process.argv[1] ?? '';
     process.argv[1] = '';
     try {
       expect(isDirectRun('file:///anything.ts')).toBe(false);
@@ -108,6 +109,7 @@ describe('runIpc — v0 envelope (no version field)', () => {
     });
 
     expect(exitCalls).toEqual([{ code: 0 }]);
+    expectDefined(stdout[0]);
     const parsed = JSON.parse(stdout[0]);
     expect(parsed.ok).toBe(true);
     expect(parsed.doubled).toBe(42);
@@ -124,6 +126,7 @@ describe('runIpc — v0 envelope (no version field)', () => {
     await p.catch(() => {
       /* exit spy throws — expected */
     });
+    expectDefined(exitCalls[0]);
     expect(exitCalls[0].code).toBe(0);
   });
 });
@@ -142,7 +145,9 @@ describe('runIpc — v1 envelope', () => {
       /* exit spy throws — expected */
     });
 
+    expectDefined(exitCalls[0]);
     expect(exitCalls[0].code).toBe(0);
+    expectDefined(stdout[0]);
     const parsed = JSON.parse(stdout[0]);
     expect(parsed.ok).toBe(true);
     expect(parsed.version).toBe(1);
@@ -162,7 +167,9 @@ describe('runIpc — typed-error → exit-code translation (ADR-006)', () => {
     await p.catch(() => {
       /* exit spy throws — expected */
     });
+    expectDefined(exitCalls[0]);
     expect(exitCalls[0].code).toBe(2);
+    expectDefined(stderr[0]);
     const parsed = JSON.parse(stderr[0]);
     expect(parsed.error.code).toBe('VALIDATION');
     expect(parsed.error.message).toBe('bad input');
@@ -179,6 +186,7 @@ describe('runIpc — typed-error → exit-code translation (ADR-006)', () => {
     await p.catch(() => {
       /* exit spy throws — expected */
     });
+    expectDefined(exitCalls[0]);
     expect(exitCalls[0].code).toBe(99);
   });
 
@@ -196,6 +204,7 @@ describe('runIpc — typed-error → exit-code translation (ADR-006)', () => {
     await p.catch(() => {
       /* exit spy throws — expected */
     });
+    expectDefined(exitCalls[0]);
     expect(exitCalls[0].code).toBe(7);
   });
 
@@ -210,7 +219,9 @@ describe('runIpc — typed-error → exit-code translation (ADR-006)', () => {
     await p.catch(() => {
       /* exit spy throws — expected */
     });
+    expectDefined(exitCalls[0]);
     expect(exitCalls[0].code).toBe(99);
+    expectDefined(stderr[0]);
     const parsed = JSON.parse(stderr[0]);
     expect(parsed.error.message).toBe('plain js error');
   });
@@ -229,6 +240,7 @@ describe('runIpc — envelope byte order (Pit Crew M2-Final QA F2)', () => {
     // Streaming-JSON consumers and grep-on-leading-bytes pipelines
     // depend on this prefix. toEqual is key-order-insensitive so
     // string-prefix is the right assertion.
+    expectDefined(stdout[0]);
     expect(stdout[0].startsWith('{"version":1,"ok":true,')).toBe(true);
   });
 
@@ -241,6 +253,7 @@ describe('runIpc — envelope byte order (Pit Crew M2-Final QA F2)', () => {
     await p.catch(() => {
       /* exit spy throws — expected */
     });
+    expectDefined(stdout[0]);
     expect(stdout[0].startsWith('{"ok":true,')).toBe(true);
     expect(stdout[0]).not.toContain('"version"');
   });
@@ -256,6 +269,7 @@ describe('runIpc — handler return-value edge cases (F4)', () => {
     await p.catch(() => {
       /* exit spy throws — expected */
     });
+    expectDefined(stdout[0]);
     const parsed = JSON.parse(stdout[0]);
     expect(parsed.result).toBeNull();
     expect(parsed.ok).toBe(true);
@@ -270,6 +284,7 @@ describe('runIpc — handler return-value edge cases (F4)', () => {
     await p.catch(() => {
       /* exit spy throws — expected */
     });
+    expectDefined(stdout[0]);
     const parsed = JSON.parse(stdout[0]);
     expect(parsed.result).toBe('hello');
   });
@@ -283,6 +298,7 @@ describe('runIpc — handler return-value edge cases (F4)', () => {
     await p.catch(() => {
       /* exit spy throws — expected */
     });
+    expectDefined(stdout[0]);
     const parsed = JSON.parse(stdout[0]);
     expect(parsed.version).toBe(1);
     expect(parsed.result).toBeNull();
@@ -300,6 +316,7 @@ describe('runIpc — multi-chunk stdin + post-end error (F5)', () => {
     await p.catch(() => {
       /* exit spy throws — expected */
     });
+    expectDefined(stdout[0]);
     expect(JSON.parse(stdout[0]).doubled).toBe(42);
   });
 });
@@ -314,6 +331,7 @@ describe('runIpc — v1 envelope edge cases (F9)', () => {
     await p.catch(() => {
       /* exit spy throws — expected */
     });
+    expectDefined(stdout[0]);
     const parsed = JSON.parse(stdout[0]);
     expect(parsed.version).toBeUndefined();
     // v0 semantics: whole payload (incl. string "1" version + input) is the input.
@@ -330,7 +348,9 @@ describe('runIpc — v1 envelope edge cases (F9)', () => {
     await p.catch(() => {
       /* exit spy throws — expected */
     });
+    expectDefined(exitCalls[0]);
     expect(exitCalls[0].code).toBe(2);
+    expectDefined(stderr[0]);
     expect(JSON.parse(stderr[0]).error.code).toBe('VALIDATION');
   });
 });
@@ -346,7 +366,9 @@ describe('runIpc — Zod schema validation', () => {
     await p.catch(() => {
       /* exit spy throws — expected */
     });
+    expectDefined(exitCalls[0]);
     expect(exitCalls[0].code).toBe(2);
+    expectDefined(stderr[0]);
     const parsed = JSON.parse(stderr[0]);
     expect(parsed.error.code).toBe('VALIDATION');
     expect(Array.isArray(parsed.error.issues)).toBe(true);
@@ -367,8 +389,10 @@ describe('runIpc — Zod schema validation', () => {
     await p.catch(() => {
       /* exit spy throws — expected */
     });
+    expectDefined(exitCalls[0]);
     expect(exitCalls[0].code).toBe(0);
     expect(receivedCount).toBe(42);
+    expectDefined(stdout[0]);
     const parsed = JSON.parse(stdout[0]);
     expect(parsed.received).toBe(42);
   });

--- a/tests/test-leaf-parity.test.ts
+++ b/tests/test-leaf-parity.test.ts
@@ -100,7 +100,7 @@ describe('diff — TS↔JS parity (no fs reads)', () => {
     const tsModule = await import('../src/lib/diff.js');
     // @ts-expect-error legacy JS, no .d.ts (parity test imports raw runtime export — see tests/test-leaf-parity.test.ts header)
     const jsModule = (await import('../bin/lib/diff.mjs')) as any;
-    const cases = [
+    const cases: [string, string, string][] = [
       ['', '', 'empty.txt'],
       ['a\nb\nc', 'a\nB\nc', 'mid-edit.txt'],
       ['x\ny\nz', 'x\ny\nz', 'unchanged.txt'],
@@ -172,6 +172,7 @@ describe('artifact-comparison — TS↔JS parity', () => {
       ['# A\nthing\n## B\ngone', '# A\nthing'],
     ];
     for (const [a, b] of cases) {
+      if (a === undefined || b === undefined) continue;
       // The legacy returns changes in insertion order from a Set
       // iteration; compare as sets to avoid order-dependence.
       const ts = tsModule.compareArtifacts(a, b);
@@ -256,6 +257,7 @@ describe('versioning — TS↔JS parity (git-free)', () => {
       ['challenger-brief', '0.0.1-rc.1'],
     ];
     for (const [name, ver] of cases) {
+      if (name === undefined || ver === undefined) continue;
       expect(tsModule.generateTag(name, ver)).toBe(jsModule.generateTag(name, ver));
     }
   });

--- a/tests/test-llm-cluster.test.ts
+++ b/tests/test-llm-cluster.test.ts
@@ -40,6 +40,7 @@ import {
   TASK_TYPES,
 } from '../src/lib/model-router.js';
 import { logUsage, summarizeUsage } from '../src/lib/usage.js';
+import { expectDefined } from './_helpers.js';
 
 let tmpDir: string;
 
@@ -59,6 +60,7 @@ describe('mock-responses — createMockRegistry', () => {
   it('returns canned defaults for known headers', () => {
     const reg = createMockRegistry();
     const r = reg.getAskQuestionsResponse({ questions: [{ header: 'TechPrefs' }] });
+    expectDefined(r.answers.TechPrefs);
     expect(r.answers.TechPrefs.selected).toEqual(['Node.js with Express']);
   });
   it('falls back to recommended option when header unknown', () => {
@@ -71,11 +73,13 @@ describe('mock-responses — createMockRegistry', () => {
         },
       ],
     });
+    expectDefined(r.answers.UnknownHeader);
     expect(r.answers.UnknownHeader.selected).toEqual(['B']);
   });
   it('falls back to "Approved" when no options exist', () => {
     const reg = createMockRegistry();
     const r = reg.getAskQuestionsResponse({ questions: [{ header: 'Bare' }] });
+    expectDefined(r.answers.Bare);
     expect(r.answers.Bare.freeText).toBe('Approved');
   });
   it('honors setAskQuestionsResponse override', () => {
@@ -86,6 +90,7 @@ describe('mock-responses — createMockRegistry', () => {
       skipped: false,
     });
     const r = reg.getAskQuestionsResponse({ questions: [{ header: 'TechPrefs' }] });
+    expectDefined(r.answers.TechPrefs);
     expect(r.answers.TechPrefs.selected).toEqual(['Custom']);
   });
   it('tracks call count', () => {
@@ -102,12 +107,15 @@ describe('mock-responses — createPersonaRegistry', () => {
     const r = reg.getAskQuestionsResponse({
       questions: [{ header: 'TechPrefs' }, { header: 'Database' }],
     });
+    expectDefined(r.answers.TechPrefs);
     expect(r.answers.TechPrefs.selected).toEqual(['Java with Spring Boot']);
+    expectDefined(r.answers.Database);
     expect(r.answers.Database.selected).toEqual(['Oracle']);
   });
   it('unknown persona falls through to defaults', () => {
     const reg = createPersonaRegistry('does-not-exist');
     const r = reg.getAskQuestionsResponse({ questions: [{ header: 'TechPrefs' }] });
+    expectDefined(r.answers.TechPrefs);
     expect(r.answers.TechPrefs.selected).toEqual(['Node.js with Express']);
   });
 });
@@ -257,6 +265,7 @@ describe('llm-provider — mock provider', () => {
     const p = createProvider({ mode: 'mock', model: 'openai/gpt-4o' });
     expect(p.mode).toBe('mock');
     const r = await p.completion([{ role: 'user', content: 'hi' }]);
+    expectDefined(r.choices[0]);
     expect(r.choices[0].message.content).toContain('mock');
     expect(p.getUsage().calls).toBe(1);
     expect(p.getUsage().totalTokens).toBeGreaterThan(0);
@@ -271,6 +280,7 @@ describe('llm-provider — mock provider', () => {
     };
     const p = createProvider({ mode: 'mock', mockResponses: customReg });
     const r = await p.completion([{ role: 'user', content: 'hi' }]);
+    expectDefined(r.choices[0]);
     expect(r.choices[0].message.content).toBe('CUSTOM');
   });
 });
@@ -304,6 +314,7 @@ describe('usage — logUsage round-trip', () => {
     });
     const summary = summarizeUsage(log);
     expect(summary.total_sessions).toBe(1);
+    expectDefined(summary.by_agent.Architect);
     expect(summary.by_agent.Architect.tokens).toBe(5000);
   });
 });

--- a/tests/test-locks.test.ts
+++ b/tests/test-locks.test.ts
@@ -31,7 +31,11 @@ function singleLockFilename(): string {
   if (files.length !== 1) {
     throw new Error(`expected 1 lock file in ${locksDir}, got ${files.length}`);
   }
-  return files[0];
+  const [name] = files;
+  if (name === undefined) {
+    throw new Error(`unexpected empty filename in ${locksDir}`);
+  }
+  return name;
 }
 
 describe('acquireLock', () => {

--- a/tests/test-m4-pitcrew-regressions.test.ts
+++ b/tests/test-m4-pitcrew-regressions.test.ts
@@ -230,7 +230,8 @@ describe('Pit Crew M4 Reviewer H3 (HIGH) — restoreCheckpoint preserves null re
     // Manually clear the checkpoint's resume_context
     const s = loadState(statePath);
     const cps = s.checkpoints || [];
-    cps[cps.length - 1].resume_context = null;
+    const last = cps[cps.length - 1];
+    if (last !== undefined) last.resume_context = null;
     writeFileSync(statePath, `${JSON.stringify(s, null, 2)}\n`, 'utf8');
     restoreCheckpoint(cp.id, statePath);
     const after = loadState(statePath);

--- a/tests/test-m7-pitcrew-regressions.test.ts
+++ b/tests/test-m7-pitcrew-regressions.test.ts
@@ -21,6 +21,7 @@ import { runRegressionSuite } from '../src/lib/regression.js';
 import { SimulationTracer } from '../src/lib/simulation-tracer.js';
 import { runBuild } from '../src/lib/smoke-tester.js';
 import { createToolBridge } from '../src/lib/tool-bridge.js';
+import { expectDefined } from './_helpers.js';
 
 let tmpDir: string;
 
@@ -41,6 +42,7 @@ describe('Pit Crew M7 BLOCKER 1 — context7-setup ClientConfig replaces cliComm
   it('CLIENT_CONFIGS["claude-code"] uses cliArgv (argv array) not cliCommand (shell string)', async () => {
     const mod = await import('../src/lib/context7-setup.js');
     const claudeCode = mod.CLIENT_CONFIGS['claude-code'];
+    expectDefined(claudeCode);
     expect(claudeCode.cliArgv).toBeDefined();
     expect(typeof claudeCode.cliArgv).toBe('function');
     // The legacy cliCommand field MUST be gone — keeping it would let
@@ -52,6 +54,7 @@ describe('Pit Crew M7 BLOCKER 1 — context7-setup ClientConfig replaces cliComm
   it('cliArgv produces a malicious-key-safe argv (apiKey is one element, not interpolated)', async () => {
     const mod = await import('../src/lib/context7-setup.js');
     const claudeCode = mod.CLIENT_CONFIGS['claude-code'];
+    expectDefined(claudeCode);
     const maliciousKey = 'ctx7sk-trailing-shell-metachars';
     const argv = claudeCode.cliArgv?.(maliciousKey) ?? [];
     // The key is the LAST element of the argv array — never a substring
@@ -229,6 +232,7 @@ describe('Pit Crew M7 HIGH — regression.runRegressionSuite no longer false-pos
       actualGenerator: () => '## Section A\n\nbody\n',
     });
     expect(r.results.length).toBe(1);
+    expectDefined(r.results[0]);
     expect(r.results[0].similarity).toBe(100);
     expect(r.results[0].pass).toBe(true);
   });
@@ -245,6 +249,7 @@ describe('Pit Crew M7 HIGH — regression.runRegressionSuite no longer false-pos
       threshold: 90,
     });
     expect(r.results.length).toBe(1);
+    expectDefined(r.results[0]);
     expect(r.results[0].pass).toBe(false);
     expect(r.results[0].similarity).toBeLessThan(90);
   });

--- a/tests/test-marketplace-leaves.test.ts
+++ b/tests/test-marketplace-leaves.test.ts
@@ -22,6 +22,7 @@ import { writeFrameworkManifest } from '../src/lib/framework-manifest.js';
 import * as integrate from '../src/lib/integrate.js';
 import * as registry from '../src/lib/registry.js';
 import * as upgrade from '../src/lib/upgrade.js';
+import { expectDefined } from './_helpers.js';
 
 // ─────────────────────────────────────────────────────────────────────────
 // Test scaffolding
@@ -141,6 +142,7 @@ describe('integrate.scanInstalledSkills', () => {
     );
     const skills = integrate.scanInstalledSkills(tmp);
     expect(skills.length).toBe(1);
+    expectDefined(skills[0]);
     expect(skills[0].id).toBe('skill.my-skill');
     expect(skills[0].displayName).toBe('My Demo Skill');
     expect(skills[0].version).toBe('1.2.3');
@@ -662,6 +664,7 @@ describe('upgrade.listUpgradeBackups', () => {
     );
     const backups = upgrade.listUpgradeBackups(tmp);
     expect(backups.length).toBe(1);
+    expectDefined(backups[0]);
     expect(backups[0].fromVersion).toBe('1.0.0');
     expect(backups[0].toVersion).toBe('2.0.0');
   });

--- a/tests/test-migration-planner.test.ts
+++ b/tests/test-migration-planner.test.ts
@@ -27,6 +27,7 @@ import {
   MIGRATION_STRATEGIES,
   saveState,
 } from '../src/lib/migration-planner.js';
+import { expectDefined } from './_helpers.js';
 
 let tmpDir: string;
 let stateFile: string;
@@ -96,7 +97,9 @@ describe('migration-planner — loadState/saveState', () => {
     saveState(s, stateFile);
     const reloaded = loadState(stateFile);
     expect(reloaded.migrations).toHaveLength(1);
-    expect(reloaded.migrations[0].id).toBe('MIG-001');
+    const [first] = reloaded.migrations;
+    expectDefined(first);
+    expect(first.id).toBe('MIG-001');
     expect(reloaded.last_updated).not.toBeNull();
   });
 
@@ -169,7 +172,9 @@ describe('migration-planner — advancePhase', () => {
     if (r.success) {
       expect(r.phase).toBe('planning');
     }
-    expect(loadState(stateFile).migrations[0].current_phase).toBe('planning');
+    const [migration] = loadState(stateFile).migrations;
+    expectDefined(migration);
+    expect(migration.current_phase).toBe('planning');
   });
 
   it('rejects unknown phase', () => {

--- a/tests/test-pattern-library.test.ts
+++ b/tests/test-pattern-library.test.ts
@@ -25,6 +25,7 @@ import {
   saveState,
   searchPatterns,
 } from '../src/lib/pattern-library.js';
+import { expectDefined } from './_helpers.js';
 
 let tmp: string;
 let stateFile: string;
@@ -157,7 +158,9 @@ describe('pattern-library — searchPatterns', () => {
     registerPattern('jwt', 'auth', { stateFile });
     const r = searchPatterns('Rate', { stateFile });
     expect(r.total).toBe(1);
-    expect(r.patterns[0].name).toBe('rate-limiter');
+    const [first] = r.patterns;
+    expectDefined(first);
+    expect(first.name).toBe('rate-limiter');
   });
 
   it('matches by tag', () => {

--- a/tests/test-persona-packs.test.ts
+++ b/tests/test-persona-packs.test.ts
@@ -18,6 +18,7 @@ import {
   PERSONA_CATALOG,
   PERSONAS,
 } from '../src/lib/persona-packs.js';
+import { expectDefined } from './_helpers.js';
 
 describe('persona-packs — PERSONAS catalog', () => {
   it('exposes the 7 documented personas', () => {
@@ -34,6 +35,7 @@ describe('persona-packs — PERSONAS catalog', () => {
   it('PERSONA_CATALOG[id] always carries label, focus, artifacts, tools', () => {
     for (const id of PERSONAS) {
       const entry = PERSONA_CATALOG[id];
+      expectDefined(entry);
       expect(entry.label).toBeTypeOf('string');
       expect(Array.isArray(entry.focus)).toBe(true);
       expect(Array.isArray(entry.artifacts)).toBe(true);
@@ -42,6 +44,7 @@ describe('persona-packs — PERSONAS catalog', () => {
   });
 
   it('architect entry matches legacy contents', () => {
+    expectDefined(PERSONA_CATALOG.architect);
     expect(PERSONA_CATALOG.architect.label).toBe('Architect');
     expect(PERSONA_CATALOG.architect.focus).toEqual([
       'system-design',
@@ -72,6 +75,7 @@ describe('persona-packs — listPersonas', () => {
   it('focus_count matches actual focus array length', () => {
     const result = listPersonas();
     const ba = result.personas.find((p) => p.id === 'business-analyst');
+    expectDefined(PERSONA_CATALOG['business-analyst']);
     expect(ba?.focus_count).toBe(PERSONA_CATALOG['business-analyst'].focus.length);
   });
 });

--- a/tests/test-platform-engineering.test.ts
+++ b/tests/test-platform-engineering.test.ts
@@ -26,6 +26,7 @@ import {
   saveState,
   TEMPLATE_TYPES,
 } from '../src/lib/platform-engineering.js';
+import { expectDefined } from './_helpers.js';
 
 let tmp: string;
 let stateFile: string;
@@ -156,7 +157,9 @@ describe('platform-engineering — listTemplates', () => {
     registerTemplate('b', 'frontend', { stateFile });
     const r = listTemplates({ stateFile, type: 'service' });
     expect(r.total).toBe(1);
-    expect(r.templates[0].name).toBe('a');
+    const [first] = r.templates;
+    expectDefined(first);
+    expect(first.name).toBe('a');
   });
 
   it('returns 0 when no templates registered', () => {

--- a/tests/test-runners.test.ts
+++ b/tests/test-runners.test.ts
@@ -28,6 +28,7 @@ import * as handoffValidator from '../src/lib/handoff-validator.js';
 import { AGENT_PHASES, DEFAULT_CONFIG } from '../src/lib/headless-runner.js';
 import * as holodeck from '../src/lib/holodeck.js';
 import { SimulationTracer } from '../src/lib/simulation-tracer.js';
+import { expectDefined } from './_helpers.js';
 
 const REPO_ROOT = path.resolve(__dirname, '..');
 const HANDOFFS_DIR = path.join(REPO_ROOT, '.jumpstart', 'handoffs');
@@ -123,7 +124,9 @@ describe('handoff-validator — public surface', () => {
     ) as handoffValidator.PmToArchitectPayload;
     expect(Array.isArray(payload.user_stories)).toBe(true);
     expect(payload.user_stories.length).toBeGreaterThan(0);
-    expect(payload.user_stories[0].id).toMatch(/^E\d+-S\d+$/);
+    const [story] = payload.user_stories;
+    expectDefined(story);
+    expect(story.id).toMatch(/^E\d+-S\d+$/);
   });
 
   it('extractHandoffPayload throws for missing artifact', () => {

--- a/tests/test-secret-scanner.test.ts
+++ b/tests/test-secret-scanner.test.ts
@@ -26,6 +26,7 @@ import {
   scanForSecrets,
   shouldSkip,
 } from '../src/lib/secret-scanner.js';
+import { expectDefined } from './_helpers.js';
 
 // Test fixtures: realistic-looking but obviously-fake secrets so they
 // trip the patterns without ever being a real key.
@@ -85,7 +86,9 @@ describe('compileCustomPatterns', () => {
       { name: 'X', pattern: 'CUSTOM_[A-Z]+', severity: 'high' },
     ]);
     expect(compiled).toHaveLength(1);
-    expect(compiled[0].pattern).toBeInstanceOf(RegExp);
+    const [first] = compiled;
+    expectDefined(first);
+    expect(first.pattern).toBeInstanceOf(RegExp);
   });
   it('drops invalid regex', () => {
     expect(compileCustomPatterns([{ pattern: '[unclosed' }])).toEqual([]);

--- a/tests/test-secrets-redaction-e2e.test.ts
+++ b/tests/test-secrets-redaction-e2e.test.ts
@@ -146,7 +146,8 @@ describe('ADR-012 e2e Scenario C — nested auth.token redacts in timeline', () 
     tl.flush();
 
     const data = loadTimeline(tlPath);
-    const ev = data.events[0];
+    const [ev] = data.events;
+    if (ev === undefined) throw new Error('expected timeline event');
     const meta = ev.metadata as { auth?: { token?: string } } | undefined;
     expect(meta?.auth?.token).toContain('[REDACTED:GitHub Token]');
     expect(meta?.auth?.token).not.toContain(FAKE_GH_TOKEN);
@@ -218,7 +219,7 @@ describe('ADR-012 e2e summary — usage.summarizeUsage on a redacted log', () =>
     const summary = summarizeUsage(usageLog);
     expect(summary.total_sessions).toBe(2);
     expect(summary.total_tokens).toBe(500);
-    expect(summary.by_agent.PM.tokens).toBe(500);
+    expect(summary.by_agent.PM?.tokens).toBe(500);
   });
 });
 

--- a/tests/test-slash-command-contract.test.ts
+++ b/tests/test-slash-command-contract.test.ts
@@ -62,7 +62,7 @@ const SUB_AGENTS_ALLOWLIST = new Set<string>([
 function extractAgentReferences(content: string): Set<string> {
   const refs = new Set<string>();
   for (const m of content.matchAll(/\.jumpstart\/agents\/([\w-]+\.md)/g)) {
-    refs.add(m[1]);
+    if (m[1] !== undefined) refs.add(m[1]);
   }
   return refs;
 }

--- a/tests/test-state-cluster.test.ts
+++ b/tests/test-state-cluster.test.ts
@@ -53,6 +53,7 @@ import {
   saveState,
   updateState,
 } from '../src/lib/state-store.js';
+import { expectDefined } from './_helpers.js';
 
 let tmpRoot: string;
 let statePath: string;
@@ -90,7 +91,9 @@ describe('state-store — load/save/update', () => {
     const s = loadState(statePath);
     expect(s.current_phase).toBe(1);
     expect(s.phase_history.length).toBe(1);
-    expect(s.phase_history[0].phase).toBe(0);
+    const [first] = s.phase_history;
+    expectDefined(first);
+    expect(first.phase).toBe(0);
   });
   it('updateState dedupes approved_artifacts', () => {
     updateState({ approved_artifact: 'specs/prd.md' }, statePath);
@@ -117,7 +120,9 @@ describe('state-store — checkpoints', () => {
     createCheckpoint('first', { statePath });
     createCheckpoint('second', { statePath });
     const list = listCheckpoints(statePath);
-    expect(list[0].label).toBe('second');
+    const [first] = list;
+    expectDefined(first);
+    expect(first.label).toBe('second');
   });
   it('restoreCheckpoint restores phase + step + agent', () => {
     updateState({ phase: 0, agent: 'challenger' }, statePath);

--- a/tests/test-testing-cluster.test.ts
+++ b/tests/test-testing-cluster.test.ts
@@ -38,6 +38,7 @@ import * as smokeTester from '../src/lib/smoke-tester.js';
 import { createToolBridge } from '../src/lib/tool-bridge.js';
 import { getToolByName, getToolsForPhase } from '../src/lib/tool-schemas.js';
 import * as verifyDiagrams from '../src/lib/verify-diagrams.js';
+import { expectDefined } from './_helpers.js';
 
 let tmp: string;
 beforeEach(() => {
@@ -146,6 +147,7 @@ describe('simulation-tracer — public surface', () => {
     t.endPhase('scout', 'PASS');
     const r = t.getReport();
     expect(Array.isArray(r.phases)).toBe(true);
+    expectDefined(r.phases[0]);
     expect(r.phases[0].name).toBe('scout');
     expect(r.phases[0].status).toBe('PASS');
   });
@@ -342,7 +344,9 @@ describe('verify-diagrams — public surface', () => {
     ].join('\n');
     const blocks = verifyDiagrams.extractMermaidBlocks(content);
     expect(blocks).toHaveLength(2);
+    expectDefined(blocks[0]);
     expect(blocks[0].body).toContain('graph TD');
+    expectDefined(blocks[1]);
     expect(blocks[1].body).toContain('sequenceDiagram');
   });
 
@@ -350,6 +354,7 @@ describe('verify-diagrams — public surface', () => {
     const content = '```mermaid\ngraph TD\nA --> B\n';
     const blocks = verifyDiagrams.extractMermaidBlocks(content);
     expect(blocks).toHaveLength(1);
+    expectDefined(blocks[0]);
     expect(blocks[0].unclosed).toBe(true);
   });
 
@@ -360,6 +365,7 @@ describe('verify-diagrams — public surface', () => {
       body: 'graph TD\nA --> B',
       unclosed: true,
     });
+    expectDefined(issues[0]);
     expect(issues[0].level).toBe('error');
     expect(issues[0].message).toMatch(/Unclosed/);
   });

--- a/tests/test-timestamps.test.ts
+++ b/tests/test-timestamps.test.ts
@@ -15,6 +15,7 @@ import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { audit, ISO_UTC_REGEX, now, validate } from '../src/lib/timestamps.js';
+import { expectDefined } from './_helpers.js';
 
 let tmpDir: string;
 
@@ -148,6 +149,7 @@ describe('audit() — body Timestamp lines', () => {
     expect(r.entries).toBe(2);
     expect(r.valid).toBe(1);
     expect(r.invalid).toHaveLength(1);
+    expectDefined(r.invalid[0]);
     expect(r.invalid[0].line).toBe(6);
     expect(r.invalid[0].value).toBe('not-a-date');
     expect(r.invalid[0].error).toContain('Invalid ISO 8601 UTC format');
@@ -190,6 +192,7 @@ describe('audit() — frontmatter date fields', () => {
     expect(r.entries).toBe(3);
     expect(r.valid).toBe(2);
     expect(r.invalid).toHaveLength(1);
+    expectDefined(r.invalid[0]);
     expect(r.invalid[0].field).toBe('updated');
     expect(r.invalid[0].value).toBe('not-a-date');
   });

--- a/tests/test-ux-cluster.test.ts
+++ b/tests/test-ux-cluster.test.ts
@@ -42,6 +42,7 @@ import { answerStep, getWizardStatus, startWizard, WIZARDS } from '../src/lib/pr
 import { generateRoleSummary, generateView, listRoles, ROLES } from '../src/lib/role-views.js';
 import { createTimeline, EVENT_TYPES, loadTimeline, queryTimeline } from '../src/lib/timeline.js';
 import { captureInsight, startSession, WORKSHOP_TYPES } from '../src/lib/workshop-mode.js';
+import { expectDefined } from './_helpers.js';
 
 let tmpRoot: string;
 
@@ -85,6 +86,7 @@ describe('dashboard — findClarifications', () => {
     writeAt('specs/prd.md', '# PRD\n\n[NEEDS CLARIFICATION: define MVP scope]\n');
     const r = findClarifications(path.join(tmpRoot, 'specs'));
     expect(r.length).toBeGreaterThanOrEqual(1);
+    expectDefined(r[0]);
     expect(r[0].file).toContain('prd.md');
   });
 });
@@ -146,6 +148,7 @@ describe('timeline — createTimeline + recordEvent + persist', () => {
     expect(existsSync(tlPath)).toBe(true);
     const data = loadTimeline(tlPath);
     expect(data.events.length).toBe(1);
+    expectDefined(data.events[0]);
     expect(data.events[0].event_type).toBe('phase_start');
   });
 });
@@ -179,6 +182,7 @@ describe('timeline — ADR-012 redaction wiring', () => {
     });
     tl.flush();
     const data = loadTimeline(tlPath);
+    expectDefined(data.events[0]);
     expect(data.events[0].metadata).toMatchObject({ step: 'init', count: 3 });
   });
 });
@@ -298,6 +302,7 @@ describe('role-views — ROLES + generateView', () => {
   });
   it('generateView returns a result for a known role', () => {
     writeAt('specs/prd.md', '# PRD\n');
+    expectDefined(ROLES[0]);
     const view = generateView(tmpRoot, ROLES[0]);
     expect(view).toBeDefined();
   });
@@ -319,11 +324,13 @@ describe('promptless-mode — WIZARDS + startWizard', () => {
   });
   it('startWizard returns initial state', () => {
     const file = path.join(tmpRoot, 'wizard.json');
+    expectDefined(WIZARDS[0]);
     const r = startWizard(WIZARDS[0], { stateFile: file });
     expect(r).toBeDefined();
   });
   it('answerStep returns a result envelope', () => {
     const file = path.join(tmpRoot, 'wizard.json');
+    expectDefined(WIZARDS[0]);
     startWizard(WIZARDS[0], { stateFile: file });
     const r = answerStep(WIZARDS[0], 'an answer', { stateFile: file });
     expect(r).toBeDefined();

--- a/tests/test-zod-codegen.test.ts
+++ b/tests/test-zod-codegen.test.ts
@@ -61,7 +61,7 @@ describe('zod-codegen pipeline', () => {
     for (const stem of stems) {
       const pascal = stem
         .split(/[-_]/)
-        .map((p) => (p.length === 0 ? '' : p[0].toUpperCase() + p.slice(1)))
+        .map((p) => (p.length === 0 ? '' : (p[0] ?? '').toUpperCase() + p.slice(1)))
         .join('');
       expect(idx[`${pascal}Schema`]).toBeDefined();
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "noImplicitThis": true,
     "alwaysStrict": true,
     "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
 
     "esModuleInterop": true,
     "isolatedModules": true,


### PR DESCRIPTION
## Summary
- **Closes #31**: enables `noUncheckedIndexedAccess: true` permanently, landing the final flag of the strict-TS ratchet
- Consolidates phase 2h (tests cluster) and phase 3 (final flag-flip) — the testing-infra ratchet (PR #46) had already cleared the src/ side to 0 errors, leaving only tests + 8 small src defensive fixes that all batch into one PR
- 42 files changed, 262 insertions, 55 deletions

## What changed
- `tsconfig.json` flips `noUncheckedIndexedAccess: true` ON
- New `tests/_helpers.ts` with `expectDefined<T>(value): asserts value is NonNullable<T>` so tests narrow index access without `!` non-null assertions (biome-forbidden)
- 35 test files use the destructure-and-assert pattern at every flagged access site
- 8 src files get small defensive fences (RISK_TIERS lookup, roleFocus chain, HANDLING_REQUIREMENTS narrow, tail-record fallback, recommended option fallback, persona flatMap, conditional DeleteMemoryResult build, byCategory bucket upsert)

## Why this is safe
- Pure defensive refactor — no public-API change, no behavior change for well-formed inputs
- Every fence is on a previously-implicit invariant that the surrounding code already assumed
- All 3680 vitest tests pass
- Zero TypeScript errors with BOTH `exactOptionalPropertyTypes` AND `noUncheckedIndexedAccess` ON

## Verification
- [x] `npx tsc --noEmit` → 0 errors
- [x] `npm run verify-baseline` → 12/12 gates green
- [x] `npm run lint` (biome) → 0 errors, 0 warnings
- [x] All 3680 tests pass
- [ ] CI green on PR

Closes #31