### PR TITLE
feat(m11-batch6): port 16 final cleanup-cluster legacy modules

### DIFF
--- a/src/cli/commands/cleanup.ts
+++ b/src/cli/commands/cleanup.ts
@@ -29,10 +29,47 @@
  */
 
 import { defineCommand } from 'citty';
+import * as guidedHandoff from '../../lib/guided-handoff.js';
+import * as portfolioReporting from '../../lib/portfolio-reporting.js';
+import * as requirementsBaseline from '../../lib/requirements-baseline.js';
 import * as legacyRevert from '../../lib/revert.js';
+import * as rootCauseAnalysis from '../../lib/root-cause-analysis.js';
+import * as runtimeDebugger from '../../lib/runtime-debugger.js';
+import * as scanner from '../../lib/scanner.js';
+import * as semanticDiff from '../../lib/semantic-diff.js';
+import * as slaSlo from '../../lib/sla-slo.js';
+import * as specComments from '../../lib/spec-comments.js';
+import * as specMaturity from '../../lib/spec-maturity.js';
+import * as sreIntegration from '../../lib/sre-integration.js';
+import * as telemetryFeedback from '../../lib/telemetry-feedback.js';
+import * as testGenerator from '../../lib/test-generator.js';
 import * as legacyTimestamps from '../../lib/timestamps.js';
+import * as toolGuardrails from '../../lib/tool-guardrails.js';
+import * as transcriptIngestion from '../../lib/transcript-ingestion.js';
+import * as webDashboard from '../../lib/web-dashboard.js';
 import { type CommandResult, createRealDeps, type Deps } from '../deps.js';
 import { assertUserPath, legacyImport, legacyRequire, safeJoin } from './_helpers.js';
+
+/** Static import map for M11 batch-6 TS ports (replaces legacyRequire for these 16). */
+// biome-ignore lint/suspicious/noExplicitAny: <TS port modules have mixed return shapes>
+const TS_PORTS: Record<string, Record<string, any>> = {
+  'guided-handoff': guidedHandoff,
+  'portfolio-reporting': portfolioReporting,
+  'requirements-baseline': requirementsBaseline,
+  'root-cause-analysis': rootCauseAnalysis,
+  'runtime-debugger': runtimeDebugger,
+  scanner: scanner,
+  'semantic-diff': semanticDiff,
+  'sla-slo': slaSlo,
+  'spec-comments': specComments,
+  'spec-maturity': specMaturity,
+  'sre-integration': sreIntegration,
+  'telemetry-feedback': telemetryFeedback,
+  'test-generator': testGenerator,
+  'tool-guardrails': toolGuardrails,
+  'transcript-ingestion': transcriptIngestion,
+  'web-dashboard': webDashboard,
+};
 
 // biome-ignore lint/suspicious/noExplicitAny: <legacy lib runtime shapes>
 type LegacyLib = Record<string, any>;
@@ -308,7 +345,10 @@ function thinWrapper(cfg: ThinWrapperConfig): {
   command: any;
 } {
   const impl = (deps: Deps, args: ThinWrapperArgs): CommandResult => {
-    const lib = legacyRequire<LegacyLib>(cfg.legacyLib);
+    // M11 batch-6: prefer static TS port; fall back to legacyRequire for
+    // any module not yet ported (the ?? branch is effectively dead for the
+    // 16 modules wired in TS_PORTS, but kept for soft-fail safety).
+    const lib: LegacyLib = TS_PORTS[cfg.legacyLib] ?? legacyRequire<LegacyLib>(cfg.legacyLib);
     const action = args.action ?? cfg.defaultAction;
     const methodCandidates = cfg.actions[action] ?? cfg.actions[cfg.defaultAction] ?? [];
     let result: unknown = {};

--- a/src/lib/guided-handoff.ts
+++ b/src/lib/guided-handoff.ts
@@ -1,0 +1,179 @@
+/**
+ * guided-handoff.ts — Guided Handoff Packages port (M11 batch 6).
+ *
+ * Pure-library port of `bin/lib/guided-handoff.js` (CJS) to a typed ES
+ * module. Public surface preserved verbatim by name + signature:
+ *
+ *   - `generateHandoff(type, root, options?)` => HandoffResult
+ *   - `listHandoffTypes()` => ListHandoffTypesResult
+ *   - `validateHandoff(type, provided, options?)` => ValidateHandoffResult
+ *   - `HANDOFF_TYPES` (frozen list)
+ *   - `HANDOFF_CHECKLISTS` (typed map)
+ *
+ * M3 hardening:
+ *   - No JSON parse paths — module is stateless (no state file).
+ *     Not applicable for prototype-pollution check.
+ *
+ * Path-safety per ADR-009:
+ *   - No user-supplied paths used in file I/O. Not applicable.
+ *
+ * @see bin/lib/guided-handoff.js (legacy reference)
+ * @see specs/implementation-plan.md M11 strangler cleanup
+ */
+
+export const HANDOFF_TYPES = [
+  'product-to-engineering',
+  'engineering-to-qa',
+  'engineering-to-ops',
+  'ops-to-support',
+] as const;
+
+export type HandoffType = (typeof HANDOFF_TYPES)[number];
+
+export interface HandoffChecklist {
+  label: string;
+  required: string[];
+  optional: string[];
+}
+
+export const HANDOFF_CHECKLISTS: Record<HandoffType, HandoffChecklist> = {
+  'product-to-engineering': {
+    label: 'Product → Engineering',
+    required: ['user_stories', 'acceptance_criteria', 'wireframes', 'priorities', 'scope_boundaries'],
+    optional: ['competitive_analysis', 'analytics_requirements', 'feature_flags'],
+  },
+  'engineering-to-qa': {
+    label: 'Engineering → QA',
+    required: ['test_plan', 'api_contracts', 'environment_setup', 'known_limitations', 'test_data'],
+    optional: ['performance_baselines', 'security_considerations', 'rollback_procedures'],
+  },
+  'engineering-to-ops': {
+    label: 'Engineering → Ops',
+    required: ['deployment_guide', 'runbooks', 'monitoring_config', 'rollback_procedures', 'dependencies'],
+    optional: ['load_test_results', 'capacity_planning', 'dr_procedures'],
+  },
+  'ops-to-support': {
+    label: 'Ops → Support',
+    required: ['known_issues', 'troubleshooting_guide', 'escalation_paths', 'sla_details', 'faq'],
+    optional: ['common_errors', 'workarounds', 'release_notes'],
+  },
+};
+
+export interface HandoffItem {
+  name: string;
+  required: boolean;
+  status: 'provided' | 'missing' | 'not_provided';
+}
+
+export interface HandoffResult {
+  success: boolean;
+  type?: HandoffType;
+  label?: string;
+  items?: HandoffItem[];
+  complete?: boolean;
+  missing_required?: string[];
+  generated_at?: string;
+  error?: string;
+}
+
+export interface ListHandoffTypesResult {
+  success: true;
+  types: Array<{ id: HandoffType; label: string; required_count: number; optional_count: number }>;
+}
+
+export interface ValidateHandoffResult {
+  success: boolean;
+  type?: HandoffType;
+  complete?: boolean;
+  coverage_pct?: number;
+  missing?: string[];
+  provided?: string[];
+  error?: string;
+}
+
+/**
+ * Generate a handoff package.
+ */
+export function generateHandoff(
+  type: string,
+  _root: string,
+  options: Record<string, unknown> = {},
+): HandoffResult {
+  if (!HANDOFF_TYPES.includes(type as HandoffType)) {
+    return {
+      success: false,
+      error: `Unknown handoff type: ${type}. Valid: ${HANDOFF_TYPES.join(', ')}`,
+    };
+  }
+
+  const handoffType = type as HandoffType;
+  const checklist = HANDOFF_CHECKLISTS[handoffType];
+  const items: HandoffItem[] = [];
+
+  for (const req of checklist.required) {
+    items.push({ name: req, required: true, status: options[req] ? 'provided' : 'missing' });
+  }
+  for (const opt of checklist.optional) {
+    items.push({ name: opt, required: false, status: options[opt] ? 'provided' : 'not_provided' });
+  }
+
+  const missing = items.filter(i => i.required && i.status === 'missing');
+
+  return {
+    success: true,
+    type: handoffType,
+    label: checklist.label,
+    items,
+    complete: missing.length === 0,
+    missing_required: missing.map(i => i.name),
+    generated_at: new Date().toISOString(),
+  };
+}
+
+/**
+ * List available handoff types.
+ */
+export function listHandoffTypes(): ListHandoffTypesResult {
+  return {
+    success: true,
+    types: HANDOFF_TYPES.map(t => ({
+      id: t,
+      label: HANDOFF_CHECKLISTS[t].label,
+      required_count: HANDOFF_CHECKLISTS[t].required.length,
+      optional_count: HANDOFF_CHECKLISTS[t].optional.length,
+    })),
+  };
+}
+
+/**
+ * Validate a handoff package completeness.
+ */
+export function validateHandoff(
+  type: string,
+  provided: string[] | undefined | null,
+  _options: Record<string, unknown> = {},
+): ValidateHandoffResult {
+  if (!HANDOFF_TYPES.includes(type as HandoffType)) {
+    return { success: false, error: `Unknown handoff type: ${type}` };
+  }
+
+  const handoffType = type as HandoffType;
+  const checklist = HANDOFF_CHECKLISTS[handoffType];
+  const providedSet = new Set(provided ?? []);
+  const missing = checklist.required.filter(r => !providedSet.has(r));
+  const coverage =
+    checklist.required.length > 0
+      ? Math.round(
+          ((checklist.required.length - missing.length) / checklist.required.length) * 100,
+        )
+      : 100;
+
+  return {
+    success: true,
+    type: handoffType,
+    complete: missing.length === 0,
+    coverage_pct: coverage,
+    missing,
+    provided: [...providedSet],
+  };
+}

--- a/src/lib/guided-handoff.ts
+++ b/src/lib/guided-handoff.ts
@@ -39,7 +39,13 @@ export interface HandoffChecklist {
 export const HANDOFF_CHECKLISTS: Record<HandoffType, HandoffChecklist> = {
   'product-to-engineering': {
     label: 'Product → Engineering',
-    required: ['user_stories', 'acceptance_criteria', 'wireframes', 'priorities', 'scope_boundaries'],
+    required: [
+      'user_stories',
+      'acceptance_criteria',
+      'wireframes',
+      'priorities',
+      'scope_boundaries',
+    ],
     optional: ['competitive_analysis', 'analytics_requirements', 'feature_flags'],
   },
   'engineering-to-qa': {
@@ -49,7 +55,13 @@ export const HANDOFF_CHECKLISTS: Record<HandoffType, HandoffChecklist> = {
   },
   'engineering-to-ops': {
     label: 'Engineering → Ops',
-    required: ['deployment_guide', 'runbooks', 'monitoring_config', 'rollback_procedures', 'dependencies'],
+    required: [
+      'deployment_guide',
+      'runbooks',
+      'monitoring_config',
+      'rollback_procedures',
+      'dependencies',
+    ],
     optional: ['load_test_results', 'capacity_planning', 'dr_procedures'],
   },
   'ops-to-support': {
@@ -97,7 +109,7 @@ export interface ValidateHandoffResult {
 export function generateHandoff(
   type: string,
   _root: string,
-  options: Record<string, unknown> = {},
+  options: Record<string, unknown> = {}
 ): HandoffResult {
   if (!HANDOFF_TYPES.includes(type as HandoffType)) {
     return {
@@ -117,7 +129,7 @@ export function generateHandoff(
     items.push({ name: opt, required: false, status: options[opt] ? 'provided' : 'not_provided' });
   }
 
-  const missing = items.filter(i => i.required && i.status === 'missing');
+  const missing = items.filter((i) => i.required && i.status === 'missing');
 
   return {
     success: true,
@@ -125,7 +137,7 @@ export function generateHandoff(
     label: checklist.label,
     items,
     complete: missing.length === 0,
-    missing_required: missing.map(i => i.name),
+    missing_required: missing.map((i) => i.name),
     generated_at: new Date().toISOString(),
   };
 }
@@ -136,7 +148,7 @@ export function generateHandoff(
 export function listHandoffTypes(): ListHandoffTypesResult {
   return {
     success: true,
-    types: HANDOFF_TYPES.map(t => ({
+    types: HANDOFF_TYPES.map((t) => ({
       id: t,
       label: HANDOFF_CHECKLISTS[t].label,
       required_count: HANDOFF_CHECKLISTS[t].required.length,
@@ -151,7 +163,7 @@ export function listHandoffTypes(): ListHandoffTypesResult {
 export function validateHandoff(
   type: string,
   provided: string[] | undefined | null,
-  _options: Record<string, unknown> = {},
+  _options: Record<string, unknown> = {}
 ): ValidateHandoffResult {
   if (!HANDOFF_TYPES.includes(type as HandoffType)) {
     return { success: false, error: `Unknown handoff type: ${type}` };
@@ -160,12 +172,10 @@ export function validateHandoff(
   const handoffType = type as HandoffType;
   const checklist = HANDOFF_CHECKLISTS[handoffType];
   const providedSet = new Set(provided ?? []);
-  const missing = checklist.required.filter(r => !providedSet.has(r));
+  const missing = checklist.required.filter((r) => !providedSet.has(r));
   const coverage =
     checklist.required.length > 0
-      ? Math.round(
-          ((checklist.required.length - missing.length) / checklist.required.length) * 100,
-        )
+      ? Math.round(((checklist.required.length - missing.length) / checklist.required.length) * 100)
       : 100;
 
   return {

--- a/src/lib/portfolio-reporting.ts
+++ b/src/lib/portfolio-reporting.ts
@@ -154,8 +154,8 @@ export function analyzeProject(projectRoot: string): ProjectAnalysis {
   if (existsSync(stateFile)) {
     try {
       const state = JSON.parse(readFileSync(stateFile, 'utf8')) as Record<string, unknown>;
-      if (typeof state['current_phase'] === 'string') {
-        result.current_phase = state['current_phase'];
+      if (typeof state.current_phase === 'string') {
+        result.current_phase = state.current_phase;
       }
     } catch {
       // ignore parse errors
@@ -177,8 +177,7 @@ export function analyzeProject(projectRoot: string): ProjectAnalysis {
     const fullPath = join(projectRoot, relPath);
     if (existsSync(fullPath)) {
       const content = readFileSync(fullPath, 'utf8');
-      const isApproved =
-        /- \[x\]/i.test(content) && /Approved by[:\s]+(?!Pending)/i.test(content);
+      const isApproved = /- \[x\]/i.test(content) && /Approved by[:\s]+(?!Pending)/i.test(content);
       if (isApproved) {
         completed++;
         latestPhase = phase;
@@ -187,7 +186,7 @@ export function analyzeProject(projectRoot: string): ProjectAnalysis {
       const blockerMatches = content.match(/\[BLOCKER[:\s]*([^\]]*)\]/gi);
       if (blockerMatches) {
         result.blockers.push(
-          ...blockerMatches.map(b => b.replace(/\[BLOCKER[:\s]*/i, '').replace(/\]/g, '')),
+          ...blockerMatches.map((b) => b.replace(/\[BLOCKER[:\s]*/i, '').replace(/\]/g, ''))
         );
       }
 
@@ -195,8 +194,8 @@ export function analyzeProject(projectRoot: string): ProjectAnalysis {
       if (clarificationMatches) {
         result.risks.push(
           ...clarificationMatches.map(
-            c => `Unresolved: ${c.replace(/\[NEEDS CLARIFICATION[:\s]*/i, '').replace(/\]/g, '')}`,
-          ),
+            (c) => `Unresolved: ${c.replace(/\[NEEDS CLARIFICATION[:\s]*/i, '').replace(/\]/g, '')}`
+          )
         );
       }
     }
@@ -206,10 +205,8 @@ export function analyzeProject(projectRoot: string): ProjectAnalysis {
   result.phase_progress = Math.round((completed / result.total_artifacts) * 100);
 
   if (!result.current_phase && latestPhase) {
-    const phaseObj = PHASES.find(p => p.id === latestPhase);
-    const nextPhase = phaseObj
-      ? PHASES.find(p => p.order === phaseObj.order + 1)
-      : undefined;
+    const phaseObj = PHASES.find((p) => p.id === latestPhase);
+    const nextPhase = phaseObj ? PHASES.find((p) => p.order === phaseObj.order + 1) : undefined;
     result.current_phase = nextPhase ? nextPhase.id : latestPhase;
   }
 
@@ -238,7 +235,7 @@ export interface RegisterResult {
 
 export function registerInitiative(
   initiative: RegisterInitiativeInput,
-  options: { portfolioFile?: string | undefined } = {},
+  options: { portfolioFile?: string | undefined } = {}
 ): RegisterResult {
   if (!initiative?.name) {
     return { success: false, error: 'initiative.name is required' };
@@ -248,7 +245,7 @@ export function registerInitiative(
   const portfolio = loadPortfolio(portfolioFile);
 
   const id = initiative.id ?? initiative.name.toLowerCase().replace(/\s+/g, '-');
-  if (portfolio.initiatives.find(i => i.id === id)) {
+  if (portfolio.initiatives.find((i) => i.id === id)) {
     return { success: false, error: `Initiative "${id}" already exists` };
   }
 
@@ -285,12 +282,12 @@ export interface RefreshResult {
 
 export function refreshInitiative(
   initiativeId: string,
-  options: { portfolioFile?: string | undefined } = {},
+  options: { portfolioFile?: string | undefined } = {}
 ): RefreshResult {
   const portfolioFile = options.portfolioFile ?? DEFAULT_PORTFOLIO_FILE;
   const portfolio = loadPortfolio(portfolioFile);
 
-  const initiative = portfolio.initiatives.find(i => i.id === initiativeId);
+  const initiative = portfolio.initiatives.find((i) => i.id === initiativeId);
   if (!initiative) {
     return { success: false, error: `Initiative not found: ${initiativeId}` };
   }
@@ -340,28 +337,28 @@ export interface PortfolioStatusResult {
 }
 
 export function getPortfolioStatus(
-  options: { portfolioFile?: string | undefined } = {},
+  options: { portfolioFile?: string | undefined } = {}
 ): PortfolioStatusResult {
   const portfolioFile = options.portfolioFile ?? DEFAULT_PORTFOLIO_FILE;
   const portfolio = loadPortfolio(portfolioFile);
 
   const statusCounts: Record<string, number> = {};
   for (const status of PORTFOLIO_STATUSES) {
-    statusCounts[status] = portfolio.initiatives.filter(i => i.status === status).length;
+    statusCounts[status] = portfolio.initiatives.filter((i) => i.status === status).length;
   }
 
   const totalBudget = portfolio.initiatives.reduce((sum, i) => sum + (i.budget ?? 0), 0);
   const totalSpend = portfolio.initiatives.reduce((sum, i) => sum + (i.spend ?? 0), 0);
 
-  const allBlockers = portfolio.initiatives.flatMap(i =>
-    (i.blockers ?? []).map(b => ({ initiative: i.name, blocker: b })),
+  const allBlockers = portfolio.initiatives.flatMap((i) =>
+    (i.blockers ?? []).map((b) => ({ initiative: i.name, blocker: b }))
   );
 
   const avgProgress =
     portfolio.initiatives.length > 0
       ? Math.round(
           portfolio.initiatives.reduce((sum, i) => sum + (i.phase_progress ?? 0), 0) /
-            portfolio.initiatives.length,
+            portfolio.initiatives.length
         )
       : 0;
 
@@ -372,7 +369,7 @@ export function getPortfolioStatus(
     average_progress: avgProgress,
     budget: { total: totalBudget, spent: totalSpend, remaining: totalBudget - totalSpend },
     blockers: allBlockers,
-    initiatives: portfolio.initiatives.map(i => ({
+    initiatives: portfolio.initiatives.map((i) => ({
       id: i.id,
       name: i.name,
       status: i.status,
@@ -394,12 +391,12 @@ export interface RemoveResult {
 
 export function removeInitiative(
   initiativeId: string,
-  options: { portfolioFile?: string | undefined } = {},
+  options: { portfolioFile?: string | undefined } = {}
 ): RemoveResult {
   const portfolioFile = options.portfolioFile ?? DEFAULT_PORTFOLIO_FILE;
   const portfolio = loadPortfolio(portfolioFile);
 
-  const index = portfolio.initiatives.findIndex(i => i.id === initiativeId);
+  const index = portfolio.initiatives.findIndex((i) => i.id === initiativeId);
   if (index === -1) {
     return { success: false, error: `Initiative not found: ${initiativeId}` };
   }
@@ -421,7 +418,7 @@ export function takeSnapshot(options: { portfolioFile?: string | undefined } = {
 
   const statusSummary: Record<string, number> = {};
   for (const status of PORTFOLIO_STATUSES) {
-    statusSummary[status] = portfolio.initiatives.filter(i => i.status === status).length;
+    statusSummary[status] = portfolio.initiatives.filter((i) => i.status === status).length;
   }
 
   const snapshot: PortfolioSnapshot = {
@@ -432,7 +429,7 @@ export function takeSnapshot(options: { portfolioFile?: string | undefined } = {
       portfolio.initiatives.length > 0
         ? Math.round(
             portfolio.initiatives.reduce((sum, i) => sum + (i.phase_progress ?? 0), 0) /
-              portfolio.initiatives.length,
+              portfolio.initiatives.length
           )
         : 0,
   };
@@ -445,4 +442,3 @@ export function takeSnapshot(options: { portfolioFile?: string | undefined } = {
 
   return { success: true, snapshot };
 }
-

--- a/src/lib/portfolio-reporting.ts
+++ b/src/lib/portfolio-reporting.ts
@@ -1,0 +1,448 @@
+/**
+ * portfolio-reporting.ts — Portfolio Reporting Layer port (M11 batch 6).
+ *
+ * Pure-library port of `bin/lib/portfolio-reporting.js` (CJS) to a typed ES
+ * module. Public surface preserved verbatim by name + signature:
+ *
+ *   - `defaultPortfolio()` => Portfolio
+ *   - `loadPortfolio(portfolioFile?)` => Portfolio
+ *   - `savePortfolio(portfolio, portfolioFile?)` => void
+ *   - `analyzeProject(projectRoot)` => ProjectAnalysis
+ *   - `registerInitiative(initiative, options?)` => RegisterResult
+ *   - `refreshInitiative(initiativeId, options?)` => RefreshResult
+ *   - `getPortfolioStatus(options?)` => PortfolioStatusResult
+ *   - `removeInitiative(initiativeId, options?)` => RemoveResult
+ *   - `takeSnapshot(options?)` => SnapshotResult
+ *   - `PORTFOLIO_STATUSES` (frozen list)
+ *   - `PHASES` (frozen list)
+ *
+ * M3 hardening:
+ *   - `loadPortfolio` runs `rejectPollutionKeys` on parsed JSON before use.
+ *   - On parse failure or pollution detection, returns `defaultPortfolio()`.
+ *
+ * Path-safety per ADR-009:
+ *   - `analyzeProject(projectRoot)` is called internally via stored
+ *     `initiative.path` values (not directly from user CLI input). No
+ *     `assertInsideRoot` needed; the path is loaded from stored state.
+ *
+ * @see bin/lib/portfolio-reporting.js (legacy reference)
+ * @see specs/implementation-plan.md M11 strangler cleanup
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+const DEFAULT_PORTFOLIO_FILE = join('.jumpstart', 'state', 'portfolio.json');
+
+export const PORTFOLIO_STATUSES = [
+  'on-track',
+  'at-risk',
+  'blocked',
+  'completed',
+  'paused',
+  'cancelled',
+] as const;
+
+export type PortfolioStatus = (typeof PORTFOLIO_STATUSES)[number];
+
+export const PHASES = [
+  { id: 'scout', name: 'Scout', order: -1 },
+  { id: 'phase-0', name: 'Challenge', order: 0 },
+  { id: 'phase-1', name: 'Analyze', order: 1 },
+  { id: 'phase-2', name: 'Plan', order: 2 },
+  { id: 'phase-3', name: 'Architect', order: 3 },
+  { id: 'phase-4', name: 'Build', order: 4 },
+] as const;
+
+export interface PortfolioInitiative {
+  id: string;
+  name: string;
+  path: string | null;
+  owner: string | null;
+  budget: number | null;
+  target_date: string | null;
+  status: PortfolioStatus;
+  registered_at: string;
+  last_checked: string | null;
+  current_phase: string | null;
+  phase_progress: number;
+  readiness: string;
+  blockers: string[];
+  risks: string[];
+  spend: number;
+  notes: unknown[];
+  artifacts_completed?: number | undefined;
+}
+
+export interface PortfolioSnapshot {
+  taken_at: string;
+  total_initiatives: number;
+  status_summary: Record<string, number>;
+  avg_progress: number;
+}
+
+export interface Portfolio {
+  version: string;
+  created_at: string;
+  last_updated: string | null;
+  initiatives: PortfolioInitiative[];
+  snapshots: PortfolioSnapshot[];
+}
+
+/** M3: recursively reject prototype-pollution keys. */
+function rejectPollutionKeys(obj: unknown): void {
+  if (obj === null || typeof obj !== 'object') return;
+  const forbidden = new Set(['__proto__', 'constructor', 'prototype']);
+  for (const key of Object.keys(obj as Record<string, unknown>)) {
+    if (forbidden.has(key)) throw new Error(`Prototype-pollution key detected: "${key}"`);
+    rejectPollutionKeys((obj as Record<string, unknown>)[key]);
+  }
+}
+
+export function defaultPortfolio(): Portfolio {
+  return {
+    version: '1.0.0',
+    created_at: new Date().toISOString(),
+    last_updated: null,
+    initiatives: [],
+    snapshots: [],
+  };
+}
+
+export function loadPortfolio(portfolioFile?: string): Portfolio {
+  const filePath = portfolioFile ?? DEFAULT_PORTFOLIO_FILE;
+  if (!existsSync(filePath)) return defaultPortfolio();
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(filePath, 'utf8'));
+    rejectPollutionKeys(parsed);
+    return parsed as Portfolio;
+  } catch {
+    return defaultPortfolio();
+  }
+}
+
+export function savePortfolio(portfolio: Portfolio, portfolioFile?: string): void {
+  const filePath = portfolioFile ?? DEFAULT_PORTFOLIO_FILE;
+  const dir = dirname(filePath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  portfolio.last_updated = new Date().toISOString();
+  writeFileSync(filePath, `${JSON.stringify(portfolio, null, 2)}\n`, 'utf8');
+}
+
+export interface ProjectAnalysis {
+  current_phase: string | null;
+  phase_progress: number;
+  artifacts_completed: number;
+  total_artifacts: number;
+  blockers: string[];
+  risks: string[];
+  readiness: string;
+}
+
+export function analyzeProject(projectRoot: string): ProjectAnalysis {
+  const result: ProjectAnalysis = {
+    current_phase: null,
+    phase_progress: 0,
+    artifacts_completed: 0,
+    total_artifacts: 5,
+    blockers: [],
+    risks: [],
+    readiness: 'unknown',
+  };
+
+  const stateFile = join(projectRoot, '.jumpstart', 'state', 'state.json');
+  if (existsSync(stateFile)) {
+    try {
+      const state = JSON.parse(readFileSync(stateFile, 'utf8')) as Record<string, unknown>;
+      if (typeof state['current_phase'] === 'string') {
+        result.current_phase = state['current_phase'];
+      }
+    } catch {
+      // ignore parse errors
+    }
+  }
+
+  const artifactMap: Record<string, string> = {
+    'specs/challenger-brief.md': 'phase-0',
+    'specs/product-brief.md': 'phase-1',
+    'specs/prd.md': 'phase-2',
+    'specs/architecture.md': 'phase-3',
+    'specs/implementation-plan.md': 'phase-3',
+  };
+
+  let completed = 0;
+  let latestPhase: string | null = null;
+
+  for (const [relPath, phase] of Object.entries(artifactMap)) {
+    const fullPath = join(projectRoot, relPath);
+    if (existsSync(fullPath)) {
+      const content = readFileSync(fullPath, 'utf8');
+      const isApproved =
+        /- \[x\]/i.test(content) && /Approved by[:\s]+(?!Pending)/i.test(content);
+      if (isApproved) {
+        completed++;
+        latestPhase = phase;
+      }
+
+      const blockerMatches = content.match(/\[BLOCKER[:\s]*([^\]]*)\]/gi);
+      if (blockerMatches) {
+        result.blockers.push(
+          ...blockerMatches.map(b => b.replace(/\[BLOCKER[:\s]*/i, '').replace(/\]/g, '')),
+        );
+      }
+
+      const clarificationMatches = content.match(/\[NEEDS CLARIFICATION[:\s]*([^\]]*)\]/gi);
+      if (clarificationMatches) {
+        result.risks.push(
+          ...clarificationMatches.map(
+            c => `Unresolved: ${c.replace(/\[NEEDS CLARIFICATION[:\s]*/i, '').replace(/\]/g, '')}`,
+          ),
+        );
+      }
+    }
+  }
+
+  result.artifacts_completed = completed;
+  result.phase_progress = Math.round((completed / result.total_artifacts) * 100);
+
+  if (!result.current_phase && latestPhase) {
+    const phaseObj = PHASES.find(p => p.id === latestPhase);
+    const nextPhase = phaseObj
+      ? PHASES.find(p => p.order === phaseObj.order + 1)
+      : undefined;
+    result.current_phase = nextPhase ? nextPhase.id : latestPhase;
+  }
+
+  if (completed >= 5) result.readiness = 'production-ready';
+  else if (completed >= 3) result.readiness = 'implementation-ready';
+  else if (completed >= 1) result.readiness = 'in-progress';
+  else result.readiness = 'not-started';
+
+  return result;
+}
+
+export interface RegisterInitiativeInput {
+  id?: string | undefined;
+  name: string;
+  path?: string | undefined;
+  owner?: string | undefined;
+  budget?: number | undefined;
+  target_date?: string | undefined;
+}
+
+export interface RegisterResult {
+  success: boolean;
+  initiative?: PortfolioInitiative | undefined;
+  error?: string | undefined;
+}
+
+export function registerInitiative(
+  initiative: RegisterInitiativeInput,
+  options: { portfolioFile?: string | undefined } = {},
+): RegisterResult {
+  if (!initiative?.name) {
+    return { success: false, error: 'initiative.name is required' };
+  }
+
+  const portfolioFile = options.portfolioFile ?? DEFAULT_PORTFOLIO_FILE;
+  const portfolio = loadPortfolio(portfolioFile);
+
+  const id = initiative.id ?? initiative.name.toLowerCase().replace(/\s+/g, '-');
+  if (portfolio.initiatives.find(i => i.id === id)) {
+    return { success: false, error: `Initiative "${id}" already exists` };
+  }
+
+  const newInitiative: PortfolioInitiative = {
+    id,
+    name: initiative.name.trim(),
+    path: initiative.path ?? null,
+    owner: initiative.owner ?? null,
+    budget: initiative.budget ?? null,
+    target_date: initiative.target_date ?? null,
+    status: 'on-track',
+    registered_at: new Date().toISOString(),
+    last_checked: null,
+    current_phase: null,
+    phase_progress: 0,
+    readiness: 'not-started',
+    blockers: [],
+    risks: [],
+    spend: 0,
+    notes: [],
+  };
+
+  portfolio.initiatives.push(newInitiative);
+  savePortfolio(portfolio, portfolioFile);
+
+  return { success: true, initiative: newInitiative };
+}
+
+export interface RefreshResult {
+  success: boolean;
+  initiative?: PortfolioInitiative | undefined;
+  error?: string | undefined;
+}
+
+export function refreshInitiative(
+  initiativeId: string,
+  options: { portfolioFile?: string | undefined } = {},
+): RefreshResult {
+  const portfolioFile = options.portfolioFile ?? DEFAULT_PORTFOLIO_FILE;
+  const portfolio = loadPortfolio(portfolioFile);
+
+  const initiative = portfolio.initiatives.find(i => i.id === initiativeId);
+  if (!initiative) {
+    return { success: false, error: `Initiative not found: ${initiativeId}` };
+  }
+
+  if (initiative.path && existsSync(initiative.path)) {
+    const analysis = analyzeProject(initiative.path);
+    initiative.current_phase = analysis.current_phase;
+    initiative.phase_progress = analysis.phase_progress;
+    initiative.readiness = analysis.readiness;
+    initiative.blockers = analysis.blockers;
+    initiative.risks = analysis.risks;
+    initiative.artifacts_completed = analysis.artifacts_completed;
+
+    if (analysis.blockers.length > 0) {
+      initiative.status = 'blocked';
+    } else if (analysis.risks.length > 3) {
+      initiative.status = 'at-risk';
+    } else if (analysis.phase_progress >= 100) {
+      initiative.status = 'completed';
+    }
+  }
+
+  initiative.last_checked = new Date().toISOString();
+  savePortfolio(portfolio, portfolioFile);
+
+  return { success: true, initiative };
+}
+
+export interface PortfolioStatusResult {
+  success: true;
+  total_initiatives: number;
+  status_counts: Record<string, number>;
+  average_progress: number;
+  budget: { total: number; spent: number; remaining: number };
+  blockers: Array<{ initiative: string; blocker: string }>;
+  initiatives: Array<{
+    id: string;
+    name: string;
+    status: PortfolioStatus;
+    phase: string | null;
+    progress: number;
+    readiness: string;
+    owner: string | null;
+    blockers: number;
+    risks: number;
+  }>;
+}
+
+export function getPortfolioStatus(
+  options: { portfolioFile?: string | undefined } = {},
+): PortfolioStatusResult {
+  const portfolioFile = options.portfolioFile ?? DEFAULT_PORTFOLIO_FILE;
+  const portfolio = loadPortfolio(portfolioFile);
+
+  const statusCounts: Record<string, number> = {};
+  for (const status of PORTFOLIO_STATUSES) {
+    statusCounts[status] = portfolio.initiatives.filter(i => i.status === status).length;
+  }
+
+  const totalBudget = portfolio.initiatives.reduce((sum, i) => sum + (i.budget ?? 0), 0);
+  const totalSpend = portfolio.initiatives.reduce((sum, i) => sum + (i.spend ?? 0), 0);
+
+  const allBlockers = portfolio.initiatives.flatMap(i =>
+    (i.blockers ?? []).map(b => ({ initiative: i.name, blocker: b })),
+  );
+
+  const avgProgress =
+    portfolio.initiatives.length > 0
+      ? Math.round(
+          portfolio.initiatives.reduce((sum, i) => sum + (i.phase_progress ?? 0), 0) /
+            portfolio.initiatives.length,
+        )
+      : 0;
+
+  return {
+    success: true,
+    total_initiatives: portfolio.initiatives.length,
+    status_counts: statusCounts,
+    average_progress: avgProgress,
+    budget: { total: totalBudget, spent: totalSpend, remaining: totalBudget - totalSpend },
+    blockers: allBlockers,
+    initiatives: portfolio.initiatives.map(i => ({
+      id: i.id,
+      name: i.name,
+      status: i.status,
+      phase: i.current_phase,
+      progress: i.phase_progress,
+      readiness: i.readiness,
+      owner: i.owner,
+      blockers: (i.blockers ?? []).length,
+      risks: (i.risks ?? []).length,
+    })),
+  };
+}
+
+export interface RemoveResult {
+  success: boolean;
+  removed?: string | undefined;
+  error?: string | undefined;
+}
+
+export function removeInitiative(
+  initiativeId: string,
+  options: { portfolioFile?: string | undefined } = {},
+): RemoveResult {
+  const portfolioFile = options.portfolioFile ?? DEFAULT_PORTFOLIO_FILE;
+  const portfolio = loadPortfolio(portfolioFile);
+
+  const index = portfolio.initiatives.findIndex(i => i.id === initiativeId);
+  if (index === -1) {
+    return { success: false, error: `Initiative not found: ${initiativeId}` };
+  }
+
+  const removed = portfolio.initiatives.splice(index, 1)[0];
+  savePortfolio(portfolio, portfolioFile);
+
+  return { success: true, removed: removed?.name };
+}
+
+export interface SnapshotResult {
+  success: true;
+  snapshot: PortfolioSnapshot;
+}
+
+export function takeSnapshot(options: { portfolioFile?: string | undefined } = {}): SnapshotResult {
+  const portfolioFile = options.portfolioFile ?? DEFAULT_PORTFOLIO_FILE;
+  const portfolio = loadPortfolio(portfolioFile);
+
+  const statusSummary: Record<string, number> = {};
+  for (const status of PORTFOLIO_STATUSES) {
+    statusSummary[status] = portfolio.initiatives.filter(i => i.status === status).length;
+  }
+
+  const snapshot: PortfolioSnapshot = {
+    taken_at: new Date().toISOString(),
+    total_initiatives: portfolio.initiatives.length,
+    status_summary: statusSummary,
+    avg_progress:
+      portfolio.initiatives.length > 0
+        ? Math.round(
+            portfolio.initiatives.reduce((sum, i) => sum + (i.phase_progress ?? 0), 0) /
+              portfolio.initiatives.length,
+          )
+        : 0,
+  };
+
+  portfolio.snapshots.push(snapshot);
+  if (portfolio.snapshots.length > 100) {
+    portfolio.snapshots = portfolio.snapshots.slice(-100);
+  }
+  savePortfolio(portfolio, portfolioFile);
+
+  return { success: true, snapshot };
+}
+

--- a/src/lib/requirements-baseline.ts
+++ b/src/lib/requirements-baseline.ts
@@ -1,0 +1,425 @@
+/**
+ * requirements-baseline.ts — Requirements Baseline & Change Control port (M11 batch 6).
+ *
+ * Pure-library port of `bin/lib/requirements-baseline.js` (CJS) to a typed
+ * ES module. Public surface preserved verbatim by name + signature.
+ *
+ * M3 hardening:
+ *   - `loadBaseline` runs `rejectPollutionKeys` on parsed JSON before use.
+ *   - On parse failure or pollution detection, returns `defaultBaseline()`.
+ *
+ * Path-safety per ADR-009:
+ *   - Receives `root` from CLI wiring which routes through assertUserPath.
+ *
+ * @see bin/lib/requirements-baseline.js (legacy reference)
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+
+const DEFAULT_BASELINE_FILE = join('.jumpstart', 'state', 'requirements-baseline.json');
+
+export const ARTIFACT_TYPES = [
+  'challenger-brief',
+  'product-brief',
+  'prd',
+  'architecture',
+  'implementation-plan',
+] as const;
+
+export type ArtifactType = (typeof ARTIFACT_TYPES)[number];
+
+export interface BaselineSnapshot {
+  type: ArtifactType;
+  path: string;
+  hash: string;
+  requirement_ids: string[];
+  frozen_at: string;
+}
+
+export interface BaselineEntry {
+  id: string;
+  frozen_at: string;
+  frozen_by: string;
+  snapshots: BaselineSnapshot[];
+  total_requirements: number;
+}
+
+export interface ChangeRequest {
+  id: string;
+  artifact: string;
+  artifact_type: ArtifactType;
+  requested_at: string;
+  impact_level: string;
+  added_requirements: string[];
+  removed_requirements: string[];
+  downstream_artifacts: ArtifactType[];
+  status: string;
+}
+
+export interface Baseline {
+  version: string;
+  created_at: string;
+  last_updated: string | null;
+  frozen: boolean;
+  baselines: BaselineEntry[];
+  change_requests: ChangeRequest[];
+}
+
+function rejectPollutionKeys(obj: unknown): void {
+  if (obj === null || typeof obj !== 'object') return;
+  const forbidden = new Set(['__proto__', 'constructor', 'prototype']);
+  for (const key of Object.keys(obj as Record<string, unknown>)) {
+    if (forbidden.has(key)) throw new Error(`Prototype-pollution key detected: "${key}"`);
+    rejectPollutionKeys((obj as Record<string, unknown>)[key]);
+  }
+}
+
+export function defaultBaseline(): Baseline {
+  return {
+    version: '1.0.0',
+    created_at: new Date().toISOString(),
+    last_updated: null,
+    frozen: false,
+    baselines: [],
+    change_requests: [],
+  };
+}
+
+export function loadBaseline(baselineFile?: string): Baseline {
+  const filePath = baselineFile ?? DEFAULT_BASELINE_FILE;
+  if (!existsSync(filePath)) return defaultBaseline();
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(filePath, 'utf8'));
+    rejectPollutionKeys(parsed);
+    return parsed as Baseline;
+  } catch {
+    return defaultBaseline();
+  }
+}
+
+export function saveBaseline(baseline: Baseline, baselineFile?: string): void {
+  const filePath = baselineFile ?? DEFAULT_BASELINE_FILE;
+  const dir = dirname(filePath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  baseline.last_updated = new Date().toISOString();
+  writeFileSync(filePath, JSON.stringify(baseline, null, 2) + '\n', 'utf8');
+}
+
+export function hashContent(content: string): string {
+  return createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+export function extractRequirementIds(content: string): string[] {
+  const patterns = [
+    /\b(REQ-\d+)\b/g,
+    /\b(E\d+-S\d+)\b/g,
+    /\b(NFR-\d+)\b/g,
+    /\b(UC-\d+)\b/g,
+    /\b(FR-\d+)\b/g,
+    /\b(AC-\d+)\b/g,
+  ];
+  const ids = new Set<string>();
+  for (const pattern of patterns) {
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(content)) !== null) {
+      const id = match[1];
+      if (id) ids.add(id);
+    }
+  }
+  return [...ids].sort();
+}
+
+export interface FreezeResult {
+  success: boolean;
+  baseline_id?: string | undefined;
+  artifacts_frozen?: number | undefined;
+  total_requirements?: number | undefined;
+  snapshots?: Array<{ type: ArtifactType; path: string; requirements: number }> | undefined;
+  error?: string | undefined;
+}
+
+export function freezeBaseline(
+  root: string,
+  options: { baselineFile?: string | undefined; approver?: string | undefined } = {},
+): FreezeResult {
+  const baselineFile = options.baselineFile ?? join(root, DEFAULT_BASELINE_FILE);
+  const baseline = loadBaseline(baselineFile);
+
+  const specsDir = join(root, 'specs');
+  if (!existsSync(specsDir)) {
+    return { success: false, error: 'specs/ directory not found' };
+  }
+
+  const snapshots: BaselineSnapshot[] = [];
+  const artifactMap: Record<string, ArtifactType> = {
+    'specs/challenger-brief.md': 'challenger-brief',
+    'specs/product-brief.md': 'product-brief',
+    'specs/prd.md': 'prd',
+    'specs/architecture.md': 'architecture',
+    'specs/implementation-plan.md': 'implementation-plan',
+  };
+
+  for (const [relPath, type] of Object.entries(artifactMap)) {
+    const fullPath = join(root, relPath);
+    if (existsSync(fullPath)) {
+      const content = readFileSync(fullPath, 'utf8');
+      snapshots.push({
+        type,
+        path: relPath,
+        hash: hashContent(content),
+        requirement_ids: extractRequirementIds(content),
+        frozen_at: new Date().toISOString(),
+      });
+    }
+  }
+
+  if (snapshots.length === 0) {
+    return { success: false, error: 'No spec artifacts found to freeze' };
+  }
+
+  const baselineEntry: BaselineEntry = {
+    id: `baseline-${Date.now()}`,
+    frozen_at: new Date().toISOString(),
+    frozen_by: options.approver ?? 'system',
+    snapshots,
+    total_requirements: snapshots.reduce((sum, s) => sum + s.requirement_ids.length, 0),
+  };
+
+  baseline.baselines.push(baselineEntry);
+  baseline.frozen = true;
+  saveBaseline(baseline, baselineFile);
+
+  return {
+    success: true,
+    baseline_id: baselineEntry.id,
+    artifacts_frozen: snapshots.length,
+    total_requirements: baselineEntry.total_requirements,
+    snapshots: snapshots.map(s => ({
+      type: s.type,
+      path: s.path,
+      requirements: s.requirement_ids.length,
+    })),
+  };
+}
+
+export interface ChangeInfo {
+  type: ArtifactType;
+  path: string;
+  change: string;
+  severity: string;
+  added_requirements?: string[] | undefined;
+  removed_requirements?: string[] | undefined;
+}
+
+export interface CheckBaselineResult {
+  success: true;
+  frozen: boolean;
+  baseline_id?: string | undefined;
+  frozen_at?: string | undefined;
+  drifted?: boolean | undefined;
+  changes?: ChangeInfo[] | undefined;
+  unchanged?: Array<{ type: ArtifactType; path: string }> | undefined;
+  summary?: {
+    total_artifacts: number;
+    changed: number;
+    unchanged: number;
+    critical: number;
+  } | undefined;
+  message?: string | undefined;
+}
+
+export function checkBaseline(
+  root: string,
+  options: { baselineFile?: string | undefined } = {},
+): CheckBaselineResult {
+  const baselineFile = options.baselineFile ?? join(root, DEFAULT_BASELINE_FILE);
+  const baseline = loadBaseline(baselineFile);
+
+  if (!baseline.frozen || baseline.baselines.length === 0) {
+    return { success: true, frozen: false, message: 'No frozen baseline found' };
+  }
+
+  const latestBaseline = baseline.baselines[baseline.baselines.length - 1];
+  if (!latestBaseline) return { success: true, frozen: false, message: 'No frozen baseline found' };
+
+  const changes: ChangeInfo[] = [];
+  const unchanged: Array<{ type: ArtifactType; path: string }> = [];
+
+  for (const snapshot of latestBaseline.snapshots) {
+    const fullPath = join(root, snapshot.path);
+    if (!existsSync(fullPath)) {
+      changes.push({ type: snapshot.type, path: snapshot.path, change: 'deleted', severity: 'critical' });
+      continue;
+    }
+
+    const content = readFileSync(fullPath, 'utf8');
+    const currentHash = hashContent(content);
+
+    if (currentHash !== snapshot.hash) {
+      const currentIds = extractRequirementIds(content);
+      const addedIds = currentIds.filter(id => !snapshot.requirement_ids.includes(id));
+      const removedIds = snapshot.requirement_ids.filter(id => !currentIds.includes(id));
+
+      changes.push({
+        type: snapshot.type,
+        path: snapshot.path,
+        change: 'modified',
+        severity: removedIds.length > 0 ? 'critical' : addedIds.length > 0 ? 'warning' : 'info',
+        added_requirements: addedIds,
+        removed_requirements: removedIds,
+      });
+    } else {
+      unchanged.push({ type: snapshot.type, path: snapshot.path });
+    }
+  }
+
+  return {
+    success: true,
+    frozen: true,
+    baseline_id: latestBaseline.id,
+    frozen_at: latestBaseline.frozen_at,
+    drifted: changes.length > 0,
+    changes,
+    unchanged,
+    summary: {
+      total_artifacts: latestBaseline.snapshots.length,
+      changed: changes.length,
+      unchanged: unchanged.length,
+      critical: changes.filter(c => c.severity === 'critical').length,
+    },
+  };
+}
+
+export interface ImpactResult {
+  success: true;
+  impact: string;
+  change_request_id?: string | undefined;
+  artifact?: string | undefined;
+  assessment?: {
+    change_type: string;
+    affected_requirements?: string[] | undefined;
+    downstream_artifacts: ArtifactType[];
+    added_requirements?: string[] | undefined;
+    removed_requirements?: string[] | undefined;
+    unchanged_requirements?: number | undefined;
+    requires_re_approval?: boolean | undefined;
+  } | undefined;
+  message?: string | undefined;
+}
+
+export function assessImpact(
+  artifactPath: string,
+  root: string,
+  options: { baselineFile?: string | undefined } = {},
+): ImpactResult {
+  const baselineFile = options.baselineFile ?? join(root, DEFAULT_BASELINE_FILE);
+  const baseline = loadBaseline(baselineFile);
+
+  if (!baseline.frozen || baseline.baselines.length === 0) {
+    return { success: true, impact: 'none', message: 'No frozen baseline — changes are unconstrained' };
+  }
+
+  const relPath = relative(root, resolve(root, artifactPath)).replace(/\\/g, '/');
+  const latestBaseline = baseline.baselines[baseline.baselines.length - 1];
+  if (!latestBaseline) return { success: true, impact: 'none', message: 'No frozen baseline found' };
+
+  const snapshot = latestBaseline.snapshots.find(s => s.path === relPath);
+
+  if (!snapshot) {
+    return { success: true, impact: 'none', message: `${relPath} is not part of the frozen baseline` };
+  }
+
+  const fullPath = join(root, relPath);
+  if (!existsSync(fullPath)) {
+    const downstreamTypes = ARTIFACT_TYPES.filter(t => t !== snapshot.type) as ArtifactType[];
+    return {
+      success: true,
+      impact: 'critical',
+      artifact: relPath,
+      assessment: {
+        change_type: 'deletion',
+        affected_requirements: snapshot.requirement_ids,
+        downstream_artifacts: downstreamTypes,
+      },
+    };
+  }
+
+  const content = readFileSync(fullPath, 'utf8');
+  const currentHash = hashContent(content);
+
+  if (currentHash === snapshot.hash) {
+    return { success: true, impact: 'none', message: 'Artifact matches frozen baseline' };
+  }
+
+  const currentIds = extractRequirementIds(content);
+  const addedIds = currentIds.filter(id => !snapshot.requirement_ids.includes(id));
+  const removedIds = snapshot.requirement_ids.filter(id => !currentIds.includes(id));
+  const unchangedIds = currentIds.filter(id => snapshot.requirement_ids.includes(id));
+
+  const typeIndex = ARTIFACT_TYPES.indexOf(snapshot.type);
+  const downstreamTypes = (typeIndex >= 0 ? ARTIFACT_TYPES.slice(typeIndex + 1) : []) as ArtifactType[];
+
+  const impactLevel =
+    removedIds.length > 0 ? 'critical'
+    : addedIds.length > 3 ? 'high'
+    : addedIds.length > 0 ? 'medium'
+    : 'low';
+
+  const changeRequest: ChangeRequest = {
+    id: `cr-${Date.now()}`,
+    artifact: relPath,
+    artifact_type: snapshot.type,
+    requested_at: new Date().toISOString(),
+    impact_level: impactLevel,
+    added_requirements: addedIds,
+    removed_requirements: removedIds,
+    downstream_artifacts: downstreamTypes,
+    status: 'pending_review',
+  };
+
+  baseline.change_requests.push(changeRequest);
+  saveBaseline(baseline, baselineFile);
+
+  return {
+    success: true,
+    impact: impactLevel,
+    change_request_id: changeRequest.id,
+    artifact: relPath,
+    assessment: {
+      change_type: removedIds.length > 0 ? 'breaking' : 'additive',
+      added_requirements: addedIds,
+      removed_requirements: removedIds,
+      unchanged_requirements: unchangedIds.length,
+      downstream_artifacts: downstreamTypes,
+      requires_re_approval: impactLevel === 'critical' || impactLevel === 'high',
+    },
+  };
+}
+
+export interface BaselineStatusResult {
+  success: true;
+  frozen: boolean;
+  total_baselines: number;
+  total_change_requests: number;
+  pending_change_requests: number;
+  latest_baseline: BaselineEntry | null;
+}
+
+export function getBaselineStatus(
+  options: { baselineFile?: string | undefined } = {},
+): BaselineStatusResult {
+  const baselineFile = options.baselineFile ?? DEFAULT_BASELINE_FILE;
+  const baseline = loadBaseline(baselineFile);
+
+  return {
+    success: true,
+    frozen: baseline.frozen,
+    total_baselines: baseline.baselines.length,
+    total_change_requests: baseline.change_requests.length,
+    pending_change_requests: baseline.change_requests.filter(cr => cr.status === 'pending_review').length,
+    latest_baseline:
+      baseline.baselines.length > 0 ? (baseline.baselines[baseline.baselines.length - 1] ?? null) : null,
+  };
+}

--- a/src/lib/requirements-baseline.ts
+++ b/src/lib/requirements-baseline.ts
@@ -104,7 +104,7 @@ export function saveBaseline(baseline: Baseline, baselineFile?: string): void {
   const dir = dirname(filePath);
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
   baseline.last_updated = new Date().toISOString();
-  writeFileSync(filePath, JSON.stringify(baseline, null, 2) + '\n', 'utf8');
+  writeFileSync(filePath, `${JSON.stringify(baseline, null, 2)}\n`, 'utf8');
 }
 
 export function hashContent(content: string): string {
@@ -122,8 +122,7 @@ export function extractRequirementIds(content: string): string[] {
   ];
   const ids = new Set<string>();
   for (const pattern of patterns) {
-    let match: RegExpExecArray | null;
-    while ((match = pattern.exec(content)) !== null) {
+    for (const match of content.matchAll(pattern)) {
       const id = match[1];
       if (id) ids.add(id);
     }
@@ -142,7 +141,7 @@ export interface FreezeResult {
 
 export function freezeBaseline(
   root: string,
-  options: { baselineFile?: string | undefined; approver?: string | undefined } = {},
+  options: { baselineFile?: string | undefined; approver?: string | undefined } = {}
 ): FreezeResult {
   const baselineFile = options.baselineFile ?? join(root, DEFAULT_BASELINE_FILE);
   const baseline = loadBaseline(baselineFile);
@@ -196,7 +195,7 @@ export function freezeBaseline(
     baseline_id: baselineEntry.id,
     artifacts_frozen: snapshots.length,
     total_requirements: baselineEntry.total_requirements,
-    snapshots: snapshots.map(s => ({
+    snapshots: snapshots.map((s) => ({
       type: s.type,
       path: s.path,
       requirements: s.requirement_ids.length,
@@ -221,18 +220,20 @@ export interface CheckBaselineResult {
   drifted?: boolean | undefined;
   changes?: ChangeInfo[] | undefined;
   unchanged?: Array<{ type: ArtifactType; path: string }> | undefined;
-  summary?: {
-    total_artifacts: number;
-    changed: number;
-    unchanged: number;
-    critical: number;
-  } | undefined;
+  summary?:
+    | {
+        total_artifacts: number;
+        changed: number;
+        unchanged: number;
+        critical: number;
+      }
+    | undefined;
   message?: string | undefined;
 }
 
 export function checkBaseline(
   root: string,
-  options: { baselineFile?: string | undefined } = {},
+  options: { baselineFile?: string | undefined } = {}
 ): CheckBaselineResult {
   const baselineFile = options.baselineFile ?? join(root, DEFAULT_BASELINE_FILE);
   const baseline = loadBaseline(baselineFile);
@@ -250,7 +251,12 @@ export function checkBaseline(
   for (const snapshot of latestBaseline.snapshots) {
     const fullPath = join(root, snapshot.path);
     if (!existsSync(fullPath)) {
-      changes.push({ type: snapshot.type, path: snapshot.path, change: 'deleted', severity: 'critical' });
+      changes.push({
+        type: snapshot.type,
+        path: snapshot.path,
+        change: 'deleted',
+        severity: 'critical',
+      });
       continue;
     }
 
@@ -259,8 +265,8 @@ export function checkBaseline(
 
     if (currentHash !== snapshot.hash) {
       const currentIds = extractRequirementIds(content);
-      const addedIds = currentIds.filter(id => !snapshot.requirement_ids.includes(id));
-      const removedIds = snapshot.requirement_ids.filter(id => !currentIds.includes(id));
+      const addedIds = currentIds.filter((id) => !snapshot.requirement_ids.includes(id));
+      const removedIds = snapshot.requirement_ids.filter((id) => !currentIds.includes(id));
 
       changes.push({
         type: snapshot.type,
@@ -287,7 +293,7 @@ export function checkBaseline(
       total_artifacts: latestBaseline.snapshots.length,
       changed: changes.length,
       unchanged: unchanged.length,
-      critical: changes.filter(c => c.severity === 'critical').length,
+      critical: changes.filter((c) => c.severity === 'critical').length,
     },
   };
 }
@@ -297,43 +303,54 @@ export interface ImpactResult {
   impact: string;
   change_request_id?: string | undefined;
   artifact?: string | undefined;
-  assessment?: {
-    change_type: string;
-    affected_requirements?: string[] | undefined;
-    downstream_artifacts: ArtifactType[];
-    added_requirements?: string[] | undefined;
-    removed_requirements?: string[] | undefined;
-    unchanged_requirements?: number | undefined;
-    requires_re_approval?: boolean | undefined;
-  } | undefined;
+  assessment?:
+    | {
+        change_type: string;
+        affected_requirements?: string[] | undefined;
+        downstream_artifacts: ArtifactType[];
+        added_requirements?: string[] | undefined;
+        removed_requirements?: string[] | undefined;
+        unchanged_requirements?: number | undefined;
+        requires_re_approval?: boolean | undefined;
+      }
+    | undefined;
   message?: string | undefined;
 }
 
 export function assessImpact(
   artifactPath: string,
   root: string,
-  options: { baselineFile?: string | undefined } = {},
+  options: { baselineFile?: string | undefined } = {}
 ): ImpactResult {
   const baselineFile = options.baselineFile ?? join(root, DEFAULT_BASELINE_FILE);
   const baseline = loadBaseline(baselineFile);
 
   if (!baseline.frozen || baseline.baselines.length === 0) {
-    return { success: true, impact: 'none', message: 'No frozen baseline — changes are unconstrained' };
+    return {
+      success: true,
+      impact: 'none',
+      message: 'No frozen baseline — changes are unconstrained',
+    };
   }
 
   const relPath = relative(root, resolve(root, artifactPath)).replace(/\\/g, '/');
   const latestBaseline = baseline.baselines[baseline.baselines.length - 1];
-  if (!latestBaseline) return { success: true, impact: 'none', message: 'No frozen baseline found' };
+  if (!latestBaseline)
+    return { success: true, impact: 'none', message: 'No frozen baseline found' };
 
-  const snapshot = latestBaseline.snapshots.find(s => s.path === relPath);
+  const snapshot = latestBaseline.snapshots.find((s) => s.path === relPath);
 
   if (!snapshot) {
-    return { success: true, impact: 'none', message: `${relPath} is not part of the frozen baseline` };
+    return {
+      success: true,
+      impact: 'none',
+      message: `${relPath} is not part of the frozen baseline`,
+    };
   }
 
   const fullPath = join(root, relPath);
   if (!existsSync(fullPath)) {
-    const downstreamTypes = ARTIFACT_TYPES.filter(t => t !== snapshot.type) as ArtifactType[];
+    const downstreamTypes = ARTIFACT_TYPES.filter((t) => t !== snapshot.type) as ArtifactType[];
     return {
       success: true,
       impact: 'critical',
@@ -354,18 +371,23 @@ export function assessImpact(
   }
 
   const currentIds = extractRequirementIds(content);
-  const addedIds = currentIds.filter(id => !snapshot.requirement_ids.includes(id));
-  const removedIds = snapshot.requirement_ids.filter(id => !currentIds.includes(id));
-  const unchangedIds = currentIds.filter(id => snapshot.requirement_ids.includes(id));
+  const addedIds = currentIds.filter((id) => !snapshot.requirement_ids.includes(id));
+  const removedIds = snapshot.requirement_ids.filter((id) => !currentIds.includes(id));
+  const unchangedIds = currentIds.filter((id) => snapshot.requirement_ids.includes(id));
 
   const typeIndex = ARTIFACT_TYPES.indexOf(snapshot.type);
-  const downstreamTypes = (typeIndex >= 0 ? ARTIFACT_TYPES.slice(typeIndex + 1) : []) as ArtifactType[];
+  const downstreamTypes = (
+    typeIndex >= 0 ? ARTIFACT_TYPES.slice(typeIndex + 1) : []
+  ) as ArtifactType[];
 
   const impactLevel =
-    removedIds.length > 0 ? 'critical'
-    : addedIds.length > 3 ? 'high'
-    : addedIds.length > 0 ? 'medium'
-    : 'low';
+    removedIds.length > 0
+      ? 'critical'
+      : addedIds.length > 3
+        ? 'high'
+        : addedIds.length > 0
+          ? 'medium'
+          : 'low';
 
   const changeRequest: ChangeRequest = {
     id: `cr-${Date.now()}`,
@@ -408,7 +430,7 @@ export interface BaselineStatusResult {
 }
 
 export function getBaselineStatus(
-  options: { baselineFile?: string | undefined } = {},
+  options: { baselineFile?: string | undefined } = {}
 ): BaselineStatusResult {
   const baselineFile = options.baselineFile ?? DEFAULT_BASELINE_FILE;
   const baseline = loadBaseline(baselineFile);
@@ -418,8 +440,11 @@ export function getBaselineStatus(
     frozen: baseline.frozen,
     total_baselines: baseline.baselines.length,
     total_change_requests: baseline.change_requests.length,
-    pending_change_requests: baseline.change_requests.filter(cr => cr.status === 'pending_review').length,
+    pending_change_requests: baseline.change_requests.filter((cr) => cr.status === 'pending_review')
+      .length,
     latest_baseline:
-      baseline.baselines.length > 0 ? (baseline.baselines[baseline.baselines.length - 1] ?? null) : null,
+      baseline.baselines.length > 0
+        ? (baseline.baselines[baseline.baselines.length - 1] ?? null)
+        : null,
   };
 }

--- a/src/lib/root-cause-analysis.ts
+++ b/src/lib/root-cause-analysis.ts
@@ -1,0 +1,158 @@
+/**
+ * root-cause-analysis.ts — Root Cause Analysis Assistant port (M11 batch 6).
+ *
+ * Pure-library port of `bin/lib/root-cause-analysis.js` (CJS). Public surface:
+ *   - `analyzeFailure(output, options?)` => AnalyzeResult
+ *   - `analyzeTestFile(filePath, options?)` => AnalyzeResult
+ *   - `generateReport(analysis)` => ReportResult
+ *   - `FAILURE_PATTERNS`
+ *
+ * M3 hardening: No JSON parse paths. Not applicable.
+ * Path-safety per ADR-009: `analyzeTestFile` receives filePath from CLI wiring.
+ *
+ * @see bin/lib/root-cause-analysis.js (legacy reference)
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+
+export interface FailurePattern {
+  pattern: RegExp;
+  category: string;
+  fix: string;
+}
+
+export const FAILURE_PATTERNS: FailurePattern[] = [
+  { pattern: /Cannot find module ['"]([^'"]+)['"]/g, category: 'missing-dependency', fix: 'Install or fix import path' },
+  { pattern: /SyntaxError:\s*(.+)/g, category: 'syntax-error', fix: 'Fix syntax at indicated location' },
+  { pattern: /TypeError:\s*(.+)\s+is not a function/g, category: 'type-error', fix: 'Check API usage and version compatibility' },
+  { pattern: /ENOENT.*['"]([^'"]+)['"]/g, category: 'missing-file', fix: 'Create missing file or fix path reference' },
+  { pattern: /AssertionError|AssertionError:\s*(.+)/g, category: 'test-assertion', fix: 'Update test or fix implementation' },
+  { pattern: /ReferenceError:\s*(\w+)\s+is not defined/g, category: 'reference-error', fix: 'Import or declare the missing variable' },
+  { pattern: /ECONNREFUSED/g, category: 'connection-error', fix: 'Ensure required services are running' },
+  { pattern: /out of memory|heap|OOM/gi, category: 'memory-error', fix: 'Optimize memory usage or increase limits' },
+  { pattern: /timeout|ETIMEDOUT/gi, category: 'timeout', fix: 'Increase timeout or optimize slow operations' },
+  { pattern: /permission denied|EACCES/gi, category: 'permission-error', fix: 'Check file permissions or user privileges' },
+];
+
+export interface Hypothesis {
+  category: string;
+  detail: string;
+  line: number;
+  suggested_fix: string;
+  confidence: string;
+  context: string;
+}
+
+export interface AnalyzeResult {
+  success: boolean;
+  total_hypotheses?: number | undefined;
+  hypotheses?: Hypothesis[] | undefined;
+  primary_cause?: Hypothesis | null | undefined;
+  categories?: string[] | undefined;
+  recommended_actions?: Array<{ action: string; detail: string; category: string }> | undefined;
+  file?: string | undefined;
+  error?: string | undefined;
+}
+
+const SEVERITY_ORDER: Record<string, number> = {
+  'syntax-error': 1,
+  'missing-dependency': 2,
+  'reference-error': 3,
+  'type-error': 4,
+  'missing-file': 5,
+  'test-assertion': 6,
+};
+
+export function analyzeFailure(
+  output: string,
+  _options: Record<string, unknown> = {},
+): AnalyzeResult {
+  if (!output) return { success: false, error: 'output is required' };
+
+  const hypotheses: Hypothesis[] = [];
+  const seen = new Set<string>();
+
+  for (const fp of FAILURE_PATTERNS) {
+    const regex = new RegExp(fp.pattern.source, fp.pattern.flags);
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(output)) !== null) {
+      const detail = match[1] ?? '';
+      const key = `${fp.category}:${detail.substring(0, 50)}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      const lineNum = output.substring(0, match.index).split('\n').length;
+      const lines = output.split('\n');
+      hypotheses.push({
+        category: fp.category,
+        detail: detail || match[0].trim(),
+        line: lineNum,
+        suggested_fix: fp.fix,
+        confidence: 'high',
+        context: lines.slice(Math.max(0, lineNum - 3), lineNum + 2).join('\n'),
+      });
+    }
+  }
+
+  hypotheses.sort((a, b) => (SEVERITY_ORDER[a.category] ?? 99) - (SEVERITY_ORDER[b.category] ?? 99));
+
+  return {
+    success: true,
+    total_hypotheses: hypotheses.length,
+    hypotheses,
+    primary_cause: hypotheses[0] ?? null,
+    categories: [...new Set(hypotheses.map(h => h.category))],
+    recommended_actions: hypotheses.slice(0, 3).map(h => ({
+      action: h.suggested_fix,
+      detail: h.detail,
+      category: h.category,
+    })),
+  };
+}
+
+export function analyzeTestFile(filePath: string, options: Record<string, unknown> = {}): AnalyzeResult {
+  if (!existsSync(filePath)) {
+    return { success: false, error: `File not found: ${filePath}` };
+  }
+
+  const content = readFileSync(filePath, 'utf8');
+  const result = analyzeFailure(content, options);
+  result.file = filePath;
+  return result;
+}
+
+export interface ReportResult {
+  success: boolean;
+  summary?: {
+    total_issues: number;
+    primary_cause: string;
+    categories: number;
+  } | undefined;
+  by_category?: Record<string, number> | undefined;
+  action_plan?: Array<{ action: string; detail: string; category: string }> | undefined;
+  hypotheses?: Hypothesis[] | undefined;
+  error?: string | undefined;
+}
+
+export function generateReport(analysis: AnalyzeResult): ReportResult {
+  if (!analysis?.hypotheses) {
+    return { success: false, error: 'Invalid analysis result' };
+  }
+
+  const byCategory = analysis.hypotheses.reduce<Record<string, number>>((acc, h) => {
+    acc[h.category] = (acc[h.category] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  return {
+    success: true,
+    summary: {
+      total_issues: analysis.total_hypotheses ?? 0,
+      primary_cause: analysis.primary_cause?.category ?? 'unknown',
+      categories: Object.keys(byCategory).length,
+    },
+    by_category: byCategory,
+    action_plan: analysis.recommended_actions ?? [],
+    hypotheses: analysis.hypotheses,
+  };
+}

--- a/src/lib/root-cause-analysis.ts
+++ b/src/lib/root-cause-analysis.ts
@@ -22,16 +22,56 @@ export interface FailurePattern {
 }
 
 export const FAILURE_PATTERNS: FailurePattern[] = [
-  { pattern: /Cannot find module ['"]([^'"]+)['"]/g, category: 'missing-dependency', fix: 'Install or fix import path' },
-  { pattern: /SyntaxError:\s*(.+)/g, category: 'syntax-error', fix: 'Fix syntax at indicated location' },
-  { pattern: /TypeError:\s*(.+)\s+is not a function/g, category: 'type-error', fix: 'Check API usage and version compatibility' },
-  { pattern: /ENOENT.*['"]([^'"]+)['"]/g, category: 'missing-file', fix: 'Create missing file or fix path reference' },
-  { pattern: /AssertionError|AssertionError:\s*(.+)/g, category: 'test-assertion', fix: 'Update test or fix implementation' },
-  { pattern: /ReferenceError:\s*(\w+)\s+is not defined/g, category: 'reference-error', fix: 'Import or declare the missing variable' },
-  { pattern: /ECONNREFUSED/g, category: 'connection-error', fix: 'Ensure required services are running' },
-  { pattern: /out of memory|heap|OOM/gi, category: 'memory-error', fix: 'Optimize memory usage or increase limits' },
-  { pattern: /timeout|ETIMEDOUT/gi, category: 'timeout', fix: 'Increase timeout or optimize slow operations' },
-  { pattern: /permission denied|EACCES/gi, category: 'permission-error', fix: 'Check file permissions or user privileges' },
+  {
+    pattern: /Cannot find module ['"]([^'"]+)['"]/g,
+    category: 'missing-dependency',
+    fix: 'Install or fix import path',
+  },
+  {
+    pattern: /SyntaxError:\s*(.+)/g,
+    category: 'syntax-error',
+    fix: 'Fix syntax at indicated location',
+  },
+  {
+    pattern: /TypeError:\s*(.+)\s+is not a function/g,
+    category: 'type-error',
+    fix: 'Check API usage and version compatibility',
+  },
+  {
+    pattern: /ENOENT.*['"]([^'"]+)['"]/g,
+    category: 'missing-file',
+    fix: 'Create missing file or fix path reference',
+  },
+  {
+    pattern: /AssertionError|AssertionError:\s*(.+)/g,
+    category: 'test-assertion',
+    fix: 'Update test or fix implementation',
+  },
+  {
+    pattern: /ReferenceError:\s*(\w+)\s+is not defined/g,
+    category: 'reference-error',
+    fix: 'Import or declare the missing variable',
+  },
+  {
+    pattern: /ECONNREFUSED/g,
+    category: 'connection-error',
+    fix: 'Ensure required services are running',
+  },
+  {
+    pattern: /out of memory|heap|OOM/gi,
+    category: 'memory-error',
+    fix: 'Optimize memory usage or increase limits',
+  },
+  {
+    pattern: /timeout|ETIMEDOUT/gi,
+    category: 'timeout',
+    fix: 'Increase timeout or optimize slow operations',
+  },
+  {
+    pattern: /permission denied|EACCES/gi,
+    category: 'permission-error',
+    fix: 'Check file permissions or user privileges',
+  },
 ];
 
 export interface Hypothesis {
@@ -65,7 +105,7 @@ const SEVERITY_ORDER: Record<string, number> = {
 
 export function analyzeFailure(
   output: string,
-  _options: Record<string, unknown> = {},
+  _options: Record<string, unknown> = {}
 ): AnalyzeResult {
   if (!output) return { success: false, error: 'output is required' };
 
@@ -74,8 +114,7 @@ export function analyzeFailure(
 
   for (const fp of FAILURE_PATTERNS) {
     const regex = new RegExp(fp.pattern.source, fp.pattern.flags);
-    let match: RegExpExecArray | null;
-    while ((match = regex.exec(output)) !== null) {
+    for (const match of output.matchAll(regex)) {
       const detail = match[1] ?? '';
       const key = `${fp.category}:${detail.substring(0, 50)}`;
       if (seen.has(key)) continue;
@@ -94,15 +133,17 @@ export function analyzeFailure(
     }
   }
 
-  hypotheses.sort((a, b) => (SEVERITY_ORDER[a.category] ?? 99) - (SEVERITY_ORDER[b.category] ?? 99));
+  hypotheses.sort(
+    (a, b) => (SEVERITY_ORDER[a.category] ?? 99) - (SEVERITY_ORDER[b.category] ?? 99)
+  );
 
   return {
     success: true,
     total_hypotheses: hypotheses.length,
     hypotheses,
     primary_cause: hypotheses[0] ?? null,
-    categories: [...new Set(hypotheses.map(h => h.category))],
-    recommended_actions: hypotheses.slice(0, 3).map(h => ({
+    categories: [...new Set(hypotheses.map((h) => h.category))],
+    recommended_actions: hypotheses.slice(0, 3).map((h) => ({
       action: h.suggested_fix,
       detail: h.detail,
       category: h.category,
@@ -110,7 +151,10 @@ export function analyzeFailure(
   };
 }
 
-export function analyzeTestFile(filePath: string, options: Record<string, unknown> = {}): AnalyzeResult {
+export function analyzeTestFile(
+  filePath: string,
+  options: Record<string, unknown> = {}
+): AnalyzeResult {
   if (!existsSync(filePath)) {
     return { success: false, error: `File not found: ${filePath}` };
   }
@@ -123,11 +167,13 @@ export function analyzeTestFile(filePath: string, options: Record<string, unknow
 
 export interface ReportResult {
   success: boolean;
-  summary?: {
-    total_issues: number;
-    primary_cause: string;
-    categories: number;
-  } | undefined;
+  summary?:
+    | {
+        total_issues: number;
+        primary_cause: string;
+        categories: number;
+      }
+    | undefined;
   by_category?: Record<string, number> | undefined;
   action_plan?: Array<{ action: string; detail: string; category: string }> | undefined;
   hypotheses?: Hypothesis[] | undefined;

--- a/src/lib/runtime-debugger.ts
+++ b/src/lib/runtime-debugger.ts
@@ -53,7 +53,10 @@ export interface LogAnalysisResult {
   error?: string | undefined;
 }
 
-export function analyzeLogs(logContent: string, _options: Record<string, unknown> = {}): LogAnalysisResult {
+export function analyzeLogs(
+  logContent: string,
+  _options: Record<string, unknown> = {}
+): LogAnalysisResult {
   const lines = logContent.split('\n');
   const findings: LogFinding[] = [];
 
@@ -74,18 +77,21 @@ export function analyzeLogs(logContent: string, _options: Record<string, unknown
 
   const summary: LogSummary = {
     total_lines: lines.length,
-    errors: findings.filter(f => f.type === 'error').length,
-    warnings: findings.filter(f => f.type === 'warning').length,
-    exceptions: findings.filter(f => f.type === 'exception').length,
-    timeouts: findings.filter(f => f.type === 'timeout').length,
-    oom: findings.filter(f => f.type === 'oom').length,
-    connection_issues: findings.filter(f => f.type === 'connection').length,
+    errors: findings.filter((f) => f.type === 'error').length,
+    warnings: findings.filter((f) => f.type === 'warning').length,
+    exceptions: findings.filter((f) => f.type === 'exception').length,
+    timeouts: findings.filter((f) => f.type === 'timeout').length,
+    oom: findings.filter((f) => f.type === 'oom').length,
+    connection_issues: findings.filter((f) => f.type === 'connection').length,
   };
 
   return { success: true, findings, summary, total_findings: findings.length };
 }
 
-export function analyzeLogFile(filePath: string, options: Record<string, unknown> = {}): LogAnalysisResult {
+export function analyzeLogFile(
+  filePath: string,
+  options: Record<string, unknown> = {}
+): LogAnalysisResult {
   if (!existsSync(filePath)) {
     return { success: false, error: `Log file not found: ${filePath}` };
   }
@@ -137,7 +143,7 @@ export function correlateWithSource(findings: LogFinding[], root: string): Corre
     success: true,
     correlations,
     total: correlations.length,
-    actionable: correlations.filter(c => c.file_exists).length,
+    actionable: correlations.filter((c) => c.file_exists).length,
   };
 }
 
@@ -157,21 +163,42 @@ export interface HypothesesResult {
 export function generateHypotheses(analysis: LogAnalysisResult): HypothesesResult {
   const hypotheses: HypothesisEntry[] = [];
   const summary = analysis.summary ?? {
-    total_lines: 0, errors: 0, warnings: 0, exceptions: 0,
-    timeouts: 0, oom: 0, connection_issues: 0,
+    total_lines: 0,
+    errors: 0,
+    warnings: 0,
+    exceptions: 0,
+    timeouts: 0,
+    oom: 0,
+    connection_issues: 0,
   };
 
   if (summary.oom > 0) {
-    hypotheses.push({ hypothesis: 'Memory leak or insufficient heap allocation', confidence: 'high', action: 'Check for unbounded data structures or increase memory limits' });
+    hypotheses.push({
+      hypothesis: 'Memory leak or insufficient heap allocation',
+      confidence: 'high',
+      action: 'Check for unbounded data structures or increase memory limits',
+    });
   }
   if (summary.timeouts > 0) {
-    hypotheses.push({ hypothesis: 'Network connectivity or slow dependency', confidence: 'medium', action: 'Check network configuration, increase timeouts, or add retries' });
+    hypotheses.push({
+      hypothesis: 'Network connectivity or slow dependency',
+      confidence: 'medium',
+      action: 'Check network configuration, increase timeouts, or add retries',
+    });
   }
   if (summary.connection_issues > 0) {
-    hypotheses.push({ hypothesis: 'Service dependency unavailable', confidence: 'high', action: 'Verify dependent services are running and network rules allow connection' });
+    hypotheses.push({
+      hypothesis: 'Service dependency unavailable',
+      confidence: 'high',
+      action: 'Verify dependent services are running and network rules allow connection',
+    });
   }
   if (summary.exceptions > 0) {
-    hypotheses.push({ hypothesis: 'Unhandled exception in application code', confidence: 'high', action: 'Review stack traces and add error handling' });
+    hypotheses.push({
+      hypothesis: 'Unhandled exception in application code',
+      confidence: 'high',
+      action: 'Review stack traces and add error handling',
+    });
   }
 
   return { success: true, hypotheses, total: hypotheses.length, summary };

--- a/src/lib/runtime-debugger.ts
+++ b/src/lib/runtime-debugger.ts
@@ -1,0 +1,178 @@
+/**
+ * runtime-debugger.ts — Runtime-Aware Debugging Mode port (M11 batch 6).
+ *
+ * Pure-library port of `bin/lib/runtime-debugger.js` (CJS). Public surface:
+ *   - `analyzeLogs(logContent, options?)` => LogAnalysisResult
+ *   - `analyzeLogFile(filePath, options?)` => LogAnalysisResult
+ *   - `correlateWithSource(findings, root)` => CorrelateResult
+ *   - `generateHypotheses(analysis)` => HypothesesResult
+ *   - `LOG_PATTERNS`
+ *
+ * M3 hardening: No JSON parse paths. Not applicable.
+ * Path-safety per ADR-009: `analyzeLogFile` receives filePath from CLI wiring.
+ *
+ * @see bin/lib/runtime-debugger.js (legacy reference)
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export const LOG_PATTERNS: Record<string, RegExp> = {
+  error: /\b(?:ERROR|FATAL|CRITICAL)\b/i,
+  warning: /\b(?:WARN(?:ING)?)\b/i,
+  exception: /(?:Error|Exception|Traceback|at\s+\S+\s+\()/,
+  stack_trace: /^\s+at\s+/m,
+  timeout: /\b(?:timeout|timed?\s*out|ETIMEDOUT)\b/i,
+  oom: /\b(?:out\s*of\s*memory|heap|OOM|ENOMEM)\b/i,
+  connection: /\b(?:ECONNREFUSED|ECONNRESET|connection\s+refused)\b/i,
+};
+
+export interface LogFinding {
+  type: string;
+  line: number;
+  content: string;
+  severity: 'high' | 'medium';
+}
+
+export interface LogSummary {
+  total_lines: number;
+  errors: number;
+  warnings: number;
+  exceptions: number;
+  timeouts: number;
+  oom: number;
+  connection_issues: number;
+}
+
+export interface LogAnalysisResult {
+  success: boolean;
+  findings?: LogFinding[] | undefined;
+  summary?: LogSummary | undefined;
+  total_findings?: number | undefined;
+  file?: string | undefined;
+  error?: string | undefined;
+}
+
+export function analyzeLogs(logContent: string, _options: Record<string, unknown> = {}): LogAnalysisResult {
+  const lines = logContent.split('\n');
+  const findings: LogFinding[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+    for (const [type, pattern] of Object.entries(LOG_PATTERNS)) {
+      if (pattern.test(line)) {
+        findings.push({
+          type,
+          line: i + 1,
+          content: line.trim().substring(0, 200),
+          severity: type === 'error' || type === 'exception' ? 'high' : 'medium',
+        });
+        break;
+      }
+    }
+  }
+
+  const summary: LogSummary = {
+    total_lines: lines.length,
+    errors: findings.filter(f => f.type === 'error').length,
+    warnings: findings.filter(f => f.type === 'warning').length,
+    exceptions: findings.filter(f => f.type === 'exception').length,
+    timeouts: findings.filter(f => f.type === 'timeout').length,
+    oom: findings.filter(f => f.type === 'oom').length,
+    connection_issues: findings.filter(f => f.type === 'connection').length,
+  };
+
+  return { success: true, findings, summary, total_findings: findings.length };
+}
+
+export function analyzeLogFile(filePath: string, options: Record<string, unknown> = {}): LogAnalysisResult {
+  if (!existsSync(filePath)) {
+    return { success: false, error: `Log file not found: ${filePath}` };
+  }
+
+  const content = readFileSync(filePath, 'utf8');
+  const result = analyzeLogs(content, options);
+  result.file = filePath;
+  return result;
+}
+
+export interface Correlation {
+  error: string;
+  source_file: string;
+  source_line: number;
+  file_exists: boolean;
+  severity: string;
+}
+
+export interface CorrelateResult {
+  success: true;
+  correlations: Correlation[];
+  total: number;
+  actionable: number;
+}
+
+export function correlateWithSource(findings: LogFinding[], root: string): CorrelateResult {
+  const correlations: Correlation[] = [];
+
+  for (const finding of findings) {
+    const fileMatch = finding.content.match(/(?:at\s+)?(\S+\.(?:js|ts|py)):(\d+)/);
+    if (fileMatch) {
+      const file = fileMatch[1];
+      const lineStr = fileMatch[2];
+      if (!file || !lineStr) continue;
+      const absPath = join(root, file);
+      const exists = existsSync(absPath);
+
+      correlations.push({
+        error: finding.content.substring(0, 100),
+        source_file: file,
+        source_line: parseInt(lineStr, 10),
+        file_exists: exists,
+        severity: finding.severity,
+      });
+    }
+  }
+
+  return {
+    success: true,
+    correlations,
+    total: correlations.length,
+    actionable: correlations.filter(c => c.file_exists).length,
+  };
+}
+
+export interface HypothesisEntry {
+  hypothesis: string;
+  confidence: string;
+  action: string;
+}
+
+export interface HypothesesResult {
+  success: true;
+  hypotheses: HypothesisEntry[];
+  total: number;
+  summary: LogSummary;
+}
+
+export function generateHypotheses(analysis: LogAnalysisResult): HypothesesResult {
+  const hypotheses: HypothesisEntry[] = [];
+  const summary = analysis.summary ?? {
+    total_lines: 0, errors: 0, warnings: 0, exceptions: 0,
+    timeouts: 0, oom: 0, connection_issues: 0,
+  };
+
+  if (summary.oom > 0) {
+    hypotheses.push({ hypothesis: 'Memory leak or insufficient heap allocation', confidence: 'high', action: 'Check for unbounded data structures or increase memory limits' });
+  }
+  if (summary.timeouts > 0) {
+    hypotheses.push({ hypothesis: 'Network connectivity or slow dependency', confidence: 'medium', action: 'Check network configuration, increase timeouts, or add retries' });
+  }
+  if (summary.connection_issues > 0) {
+    hypotheses.push({ hypothesis: 'Service dependency unavailable', confidence: 'high', action: 'Verify dependent services are running and network rules allow connection' });
+  }
+  if (summary.exceptions > 0) {
+    hypotheses.push({ hypothesis: 'Unhandled exception in application code', confidence: 'high', action: 'Review stack traces and add error handling' });
+  }
+
+  return { success: true, hypotheses, total: hypotheses.length, summary };
+}

--- a/src/lib/scanner.ts
+++ b/src/lib/scanner.ts
@@ -1,0 +1,306 @@
+/**
+ * scanner.ts — Project Context Discovery port (M11 batch 6).
+ *
+ * Port of `bin/lib/scanner.mjs` (ESM). Near-trivial since it was already
+ * ESM — mostly type annotations. Public surface preserved verbatim:
+ *   - `scan(opts)` => ScanResult
+ *   - `scanDir(dir, ignore, root)` => { files, dirs }
+ *   - `detectStack(root, files)` => StackInfo
+ *   - `countDebtMarkers(root, files)` => DebtMarkers
+ *   - `identifyRisks(root, files, stack)` => Risk[]
+ *
+ * M3 hardening: No JSON state file. package.json parsed with try/catch + defaulting.
+ * Path-safety per ADR-009: `scan(opts)` receives root from CLI wiring.
+ *
+ * @see bin/lib/scanner.mjs (legacy reference)
+ */
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { extname, join, relative } from 'node:path';
+
+const DEFAULT_IGNORE = ['node_modules', '.git', 'dist', 'build', '.next', 'coverage', '__pycache__', '.venv'];
+
+export interface StackInfo {
+  language: string | null;
+  language_version: string | null;
+  runtime: string | null;
+  runtime_version: string | null;
+  framework: string | null;
+  framework_version: string | null;
+  package_manager: string | null;
+  test_framework: string | null;
+  database: string | null;
+}
+
+export interface DebtDetail {
+  file: string;
+  line: number;
+}
+
+export interface DebtMarkers {
+  TODO: number;
+  FIXME: number;
+  HACK: number;
+  XXX: number;
+  details: {
+    TODO: DebtDetail[];
+    FIXME: DebtDetail[];
+    HACK: DebtDetail[];
+    XXX: DebtDetail[];
+  };
+}
+
+export interface Risk {
+  risk: string;
+  severity: string;
+  detail: string;
+}
+
+export interface ScanResult {
+  scanned_at: string;
+  stack: StackInfo;
+  structure: {
+    top_level: string[];
+    file_extensions: Record<string, number>;
+  };
+  stats: { files: number; directories: number };
+  debt_markers: DebtMarkers;
+  risks: Risk[];
+}
+
+export function scanDir(
+  dir: string,
+  ignore: string[],
+  root: string,
+): { files: string[]; dirs: string[] } {
+  const files: string[] = [];
+  const dirs: string[] = [];
+
+  if (!existsSync(dir)) return { files, dirs };
+
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (ignore.includes(entry.name)) continue;
+    if (entry.name.startsWith('.') && entry.name !== '.env.example') continue;
+
+    const full = join(dir, entry.name);
+    const rel = relative(root, full).replace(/\\/g, '/');
+
+    if (entry.isDirectory()) {
+      dirs.push(rel);
+      const sub = scanDir(full, ignore, root);
+      files.push(...sub.files);
+      dirs.push(...sub.dirs);
+    } else {
+      files.push(rel);
+    }
+  }
+
+  return { files, dirs };
+}
+
+export function detectStack(root: string, files: string[]): StackInfo {
+  const stack: StackInfo = {
+    language: null,
+    language_version: null,
+    runtime: null,
+    runtime_version: null,
+    framework: null,
+    framework_version: null,
+    package_manager: null,
+    test_framework: null,
+    database: null,
+  };
+
+  const pkgPath = join(root, 'package.json');
+  if (existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as {
+        dependencies?: Record<string, string>;
+        devDependencies?: Record<string, string>;
+        engines?: { node?: string };
+      };
+      const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
+
+      if (allDeps['typescript'] || files.some(f => f.endsWith('.ts') || f.endsWith('.tsx'))) {
+        stack.language = 'TypeScript';
+        stack.language_version = allDeps['typescript'] ?? 'detected';
+      } else {
+        stack.language = 'JavaScript';
+      }
+
+      stack.runtime = 'Node.js';
+      if (pkg.engines?.node) stack.runtime_version = pkg.engines.node;
+
+      const frameworks = [
+        { key: 'next', name: 'Next.js' },
+        { key: 'react', name: 'React' },
+        { key: 'vue', name: 'Vue.js' },
+        { key: 'express', name: 'Express' },
+        { key: 'fastify', name: 'Fastify' },
+        { key: 'nuxt', name: 'Nuxt' },
+        { key: '@angular/core', name: 'Angular' },
+        { key: 'svelte', name: 'Svelte' },
+        { key: 'hono', name: 'Hono' },
+      ];
+      for (const fw of frameworks) {
+        if (allDeps[fw.key]) {
+          stack.framework = fw.name;
+          stack.framework_version = allDeps[fw.key] ?? null;
+          break;
+        }
+      }
+
+      if (existsSync(join(root, 'pnpm-lock.yaml'))) stack.package_manager = 'pnpm';
+      else if (existsSync(join(root, 'yarn.lock'))) stack.package_manager = 'yarn';
+      else if (existsSync(join(root, 'bun.lockb'))) stack.package_manager = 'bun';
+      else stack.package_manager = 'npm';
+
+      const testFrameworks = [
+        { key: 'vitest', name: 'Vitest' },
+        { key: 'jest', name: 'Jest' },
+        { key: 'mocha', name: 'Mocha' },
+        { key: '@playwright/test', name: 'Playwright' },
+        { key: 'cypress', name: 'Cypress' },
+      ];
+      for (const tf of testFrameworks) {
+        if (allDeps[tf.key]) {
+          stack.test_framework = tf.name;
+          break;
+        }
+      }
+
+      const databases = [
+        { key: '@prisma/client', name: 'Prisma (PostgreSQL/MySQL/SQLite)' },
+        { key: 'pg', name: 'PostgreSQL' },
+        { key: 'mysql2', name: 'MySQL' },
+        { key: 'mongodb', name: 'MongoDB' },
+        { key: 'better-sqlite3', name: 'SQLite' },
+        { key: 'redis', name: 'Redis' },
+      ];
+      for (const db of databases) {
+        if (allDeps[db.key]) {
+          stack.database = db.name;
+          break;
+        }
+      }
+    } catch {
+      // Ignore parse errors
+    }
+  }
+
+  if (files.some(f => f === 'requirements.txt' || f === 'pyproject.toml' || f === 'setup.py')) {
+    stack.language = stack.language ?? 'Python';
+    stack.runtime = stack.runtime ?? 'Python';
+  }
+
+  if (files.some(f => f === 'go.mod')) {
+    stack.language = stack.language ?? 'Go';
+    stack.runtime = stack.runtime ?? 'Go';
+  }
+
+  if (files.some(f => f === 'Cargo.toml')) {
+    stack.language = stack.language ?? 'Rust';
+    stack.runtime = stack.runtime ?? 'Rust';
+  }
+
+  return stack;
+}
+
+export function countDebtMarkers(root: string, files: string[]): DebtMarkers {
+  const markers: { TODO: DebtDetail[]; FIXME: DebtDetail[]; HACK: DebtDetail[]; XXX: DebtDetail[] } = {
+    TODO: [], FIXME: [], HACK: [], XXX: [],
+  };
+  const sourceExtensions = ['.js', '.ts', '.jsx', '.tsx', '.py', '.go', '.rs', '.java'];
+
+  for (const file of files) {
+    const ext = extname(file);
+    if (!sourceExtensions.includes(ext)) continue;
+
+    try {
+      const content = readFileSync(join(root, file), 'utf8');
+      const lines = content.split('\n');
+
+      lines.forEach((line, idx) => {
+        for (const marker of Object.keys(markers) as Array<keyof typeof markers>) {
+          if (line.includes(marker)) {
+            markers[marker].push({ file, line: idx + 1 });
+          }
+        }
+      });
+    } catch {
+      // Skip unreadable files
+    }
+  }
+
+  return {
+    TODO: markers.TODO.length,
+    FIXME: markers.FIXME.length,
+    HACK: markers.HACK.length,
+    XXX: markers.XXX.length,
+    details: markers,
+  };
+}
+
+export function identifyRisks(root: string, files: string[], stack: StackInfo): Risk[] {
+  const risks: Risk[] = [];
+
+  const hasTests = files.some(f => f.includes('test') || f.includes('spec') || f.includes('__tests__'));
+  if (!hasTests) {
+    risks.push({ risk: 'No test files detected', severity: 'High', detail: 'No files matching test/spec patterns found' });
+  }
+
+  const hasLock = files.some(f => ['package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb'].includes(f));
+  if (stack.runtime === 'Node.js' && !hasLock) {
+    risks.push({ risk: 'No lock file', severity: 'Medium', detail: 'Non-deterministic dependency resolution' });
+  }
+
+  if (!files.includes('.gitignore') && !existsSync(join(root, '.gitignore'))) {
+    risks.push({ risk: 'No .gitignore', severity: 'Low', detail: 'Risk of committing build artifacts or secrets' });
+  }
+
+  if (files.some(f => f === '.env')) {
+    risks.push({ risk: '.env file in repository', severity: 'High', detail: 'Potential secret exposure' });
+  }
+
+  return risks;
+}
+
+export interface ScanOptions {
+  root?: string | undefined;
+  ignore?: string[] | undefined;
+}
+
+export function scan(opts: ScanOptions): ScanResult {
+  const root = opts.root ?? '.';
+  const ignore = opts.ignore ?? DEFAULT_IGNORE;
+
+  const { files, dirs } = scanDir(root, ignore, root);
+  const stack = detectStack(root, files);
+  const debt = countDebtMarkers(root, files);
+
+  const extensions: Record<string, number> = {};
+  for (const file of files) {
+    const ext = extname(file) || '(no ext)';
+    extensions[ext] = (extensions[ext] ?? 0) + 1;
+  }
+
+  const topLevel: string[] = [];
+  try {
+    for (const entry of readdirSync(root, { withFileTypes: true })) {
+      if (ignore.includes(entry.name) || entry.name.startsWith('.')) continue;
+      topLevel.push(entry.isDirectory() ? `${entry.name}/` : entry.name);
+    }
+  } catch {
+    // Ignore errors
+  }
+
+  return {
+    scanned_at: new Date().toISOString(),
+    stack,
+    structure: { top_level: topLevel, file_extensions: extensions },
+    stats: { files: files.length, directories: dirs.length },
+    debt_markers: debt,
+    risks: identifyRisks(root, files, stack),
+  };
+}
+

--- a/src/lib/scanner.ts
+++ b/src/lib/scanner.ts
@@ -15,10 +15,19 @@
  * @see bin/lib/scanner.mjs (legacy reference)
  */
 
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { extname, join, relative } from 'node:path';
 
-const DEFAULT_IGNORE = ['node_modules', '.git', 'dist', 'build', '.next', 'coverage', '__pycache__', '.venv'];
+const DEFAULT_IGNORE = [
+  'node_modules',
+  '.git',
+  'dist',
+  'build',
+  '.next',
+  'coverage',
+  '__pycache__',
+  '.venv',
+];
 
 export interface StackInfo {
   language: string | null;
@@ -71,7 +80,7 @@ export interface ScanResult {
 export function scanDir(
   dir: string,
   ignore: string[],
-  root: string,
+  root: string
 ): { files: string[]; dirs: string[] } {
   const files: string[] = [];
   const dirs: string[] = [];
@@ -121,9 +130,9 @@ export function detectStack(root: string, files: string[]): StackInfo {
       };
       const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
 
-      if (allDeps['typescript'] || files.some(f => f.endsWith('.ts') || f.endsWith('.tsx'))) {
+      if (allDeps.typescript || files.some((f) => f.endsWith('.ts') || f.endsWith('.tsx'))) {
         stack.language = 'TypeScript';
-        stack.language_version = allDeps['typescript'] ?? 'detected';
+        stack.language_version = allDeps.typescript ?? 'detected';
       } else {
         stack.language = 'JavaScript';
       }
@@ -188,17 +197,17 @@ export function detectStack(root: string, files: string[]): StackInfo {
     }
   }
 
-  if (files.some(f => f === 'requirements.txt' || f === 'pyproject.toml' || f === 'setup.py')) {
+  if (files.some((f) => f === 'requirements.txt' || f === 'pyproject.toml' || f === 'setup.py')) {
     stack.language = stack.language ?? 'Python';
     stack.runtime = stack.runtime ?? 'Python';
   }
 
-  if (files.some(f => f === 'go.mod')) {
+  if (files.some((f) => f === 'go.mod')) {
     stack.language = stack.language ?? 'Go';
     stack.runtime = stack.runtime ?? 'Go';
   }
 
-  if (files.some(f => f === 'Cargo.toml')) {
+  if (files.some((f) => f === 'Cargo.toml')) {
     stack.language = stack.language ?? 'Rust';
     stack.runtime = stack.runtime ?? 'Rust';
   }
@@ -207,8 +216,16 @@ export function detectStack(root: string, files: string[]): StackInfo {
 }
 
 export function countDebtMarkers(root: string, files: string[]): DebtMarkers {
-  const markers: { TODO: DebtDetail[]; FIXME: DebtDetail[]; HACK: DebtDetail[]; XXX: DebtDetail[] } = {
-    TODO: [], FIXME: [], HACK: [], XXX: [],
+  const markers: {
+    TODO: DebtDetail[];
+    FIXME: DebtDetail[];
+    HACK: DebtDetail[];
+    XXX: DebtDetail[];
+  } = {
+    TODO: [],
+    FIXME: [],
+    HACK: [],
+    XXX: [],
   };
   const sourceExtensions = ['.js', '.ts', '.jsx', '.tsx', '.py', '.go', '.rs', '.java'];
 
@@ -244,22 +261,42 @@ export function countDebtMarkers(root: string, files: string[]): DebtMarkers {
 export function identifyRisks(root: string, files: string[], stack: StackInfo): Risk[] {
   const risks: Risk[] = [];
 
-  const hasTests = files.some(f => f.includes('test') || f.includes('spec') || f.includes('__tests__'));
+  const hasTests = files.some(
+    (f) => f.includes('test') || f.includes('spec') || f.includes('__tests__')
+  );
   if (!hasTests) {
-    risks.push({ risk: 'No test files detected', severity: 'High', detail: 'No files matching test/spec patterns found' });
+    risks.push({
+      risk: 'No test files detected',
+      severity: 'High',
+      detail: 'No files matching test/spec patterns found',
+    });
   }
 
-  const hasLock = files.some(f => ['package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb'].includes(f));
+  const hasLock = files.some((f) =>
+    ['package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb'].includes(f)
+  );
   if (stack.runtime === 'Node.js' && !hasLock) {
-    risks.push({ risk: 'No lock file', severity: 'Medium', detail: 'Non-deterministic dependency resolution' });
+    risks.push({
+      risk: 'No lock file',
+      severity: 'Medium',
+      detail: 'Non-deterministic dependency resolution',
+    });
   }
 
   if (!files.includes('.gitignore') && !existsSync(join(root, '.gitignore'))) {
-    risks.push({ risk: 'No .gitignore', severity: 'Low', detail: 'Risk of committing build artifacts or secrets' });
+    risks.push({
+      risk: 'No .gitignore',
+      severity: 'Low',
+      detail: 'Risk of committing build artifacts or secrets',
+    });
   }
 
-  if (files.some(f => f === '.env')) {
-    risks.push({ risk: '.env file in repository', severity: 'High', detail: 'Potential secret exposure' });
+  if (files.some((f) => f === '.env')) {
+    risks.push({
+      risk: '.env file in repository',
+      severity: 'High',
+      detail: 'Potential secret exposure',
+    });
   }
 
   return risks;
@@ -303,4 +340,3 @@ export function scan(opts: ScanOptions): ScanResult {
     risks: identifyRisks(root, files, stack),
   };
 }
-

--- a/src/lib/semantic-diff.ts
+++ b/src/lib/semantic-diff.ts
@@ -1,0 +1,331 @@
+/**
+ * semantic-diff.ts — Cross-artifact Semantic Diffing port (M11 batch 6).
+ *
+ * Pure-library port of `bin/lib/semantic-diff.js` (CJS). Public surface:
+ *   - `extractSections(content)` => Section[]
+ *   - `extractRequirements(content)` => string[]
+ *   - `extractApiEndpoints(content)` => ApiEndpoint[]
+ *   - `extractTableData(content)` => string[][]
+ *   - `normalizeText(text)` => string
+ *   - `textSimilarity(a, b)` => number
+ *   - `compareArtifacts(contentA, contentB, options?)` => CompareResult
+ *   - `compareFiles(pathA, pathB, options?)` => CompareResult
+ *   - `crossArtifactDiff(root, options?)` => CrossDiffResult
+ *
+ * M3 hardening: No JSON state paths. Not applicable.
+ * Path-safety per ADR-009: `compareFiles` paths come from CLI wiring.
+ *
+ * @see bin/lib/semantic-diff.js (legacy reference)
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const REQUIREMENT_PATTERN = /\b(REQ-\d+|E\d+-S\d+|NFR-\d+|UC-\d+|FR-\d+|AC-\d+|M\d+-T\d+)\b/g;
+const API_ENDPOINT = /\b(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s+(\S+)/g;
+const TABLE_ROW = /^\|(.+)\|$/gm;
+
+export interface Section {
+  heading: string;
+  level: number;
+  content: string;
+  startLine: number;
+}
+
+export function extractSections(content: string): Section[] {
+  const sections: Section[] = [];
+  const lines = content.split('\n');
+  let currentSection: { heading: string; level: number; content: string[]; startLine: number } = {
+    heading: '(preamble)',
+    level: 0,
+    content: [],
+    startLine: 0,
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+    const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
+    if (headingMatch) {
+      if (currentSection.content.length > 0 || currentSection.heading !== '(preamble)') {
+        sections.push({
+          heading: currentSection.heading,
+          level: currentSection.level,
+          content: currentSection.content.join('\n').trim(),
+          startLine: currentSection.startLine,
+        });
+      }
+      currentSection = {
+        heading: (headingMatch[2] ?? '').trim(),
+        level: headingMatch[1]?.length ?? 1,
+        content: [],
+        startLine: i + 1,
+      };
+    } else {
+      currentSection.content.push(line);
+    }
+  }
+  sections.push({
+    heading: currentSection.heading,
+    level: currentSection.level,
+    content: currentSection.content.join('\n').trim(),
+    startLine: currentSection.startLine,
+  });
+
+  return sections;
+}
+
+export function extractRequirements(content: string): string[] {
+  const matches = content.match(REQUIREMENT_PATTERN) ?? [];
+  return [...new Set(matches)].sort();
+}
+
+export interface ApiEndpoint {
+  method: string;
+  path: string;
+}
+
+export function extractApiEndpoints(content: string): ApiEndpoint[] {
+  const endpoints: ApiEndpoint[] = [];
+  let match: RegExpExecArray | null;
+  const pattern = new RegExp(API_ENDPOINT.source, 'g');
+  while ((match = pattern.exec(content)) !== null) {
+    const method = match[1];
+    const apiPath = match[2];
+    if (method && apiPath) endpoints.push({ method, path: apiPath });
+  }
+  return endpoints;
+}
+
+export function extractTableData(content: string): string[][] {
+  const rows: string[][] = [];
+  let match: RegExpExecArray | null;
+  const pattern = new RegExp(TABLE_ROW.source, 'gm');
+  while ((match = pattern.exec(content)) !== null) {
+    const cells = (match[1] ?? '').split('|').map(c => c.trim()).filter(c => c.length > 0);
+    if (cells.some(c => /^[-:]+$/.test(c))) continue;
+    rows.push(cells);
+  }
+  return rows;
+}
+
+export function normalizeText(text: string): string {
+  return text.toLowerCase().replace(/[^\w\s]/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+export function textSimilarity(a: string, b: string): number {
+  const wordsA = new Set(normalizeText(a).split(' ').filter(w => w.length > 2));
+  const wordsB = new Set(normalizeText(b).split(' ').filter(w => w.length > 2));
+  if (wordsA.size === 0 && wordsB.size === 0) return 1;
+  if (wordsA.size === 0 || wordsB.size === 0) return 0;
+
+  let intersection = 0;
+  for (const w of wordsA) {
+    if (wordsB.has(w)) intersection++;
+  }
+  const union = new Set([...wordsA, ...wordsB]).size;
+  return union === 0 ? 1 : intersection / union;
+}
+
+export interface SectionChange {
+  type: 'section_added' | 'section_removed' | 'section_modified';
+  heading: string;
+  severity: string;
+  similarity?: number | undefined;
+}
+
+export interface CompareResult {
+  success: true;
+  overall_similarity: number;
+  has_breaking_changes: boolean;
+  section_changes: SectionChange[];
+  requirement_changes: {
+    added: string[];
+    removed: string[];
+    total_before: number;
+    total_after: number;
+  };
+  api_changes: {
+    added: string[];
+    removed: string[];
+    total_before: number;
+    total_after: number;
+  };
+  table_changes: { rows_before: number; rows_after: number };
+  summary: {
+    sections_added: number;
+    sections_removed: number;
+    sections_modified: number;
+    requirements_added: number;
+    requirements_removed: number;
+    apis_added: number;
+    apis_removed: number;
+  };
+  file_a?: string | undefined;
+  file_b?: string | undefined;
+}
+
+export function compareArtifacts(
+  contentA: string,
+  contentB: string,
+  _options: Record<string, unknown> = {},
+): CompareResult {
+  const sectionsA = extractSections(contentA);
+  const sectionsB = extractSections(contentB);
+  const sectionChanges: SectionChange[] = [];
+  const headingsA = sectionsA.map(s => s.heading);
+  const headingsB = sectionsB.map(s => s.heading);
+
+  for (const sec of sectionsB) {
+    if (!headingsA.includes(sec.heading)) {
+      sectionChanges.push({ type: 'section_added', heading: sec.heading, severity: 'info' });
+    }
+  }
+
+  for (const sec of sectionsA) {
+    if (!headingsB.includes(sec.heading)) {
+      sectionChanges.push({ type: 'section_removed', heading: sec.heading, severity: 'warning' });
+    }
+  }
+
+  for (const secA of sectionsA) {
+    const secB = sectionsB.find(s => s.heading === secA.heading);
+    if (secB) {
+      const similarity = textSimilarity(secA.content, secB.content);
+      if (similarity < 0.95) {
+        sectionChanges.push({
+          type: 'section_modified',
+          heading: secA.heading,
+          similarity: Math.round(similarity * 100),
+          severity: similarity < 0.5 ? 'critical' : similarity < 0.8 ? 'warning' : 'info',
+        });
+      }
+    }
+  }
+
+  const reqsA = extractRequirements(contentA);
+  const reqsB = extractRequirements(contentB);
+  const addedReqs = reqsB.filter(r => !reqsA.includes(r));
+  const removedReqs = reqsA.filter(r => !reqsB.includes(r));
+
+  const apisA = extractApiEndpoints(contentA);
+  const apisB = extractApiEndpoints(contentB);
+  const apiKeysA = apisA.map(a => `${a.method} ${a.path}`);
+  const apiKeysB = apisB.map(a => `${a.method} ${a.path}`);
+  const addedApis = apiKeysB.filter(k => !apiKeysA.includes(k));
+  const removedApis = apiKeysA.filter(k => !apiKeysB.includes(k));
+
+  const tablesA = extractTableData(contentA);
+  const tablesB = extractTableData(contentB);
+
+  const overallSimilarity = textSimilarity(contentA, contentB);
+  const hasBreakingChanges =
+    removedReqs.length > 0 || removedApis.length > 0 || sectionChanges.some(c => c.severity === 'critical');
+
+  return {
+    success: true,
+    overall_similarity: Math.round(overallSimilarity * 100),
+    has_breaking_changes: hasBreakingChanges,
+    section_changes: sectionChanges,
+    requirement_changes: { added: addedReqs, removed: removedReqs, total_before: reqsA.length, total_after: reqsB.length },
+    api_changes: { added: addedApis, removed: removedApis, total_before: apisA.length, total_after: apisB.length },
+    table_changes: { rows_before: tablesA.length, rows_after: tablesB.length },
+    summary: {
+      sections_added: sectionChanges.filter(c => c.type === 'section_added').length,
+      sections_removed: sectionChanges.filter(c => c.type === 'section_removed').length,
+      sections_modified: sectionChanges.filter(c => c.type === 'section_modified').length,
+      requirements_added: addedReqs.length,
+      requirements_removed: removedReqs.length,
+      apis_added: addedApis.length,
+      apis_removed: removedApis.length,
+    },
+  };
+}
+
+export type CompareFilesResult =
+  | (CompareResult & { file_a: string; file_b: string })
+  | { success: false; error: string };
+
+export function compareFiles(
+  pathA: string,
+  pathB: string,
+  options: Record<string, unknown> = {},
+): CompareFilesResult {
+  if (!existsSync(pathA)) return { success: false, error: `File not found: ${pathA}` };
+  if (!existsSync(pathB)) return { success: false, error: `File not found: ${pathB}` };
+
+  const contentA = readFileSync(pathA, 'utf8');
+  const contentB = readFileSync(pathB, 'utf8');
+  const result = compareArtifacts(contentA, contentB, options);
+  return { ...result, file_a: pathA, file_b: pathB };
+}
+
+export interface CrossDiffResult {
+  success: boolean;
+  artifacts_analyzed?: number | undefined;
+  inconsistencies?: Array<{
+    type: string;
+    upstream: string;
+    downstream: string;
+    missing_requirements: string[];
+    severity: string;
+  }> | undefined;
+  summary?: { total_inconsistencies: number; requirement_gaps: number } | undefined;
+  error?: string | undefined;
+}
+
+export function crossArtifactDiff(root: string, _options: Record<string, unknown> = {}): CrossDiffResult {
+  const specsDir = join(root, 'specs');
+  if (!existsSync(specsDir)) {
+    return { success: false, error: 'specs/ directory not found' };
+  }
+
+  const artifactFiles = ['challenger-brief.md', 'product-brief.md', 'prd.md', 'architecture.md', 'implementation-plan.md'];
+  const artifacts: Record<string, { requirements: string[] }> = {};
+
+  for (const file of artifactFiles) {
+    const fullPath = join(specsDir, file);
+    if (existsSync(fullPath)) {
+      const content = readFileSync(fullPath, 'utf8');
+      artifacts[file] = { requirements: extractRequirements(content) };
+    }
+  }
+
+  const inconsistencies: Array<{
+    type: string;
+    upstream: string;
+    downstream: string;
+    missing_requirements: string[];
+    severity: string;
+  }> = [];
+
+  const orderedKeys = Object.keys(artifacts);
+  for (let i = 0; i < orderedKeys.length - 1; i++) {
+    const upstreamKey = orderedKeys[i];
+    const downstreamKey = orderedKeys[i + 1];
+    if (!upstreamKey || !downstreamKey) continue;
+    const upstream = artifacts[upstreamKey];
+    const downstream = artifacts[downstreamKey];
+    if (!upstream || !downstream) continue;
+
+    const missingDownstream = upstream.requirements.filter(r => !downstream.requirements.includes(r));
+    if (missingDownstream.length > 0) {
+      inconsistencies.push({
+        type: 'requirement_gap',
+        upstream: upstreamKey,
+        downstream: downstreamKey,
+        missing_requirements: missingDownstream,
+        severity: 'warning',
+      });
+    }
+  }
+
+  return {
+    success: true,
+    artifacts_analyzed: Object.keys(artifacts).length,
+    inconsistencies,
+    summary: {
+      total_inconsistencies: inconsistencies.length,
+      requirement_gaps: inconsistencies.filter(i => i.type === 'requirement_gap').length,
+    },
+  };
+}

--- a/src/lib/semantic-diff.ts
+++ b/src/lib/semantic-diff.ts
@@ -86,9 +86,8 @@ export interface ApiEndpoint {
 
 export function extractApiEndpoints(content: string): ApiEndpoint[] {
   const endpoints: ApiEndpoint[] = [];
-  let match: RegExpExecArray | null;
   const pattern = new RegExp(API_ENDPOINT.source, 'g');
-  while ((match = pattern.exec(content)) !== null) {
+  for (const match of content.matchAll(pattern)) {
     const method = match[1];
     const apiPath = match[2];
     if (method && apiPath) endpoints.push({ method, path: apiPath });
@@ -98,23 +97,37 @@ export function extractApiEndpoints(content: string): ApiEndpoint[] {
 
 export function extractTableData(content: string): string[][] {
   const rows: string[][] = [];
-  let match: RegExpExecArray | null;
   const pattern = new RegExp(TABLE_ROW.source, 'gm');
-  while ((match = pattern.exec(content)) !== null) {
-    const cells = (match[1] ?? '').split('|').map(c => c.trim()).filter(c => c.length > 0);
-    if (cells.some(c => /^[-:]+$/.test(c))) continue;
+  for (const match of content.matchAll(pattern)) {
+    const cells = (match[1] ?? '')
+      .split('|')
+      .map((c) => c.trim())
+      .filter((c) => c.length > 0);
+    if (cells.some((c) => /^[-:]+$/.test(c))) continue;
     rows.push(cells);
   }
   return rows;
 }
 
 export function normalizeText(text: string): string {
-  return text.toLowerCase().replace(/[^\w\s]/g, ' ').replace(/\s+/g, ' ').trim();
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
 }
 
 export function textSimilarity(a: string, b: string): number {
-  const wordsA = new Set(normalizeText(a).split(' ').filter(w => w.length > 2));
-  const wordsB = new Set(normalizeText(b).split(' ').filter(w => w.length > 2));
+  const wordsA = new Set(
+    normalizeText(a)
+      .split(' ')
+      .filter((w) => w.length > 2)
+  );
+  const wordsB = new Set(
+    normalizeText(b)
+      .split(' ')
+      .filter((w) => w.length > 2)
+  );
   if (wordsA.size === 0 && wordsB.size === 0) return 1;
   if (wordsA.size === 0 || wordsB.size === 0) return 0;
 
@@ -167,13 +180,13 @@ export interface CompareResult {
 export function compareArtifacts(
   contentA: string,
   contentB: string,
-  _options: Record<string, unknown> = {},
+  _options: Record<string, unknown> = {}
 ): CompareResult {
   const sectionsA = extractSections(contentA);
   const sectionsB = extractSections(contentB);
   const sectionChanges: SectionChange[] = [];
-  const headingsA = sectionsA.map(s => s.heading);
-  const headingsB = sectionsB.map(s => s.heading);
+  const headingsA = sectionsA.map((s) => s.heading);
+  const headingsB = sectionsB.map((s) => s.heading);
 
   for (const sec of sectionsB) {
     if (!headingsA.includes(sec.heading)) {
@@ -188,7 +201,7 @@ export function compareArtifacts(
   }
 
   for (const secA of sectionsA) {
-    const secB = sectionsB.find(s => s.heading === secA.heading);
+    const secB = sectionsB.find((s) => s.heading === secA.heading);
     if (secB) {
       const similarity = textSimilarity(secA.content, secB.content);
       if (similarity < 0.95) {
@@ -204,35 +217,47 @@ export function compareArtifacts(
 
   const reqsA = extractRequirements(contentA);
   const reqsB = extractRequirements(contentB);
-  const addedReqs = reqsB.filter(r => !reqsA.includes(r));
-  const removedReqs = reqsA.filter(r => !reqsB.includes(r));
+  const addedReqs = reqsB.filter((r) => !reqsA.includes(r));
+  const removedReqs = reqsA.filter((r) => !reqsB.includes(r));
 
   const apisA = extractApiEndpoints(contentA);
   const apisB = extractApiEndpoints(contentB);
-  const apiKeysA = apisA.map(a => `${a.method} ${a.path}`);
-  const apiKeysB = apisB.map(a => `${a.method} ${a.path}`);
-  const addedApis = apiKeysB.filter(k => !apiKeysA.includes(k));
-  const removedApis = apiKeysA.filter(k => !apiKeysB.includes(k));
+  const apiKeysA = apisA.map((a) => `${a.method} ${a.path}`);
+  const apiKeysB = apisB.map((a) => `${a.method} ${a.path}`);
+  const addedApis = apiKeysB.filter((k) => !apiKeysA.includes(k));
+  const removedApis = apiKeysA.filter((k) => !apiKeysB.includes(k));
 
   const tablesA = extractTableData(contentA);
   const tablesB = extractTableData(contentB);
 
   const overallSimilarity = textSimilarity(contentA, contentB);
   const hasBreakingChanges =
-    removedReqs.length > 0 || removedApis.length > 0 || sectionChanges.some(c => c.severity === 'critical');
+    removedReqs.length > 0 ||
+    removedApis.length > 0 ||
+    sectionChanges.some((c) => c.severity === 'critical');
 
   return {
     success: true,
     overall_similarity: Math.round(overallSimilarity * 100),
     has_breaking_changes: hasBreakingChanges,
     section_changes: sectionChanges,
-    requirement_changes: { added: addedReqs, removed: removedReqs, total_before: reqsA.length, total_after: reqsB.length },
-    api_changes: { added: addedApis, removed: removedApis, total_before: apisA.length, total_after: apisB.length },
+    requirement_changes: {
+      added: addedReqs,
+      removed: removedReqs,
+      total_before: reqsA.length,
+      total_after: reqsB.length,
+    },
+    api_changes: {
+      added: addedApis,
+      removed: removedApis,
+      total_before: apisA.length,
+      total_after: apisB.length,
+    },
     table_changes: { rows_before: tablesA.length, rows_after: tablesB.length },
     summary: {
-      sections_added: sectionChanges.filter(c => c.type === 'section_added').length,
-      sections_removed: sectionChanges.filter(c => c.type === 'section_removed').length,
-      sections_modified: sectionChanges.filter(c => c.type === 'section_modified').length,
+      sections_added: sectionChanges.filter((c) => c.type === 'section_added').length,
+      sections_removed: sectionChanges.filter((c) => c.type === 'section_removed').length,
+      sections_modified: sectionChanges.filter((c) => c.type === 'section_modified').length,
       requirements_added: addedReqs.length,
       requirements_removed: removedReqs.length,
       apis_added: addedApis.length,
@@ -248,7 +273,7 @@ export type CompareFilesResult =
 export function compareFiles(
   pathA: string,
   pathB: string,
-  options: Record<string, unknown> = {},
+  options: Record<string, unknown> = {}
 ): CompareFilesResult {
   if (!existsSync(pathA)) return { success: false, error: `File not found: ${pathA}` };
   if (!existsSync(pathB)) return { success: false, error: `File not found: ${pathB}` };
@@ -262,24 +287,35 @@ export function compareFiles(
 export interface CrossDiffResult {
   success: boolean;
   artifacts_analyzed?: number | undefined;
-  inconsistencies?: Array<{
-    type: string;
-    upstream: string;
-    downstream: string;
-    missing_requirements: string[];
-    severity: string;
-  }> | undefined;
+  inconsistencies?:
+    | Array<{
+        type: string;
+        upstream: string;
+        downstream: string;
+        missing_requirements: string[];
+        severity: string;
+      }>
+    | undefined;
   summary?: { total_inconsistencies: number; requirement_gaps: number } | undefined;
   error?: string | undefined;
 }
 
-export function crossArtifactDiff(root: string, _options: Record<string, unknown> = {}): CrossDiffResult {
+export function crossArtifactDiff(
+  root: string,
+  _options: Record<string, unknown> = {}
+): CrossDiffResult {
   const specsDir = join(root, 'specs');
   if (!existsSync(specsDir)) {
     return { success: false, error: 'specs/ directory not found' };
   }
 
-  const artifactFiles = ['challenger-brief.md', 'product-brief.md', 'prd.md', 'architecture.md', 'implementation-plan.md'];
+  const artifactFiles = [
+    'challenger-brief.md',
+    'product-brief.md',
+    'prd.md',
+    'architecture.md',
+    'implementation-plan.md',
+  ];
   const artifacts: Record<string, { requirements: string[] }> = {};
 
   for (const file of artifactFiles) {
@@ -307,7 +343,9 @@ export function crossArtifactDiff(root: string, _options: Record<string, unknown
     const downstream = artifacts[downstreamKey];
     if (!upstream || !downstream) continue;
 
-    const missingDownstream = upstream.requirements.filter(r => !downstream.requirements.includes(r));
+    const missingDownstream = upstream.requirements.filter(
+      (r) => !downstream.requirements.includes(r)
+    );
     if (missingDownstream.length > 0) {
       inconsistencies.push({
         type: 'requirement_gap',
@@ -325,7 +363,7 @@ export function crossArtifactDiff(root: string, _options: Record<string, unknown
     inconsistencies,
     summary: {
       total_inconsistencies: inconsistencies.length,
-      requirement_gaps: inconsistencies.filter(i => i.type === 'requirement_gap').length,
+      requirement_gaps: inconsistencies.filter((i) => i.type === 'requirement_gap').length,
     },
   };
 }

--- a/src/lib/sla-slo.ts
+++ b/src/lib/sla-slo.ts
@@ -1,0 +1,286 @@
+/**
+ * sla-slo.ts — SLA & SLO Specification Support port (M11 batch 6).
+ *
+ * Pure-library port of `bin/lib/sla-slo.js` (CJS). Public surface:
+ *   - `defaultState()` => SlaState
+ *   - `loadState(stateFile?)` => SlaState
+ *   - `saveState(state, stateFile?)` => void
+ *   - `defineSLO(slo, options?)` => DefineSLOResult
+ *   - `applyTemplate(serviceName, templateType, options?)` => ApplyTemplateResult
+ *   - `checkSLOCoverage(root, options?)` => CoverageResult
+ *   - `generateReport(options?)` => SloReport
+ *   - `SLO_TYPES`
+ *   - `DEFAULT_SLO_TEMPLATES`
+ *
+ * M3 hardening:
+ *   - `loadState` runs `rejectPollutionKeys` on parsed JSON before use.
+ *   - On parse failure or pollution, returns `defaultState()`.
+ *
+ * Path-safety per ADR-009: Not applicable — no user-supplied paths to fs.
+ *
+ * @see bin/lib/sla-slo.js (legacy reference)
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+const DEFAULT_STATE_FILE = join('.jumpstart', 'state', 'sla-slo.json');
+
+export const SLO_TYPES = ['availability', 'latency', 'throughput', 'error-rate', 'durability', 'freshness'] as const;
+export type SloType = (typeof SLO_TYPES)[number];
+
+export interface SloTemplate {
+  type: string;
+  target: number;
+  unit: string;
+  window: string;
+  percentile?: string | undefined;
+}
+
+export const DEFAULT_SLO_TEMPLATES: Record<string, SloTemplate[]> = {
+  'web-api': [
+    { type: 'availability', target: 99.9, unit: 'percent', window: '30d' },
+    { type: 'latency', target: 200, unit: 'ms', percentile: 'p99', window: '30d' },
+    { type: 'error-rate', target: 0.1, unit: 'percent', window: '30d' },
+  ],
+  'batch-processing': [
+    { type: 'availability', target: 99.5, unit: 'percent', window: '30d' },
+    { type: 'throughput', target: 1000, unit: 'records/sec', window: '1h' },
+    { type: 'freshness', target: 60, unit: 'minutes', window: '24h' },
+  ],
+  'data-pipeline': [
+    { type: 'availability', target: 99.0, unit: 'percent', window: '30d' },
+    { type: 'freshness', target: 15, unit: 'minutes', window: '24h' },
+    { type: 'durability', target: 99.999, unit: 'percent', window: '30d' },
+  ],
+};
+
+export interface SloEntry {
+  id: string;
+  name: string;
+  service: string;
+  type: string;
+  target: number;
+  unit: string;
+  window: string;
+  description: string;
+  created_at: string;
+}
+
+export interface SlaEntry {
+  id: string;
+  name: string;
+  service: string;
+  [key: string]: unknown;
+}
+
+export interface SlaState {
+  version: string;
+  created_at: string;
+  last_updated: string | null;
+  slos: SloEntry[];
+  slas: SlaEntry[];
+  error_budgets: unknown[];
+}
+
+function rejectPollutionKeys(obj: unknown): void {
+  if (obj === null || typeof obj !== 'object') return;
+  const forbidden = new Set(['__proto__', 'constructor', 'prototype']);
+  for (const key of Object.keys(obj as Record<string, unknown>)) {
+    if (forbidden.has(key)) throw new Error(`Prototype-pollution key detected: "${key}"`);
+    rejectPollutionKeys((obj as Record<string, unknown>)[key]);
+  }
+}
+
+export function defaultState(): SlaState {
+  return {
+    version: '1.0.0',
+    created_at: new Date().toISOString(),
+    last_updated: null,
+    slos: [],
+    slas: [],
+    error_budgets: [],
+  };
+}
+
+export function loadState(stateFile?: string): SlaState {
+  const fp = stateFile ?? DEFAULT_STATE_FILE;
+  if (!existsSync(fp)) return defaultState();
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(fp, 'utf8'));
+    rejectPollutionKeys(parsed);
+    return parsed as SlaState;
+  } catch {
+    return defaultState();
+  }
+}
+
+export function saveState(state: SlaState, stateFile?: string): void {
+  const fp = stateFile ?? DEFAULT_STATE_FILE;
+  const dir = dirname(fp);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  state.last_updated = new Date().toISOString();
+  writeFileSync(fp, JSON.stringify(state, null, 2) + '\n', 'utf8');
+}
+
+export interface DefineSLOInput {
+  name: string;
+  service: string;
+  target: number;
+  type?: string | undefined;
+  unit?: string | undefined;
+  window?: string | undefined;
+  description?: string | undefined;
+}
+
+export interface DefineSLOResult {
+  success: boolean;
+  slo?: SloEntry | undefined;
+  error?: string | undefined;
+}
+
+export function defineSLO(
+  slo: DefineSLOInput,
+  options: { stateFile?: string | undefined } = {},
+): DefineSLOResult {
+  if (!slo?.name || !slo.service || slo.target === undefined) {
+    return { success: false, error: 'name, service, and target are required' };
+  }
+
+  const type = (slo.type ?? 'availability').toLowerCase();
+  if (!SLO_TYPES.includes(type as SloType)) {
+    return { success: false, error: `Invalid type. Must be one of: ${SLO_TYPES.join(', ')}` };
+  }
+
+  const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
+  const state = loadState(stateFile);
+
+  const newSLO: SloEntry = {
+    id: `SLO-${Date.now().toString(36).toUpperCase()}`,
+    name: slo.name,
+    service: slo.service,
+    type,
+    target: slo.target,
+    unit: slo.unit ?? 'percent',
+    window: slo.window ?? '30d',
+    description: slo.description ?? '',
+    created_at: new Date().toISOString(),
+  };
+
+  state.slos.push(newSLO);
+  saveState(state, stateFile);
+
+  return { success: true, slo: newSLO };
+}
+
+export interface ApplyTemplateResult {
+  success: boolean;
+  service?: string | undefined;
+  template?: string | undefined;
+  slos_created?: number | undefined;
+  error?: string | undefined;
+}
+
+export function applyTemplate(
+  serviceName: string,
+  templateType: string,
+  options: { stateFile?: string | undefined } = {},
+): ApplyTemplateResult {
+  const template = DEFAULT_SLO_TEMPLATES[templateType];
+  if (!template) {
+    return { success: false, error: `Unknown template: ${templateType}. Available: ${Object.keys(DEFAULT_SLO_TEMPLATES).join(', ')}` };
+  }
+
+  const results: DefineSLOResult[] = [];
+  for (const t of template) {
+    const result = defineSLO({
+      name: `${serviceName} ${t.type}`,
+      service: serviceName,
+      type: t.type,
+      target: t.target,
+      unit: t.unit,
+      window: t.window,
+    }, options);
+    results.push(result);
+  }
+
+  return { success: true, service: serviceName, template: templateType, slos_created: results.length };
+}
+
+export interface CoverageResult {
+  success: true;
+  defined_slos: number;
+  architecture_mentions_slo: boolean;
+  prd_mentions_slo: boolean;
+  coverage: string;
+  recommendations: string[];
+}
+
+export function checkSLOCoverage(
+  root: string,
+  options: { stateFile?: string | undefined } = {},
+): CoverageResult {
+  const stateFile = options.stateFile ?? join(root, DEFAULT_STATE_FILE);
+  const state = loadState(stateFile);
+
+  const archFile = join(root, 'specs', 'architecture.md');
+  const prdFile = join(root, 'specs', 'prd.md');
+
+  let archHasSLO = false;
+  let prdHasSLO = false;
+
+  if (existsSync(archFile)) {
+    try {
+      const content = readFileSync(archFile, 'utf8');
+      archHasSLO = /\bSL[OA]\b|service.level|availability|latency.target/i.test(content);
+    } catch { /* ignore */ }
+  }
+
+  if (existsSync(prdFile)) {
+    try {
+      const content = readFileSync(prdFile, 'utf8');
+      prdHasSLO = /\bSL[OA]\b|service.level|availability|uptime/i.test(content);
+    } catch { /* ignore */ }
+  }
+
+  return {
+    success: true,
+    defined_slos: state.slos.length,
+    architecture_mentions_slo: archHasSLO,
+    prd_mentions_slo: prdHasSLO,
+    coverage: state.slos.length > 0 ? 'defined' : 'missing',
+    recommendations: state.slos.length === 0 ? ['Define SLOs using `jumpstart-mode sla-slo define`'] : [],
+  };
+}
+
+export interface SloReport {
+  success: true;
+  slos: SloEntry[];
+  slas: SlaEntry[];
+  total_slos: number;
+  total_slas: number;
+  by_service: Record<string, SloEntry[]>;
+  by_type: Record<string, number>;
+}
+
+export function generateReport(options: { stateFile?: string | undefined } = {}): SloReport {
+  const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
+  const state = loadState(stateFile);
+
+  return {
+    success: true,
+    slos: state.slos,
+    slas: state.slas,
+    total_slos: state.slos.length,
+    total_slas: state.slas.length,
+    by_service: state.slos.reduce<Record<string, SloEntry[]>>((acc, s) => {
+      acc[s.service] = acc[s.service] ?? [];
+      acc[s.service]!.push(s);
+      return acc;
+    }, {}),
+    by_type: state.slos.reduce<Record<string, number>>((acc, s) => {
+      acc[s.type] = (acc[s.type] ?? 0) + 1;
+      return acc;
+    }, {}),
+  };
+}

--- a/src/lib/sla-slo.ts
+++ b/src/lib/sla-slo.ts
@@ -26,7 +26,14 @@ import { dirname, join } from 'node:path';
 
 const DEFAULT_STATE_FILE = join('.jumpstart', 'state', 'sla-slo.json');
 
-export const SLO_TYPES = ['availability', 'latency', 'throughput', 'error-rate', 'durability', 'freshness'] as const;
+export const SLO_TYPES = [
+  'availability',
+  'latency',
+  'throughput',
+  'error-rate',
+  'durability',
+  'freshness',
+] as const;
 export type SloType = (typeof SLO_TYPES)[number];
 
 export interface SloTemplate {
@@ -120,7 +127,7 @@ export function saveState(state: SlaState, stateFile?: string): void {
   const dir = dirname(fp);
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
   state.last_updated = new Date().toISOString();
-  writeFileSync(fp, JSON.stringify(state, null, 2) + '\n', 'utf8');
+  writeFileSync(fp, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
 }
 
 export interface DefineSLOInput {
@@ -141,7 +148,7 @@ export interface DefineSLOResult {
 
 export function defineSLO(
   slo: DefineSLOInput,
-  options: { stateFile?: string | undefined } = {},
+  options: { stateFile?: string | undefined } = {}
 ): DefineSLOResult {
   if (!slo?.name || !slo.service || slo.target === undefined) {
     return { success: false, error: 'name, service, and target are required' };
@@ -184,27 +191,38 @@ export interface ApplyTemplateResult {
 export function applyTemplate(
   serviceName: string,
   templateType: string,
-  options: { stateFile?: string | undefined } = {},
+  options: { stateFile?: string | undefined } = {}
 ): ApplyTemplateResult {
   const template = DEFAULT_SLO_TEMPLATES[templateType];
   if (!template) {
-    return { success: false, error: `Unknown template: ${templateType}. Available: ${Object.keys(DEFAULT_SLO_TEMPLATES).join(', ')}` };
+    return {
+      success: false,
+      error: `Unknown template: ${templateType}. Available: ${Object.keys(DEFAULT_SLO_TEMPLATES).join(', ')}`,
+    };
   }
 
   const results: DefineSLOResult[] = [];
   for (const t of template) {
-    const result = defineSLO({
-      name: `${serviceName} ${t.type}`,
-      service: serviceName,
-      type: t.type,
-      target: t.target,
-      unit: t.unit,
-      window: t.window,
-    }, options);
+    const result = defineSLO(
+      {
+        name: `${serviceName} ${t.type}`,
+        service: serviceName,
+        type: t.type,
+        target: t.target,
+        unit: t.unit,
+        window: t.window,
+      },
+      options
+    );
     results.push(result);
   }
 
-  return { success: true, service: serviceName, template: templateType, slos_created: results.length };
+  return {
+    success: true,
+    service: serviceName,
+    template: templateType,
+    slos_created: results.length,
+  };
 }
 
 export interface CoverageResult {
@@ -218,7 +236,7 @@ export interface CoverageResult {
 
 export function checkSLOCoverage(
   root: string,
-  options: { stateFile?: string | undefined } = {},
+  options: { stateFile?: string | undefined } = {}
 ): CoverageResult {
   const stateFile = options.stateFile ?? join(root, DEFAULT_STATE_FILE);
   const state = loadState(stateFile);
@@ -233,14 +251,18 @@ export function checkSLOCoverage(
     try {
       const content = readFileSync(archFile, 'utf8');
       archHasSLO = /\bSL[OA]\b|service.level|availability|latency.target/i.test(content);
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
   }
 
   if (existsSync(prdFile)) {
     try {
       const content = readFileSync(prdFile, 'utf8');
       prdHasSLO = /\bSL[OA]\b|service.level|availability|uptime/i.test(content);
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
   }
 
   return {
@@ -249,7 +271,8 @@ export function checkSLOCoverage(
     architecture_mentions_slo: archHasSLO,
     prd_mentions_slo: prdHasSLO,
     coverage: state.slos.length > 0 ? 'defined' : 'missing',
-    recommendations: state.slos.length === 0 ? ['Define SLOs using `jumpstart-mode sla-slo define`'] : [],
+    recommendations:
+      state.slos.length === 0 ? ['Define SLOs using `jumpstart-mode sla-slo define`'] : [],
   };
 }
 
@@ -275,7 +298,7 @@ export function generateReport(options: { stateFile?: string | undefined } = {})
     total_slas: state.slas.length,
     by_service: state.slos.reduce<Record<string, SloEntry[]>>((acc, s) => {
       acc[s.service] = acc[s.service] ?? [];
-      acc[s.service]!.push(s);
+      acc[s.service]?.push(s);
       return acc;
     }, {}),
     by_type: state.slos.reduce<Record<string, number>>((acc, s) => {

--- a/src/lib/spec-comments.ts
+++ b/src/lib/spec-comments.ts
@@ -1,0 +1,202 @@
+/**
+ * spec-comments.ts — Inline Spec Review Comments port (M11 batch 6).
+ *
+ * Pure-library port of `bin/lib/spec-comments.js` (CJS). Public surface:
+ *   - `addComment(artifact, section, text, options?)` => CommentResult
+ *   - `resolveComment(commentId, resolution, options?)` => CommentResult
+ *   - `listComments(options?)` => ListCommentsResult
+ *   - `assignComment(commentId, assignee, options?)` => CommentResult
+ *   - `loadState(stateFile?)` => CommentsState
+ *   - `saveState(state, stateFile?)` => void
+ *   - `defaultState()` => CommentsState
+ *   - `COMMENT_STATUSES`
+ *
+ * M3 hardening:
+ *   - `loadState` runs `rejectPollutionKeys` on parsed JSON.
+ *   - On parse failure or pollution, returns `defaultState()`.
+ *
+ * Path-safety per ADR-009: No user-supplied paths to fs. Not applicable.
+ *
+ * @see bin/lib/spec-comments.js (legacy reference)
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+const DEFAULT_STATE_FILE = join('.jumpstart', 'state', 'spec-comments.json');
+
+export const COMMENT_STATUSES = ['open', 'resolved', 'wontfix', 'deferred'] as const;
+export type CommentStatus = (typeof COMMENT_STATUSES)[number];
+
+export interface Comment {
+  id: string;
+  artifact: string;
+  section: string | null;
+  text: string;
+  author: string;
+  assignee: string | null;
+  status: CommentStatus;
+  created_at: string;
+  resolved_at: string | null;
+  replies: unknown[];
+  resolution?: string | undefined;
+  resolved_by?: string | undefined;
+}
+
+export interface CommentsState {
+  version: string;
+  created_at: string;
+  last_updated: string | null;
+  comments: Comment[];
+}
+
+function rejectPollutionKeys(obj: unknown): void {
+  if (obj === null || typeof obj !== 'object') return;
+  const forbidden = new Set(['__proto__', 'constructor', 'prototype']);
+  for (const key of Object.keys(obj as Record<string, unknown>)) {
+    if (forbidden.has(key)) throw new Error(`Prototype-pollution key detected: "${key}"`);
+    rejectPollutionKeys((obj as Record<string, unknown>)[key]);
+  }
+}
+
+export function defaultState(): CommentsState {
+  return {
+    version: '1.0.0',
+    created_at: new Date().toISOString(),
+    last_updated: null,
+    comments: [],
+  };
+}
+
+export function loadState(stateFile?: string): CommentsState {
+  const fp = stateFile ?? DEFAULT_STATE_FILE;
+  if (!existsSync(fp)) return defaultState();
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(fp, 'utf8'));
+    rejectPollutionKeys(parsed);
+    return parsed as CommentsState;
+  } catch {
+    return defaultState();
+  }
+}
+
+export function saveState(state: CommentsState, stateFile?: string): void {
+  const fp = stateFile ?? DEFAULT_STATE_FILE;
+  const dir = dirname(fp);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  state.last_updated = new Date().toISOString();
+  writeFileSync(fp, JSON.stringify(state, null, 2) + '\n', 'utf8');
+}
+
+export interface CommentResult {
+  success: boolean;
+  comment?: Comment | undefined;
+  error?: string | undefined;
+}
+
+export function addComment(
+  artifact: string,
+  section: string | null | undefined,
+  text: string,
+  options: {
+    stateFile?: string | undefined;
+    author?: string | undefined;
+    assignee?: string | undefined;
+  } = {},
+): CommentResult {
+  if (!artifact || !text) return { success: false, error: 'artifact and text are required' };
+
+  const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
+  const state = loadState(stateFile);
+
+  const comment: Comment = {
+    id: `C-${Date.now()}`,
+    artifact,
+    section: section ?? null,
+    text,
+    author: options.author ?? 'anonymous',
+    assignee: options.assignee ?? null,
+    status: 'open',
+    created_at: new Date().toISOString(),
+    resolved_at: null,
+    replies: [],
+  };
+
+  state.comments.push(comment);
+  saveState(state, stateFile);
+
+  return { success: true, comment };
+}
+
+export function resolveComment(
+  commentId: string,
+  resolution: string | undefined,
+  options: { stateFile?: string | undefined; author?: string | undefined } = {},
+): CommentResult {
+  if (!commentId) return { success: false, error: 'commentId is required' };
+
+  const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
+  const state = loadState(stateFile);
+
+  const comment = state.comments.find(c => c.id === commentId);
+  if (!comment) return { success: false, error: `Comment ${commentId} not found` };
+
+  comment.status = 'resolved';
+  comment.resolution = resolution ?? 'Resolved';
+  comment.resolved_at = new Date().toISOString();
+  comment.resolved_by = options.author ?? 'anonymous';
+  saveState(state, stateFile);
+
+  return { success: true, comment };
+}
+
+export interface ListCommentsResult {
+  success: true;
+  total: number;
+  comments: Comment[];
+}
+
+export function listComments(
+  options: {
+    stateFile?: string | undefined;
+    artifact?: string | undefined;
+    status?: string | undefined;
+    assignee?: string | undefined;
+  } = {},
+): ListCommentsResult {
+  const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
+  const state = loadState(stateFile);
+
+  let comments = state.comments;
+
+  if (options.artifact) {
+    comments = comments.filter(c => c.artifact === options.artifact);
+  }
+  if (options.status) {
+    comments = comments.filter(c => c.status === options.status);
+  }
+  if (options.assignee) {
+    comments = comments.filter(c => c.assignee === options.assignee);
+  }
+
+  return { success: true, total: comments.length, comments };
+}
+
+export function assignComment(
+  commentId: string,
+  assignee: string,
+  options: { stateFile?: string | undefined } = {},
+): CommentResult {
+  if (!commentId || !assignee) return { success: false, error: 'commentId and assignee are required' };
+
+  const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
+  const state = loadState(stateFile);
+
+  const comment = state.comments.find(c => c.id === commentId);
+  if (!comment) return { success: false, error: `Comment ${commentId} not found` };
+
+  comment.assignee = assignee;
+  saveState(state, stateFile);
+
+  return { success: true, comment };
+}

--- a/src/lib/spec-comments.ts
+++ b/src/lib/spec-comments.ts
@@ -85,7 +85,7 @@ export function saveState(state: CommentsState, stateFile?: string): void {
   const dir = dirname(fp);
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
   state.last_updated = new Date().toISOString();
-  writeFileSync(fp, JSON.stringify(state, null, 2) + '\n', 'utf8');
+  writeFileSync(fp, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
 }
 
 export interface CommentResult {
@@ -102,7 +102,7 @@ export function addComment(
     stateFile?: string | undefined;
     author?: string | undefined;
     assignee?: string | undefined;
-  } = {},
+  } = {}
 ): CommentResult {
   if (!artifact || !text) return { success: false, error: 'artifact and text are required' };
 
@@ -131,14 +131,14 @@ export function addComment(
 export function resolveComment(
   commentId: string,
   resolution: string | undefined,
-  options: { stateFile?: string | undefined; author?: string | undefined } = {},
+  options: { stateFile?: string | undefined; author?: string | undefined } = {}
 ): CommentResult {
   if (!commentId) return { success: false, error: 'commentId is required' };
 
   const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
   const state = loadState(stateFile);
 
-  const comment = state.comments.find(c => c.id === commentId);
+  const comment = state.comments.find((c) => c.id === commentId);
   if (!comment) return { success: false, error: `Comment ${commentId} not found` };
 
   comment.status = 'resolved';
@@ -162,7 +162,7 @@ export function listComments(
     artifact?: string | undefined;
     status?: string | undefined;
     assignee?: string | undefined;
-  } = {},
+  } = {}
 ): ListCommentsResult {
   const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
   const state = loadState(stateFile);
@@ -170,13 +170,13 @@ export function listComments(
   let comments = state.comments;
 
   if (options.artifact) {
-    comments = comments.filter(c => c.artifact === options.artifact);
+    comments = comments.filter((c) => c.artifact === options.artifact);
   }
   if (options.status) {
-    comments = comments.filter(c => c.status === options.status);
+    comments = comments.filter((c) => c.status === options.status);
   }
   if (options.assignee) {
-    comments = comments.filter(c => c.assignee === options.assignee);
+    comments = comments.filter((c) => c.assignee === options.assignee);
   }
 
   return { success: true, total: comments.length, comments };
@@ -185,14 +185,15 @@ export function listComments(
 export function assignComment(
   commentId: string,
   assignee: string,
-  options: { stateFile?: string | undefined } = {},
+  options: { stateFile?: string | undefined } = {}
 ): CommentResult {
-  if (!commentId || !assignee) return { success: false, error: 'commentId and assignee are required' };
+  if (!commentId || !assignee)
+    return { success: false, error: 'commentId and assignee are required' };
 
   const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
   const state = loadState(stateFile);
 
-  const comment = state.comments.find(c => c.id === commentId);
+  const comment = state.comments.find((c) => c.id === commentId);
   if (!comment) return { success: false, error: `Comment ${commentId} not found` };
 
   comment.assignee = assignee;

--- a/src/lib/spec-maturity.ts
+++ b/src/lib/spec-maturity.ts
@@ -26,11 +26,31 @@ export interface MaturityLevel {
 }
 
 export const MATURITY_LEVELS: MaturityLevel[] = [
-  { level: 1, name: 'Draft', min_score: 0, description: 'Initial capture, may contain placeholders and gaps' },
+  {
+    level: 1,
+    name: 'Draft',
+    min_score: 0,
+    description: 'Initial capture, may contain placeholders and gaps',
+  },
   { level: 2, name: 'Reviewed', min_score: 30, description: 'Peer-reviewed, major gaps addressed' },
-  { level: 3, name: 'Approved', min_score: 55, description: 'Stakeholder-approved, phase gate passed' },
-  { level: 4, name: 'Implementation-Ready', min_score: 75, description: 'Detailed enough for developers to implement' },
-  { level: 5, name: 'Production-Ready', min_score: 90, description: 'Complete, validated, enterprise-ready' },
+  {
+    level: 3,
+    name: 'Approved',
+    min_score: 55,
+    description: 'Stakeholder-approved, phase gate passed',
+  },
+  {
+    level: 4,
+    name: 'Implementation-Ready',
+    min_score: 75,
+    description: 'Detailed enough for developers to implement',
+  },
+  {
+    level: 5,
+    name: 'Production-Ready',
+    min_score: 90,
+    description: 'Complete, validated, enterprise-ready',
+  },
 ];
 
 export interface CriterionDef {
@@ -71,7 +91,7 @@ export const MATURITY_CRITERIA: Record<string, CriteriaCategory> = {
     ],
   },
   quality: {
-    weight: 0.20,
+    weight: 0.2,
     checks: [
       { id: 'has_acceptance_criteria', description: 'Acceptance criteria defined' },
       { id: 'has_diagrams', description: 'Diagrams included (Mermaid/images)' },
@@ -88,7 +108,7 @@ export const MATURITY_CRITERIA: Record<string, CriteriaCategory> = {
     ],
   },
   enterprise: {
-    weight: 0.10,
+    weight: 0.1,
     checks: [
       { id: 'has_nfrs', description: 'Non-functional requirements addressed' },
       { id: 'has_security', description: 'Security considerations' },
@@ -103,10 +123,10 @@ export function runMaturityChecks(content: string): MaturityChecks {
   const results: MaturityChecks = {};
   const lines = content.split('\n');
 
-  results['has_frontmatter'] = content.startsWith('---');
-  results['has_toc'] = /table of contents|## contents|## toc/i.test(content);
-  const headings = lines.filter(l => /^#{1,4}\s+/.test(l));
-  results['has_sections'] = headings.length >= 3;
+  results.has_frontmatter = content.startsWith('---');
+  results.has_toc = /table of contents|## contents|## toc/i.test(content);
+  const headings = lines.filter((l) => /^#{1,4}\s+/.test(l));
+  results.has_sections = headings.length >= 3;
 
   let emptyCount = 0;
   let currentHeading: string | null = null;
@@ -120,43 +140,57 @@ export function runMaturityChecks(content: string): MaturityChecks {
       hasContentAfterHeading = true;
     }
   }
-  results['no_empty_sections'] = emptyCount === 0;
+  results.no_empty_sections = emptyCount === 0;
 
-  results['no_placeholders'] = !/\[TODO\]|\[TBD\]|\[PLACEHOLDER\]/i.test(content);
-  results['no_clarifications'] = !/\[NEEDS CLARIFICATION/i.test(content);
-  results['sufficient_length'] = content.length > 1000;
+  results.no_placeholders = !/\[TODO\]|\[TBD\]|\[PLACEHOLDER\]/i.test(content);
+  results.no_clarifications = !/\[NEEDS CLARIFICATION/i.test(content);
+  results.sufficient_length = content.length > 1000;
 
-  const paragraphs = content.split(/\n\n+/).filter(p => p.trim().length > 0 && !/^#/.test(p.trim()));
+  const paragraphs = content
+    .split(/\n\n+/)
+    .filter((p) => p.trim().length > 0 && !/^#/.test(p.trim()));
   const avgWords =
     paragraphs.length > 0
       ? paragraphs.reduce((sum, p) => sum + p.split(/\s+/).length, 0) / paragraphs.length
       : 0;
-  results['has_detail'] = avgWords > 20;
+  results.has_detail = avgWords > 20;
 
-  results['has_requirement_ids'] = /\b(REQ-\d+|E\d+-S\d+|NFR-\d+|UC-\d+|FR-\d+|AC-\d+|M\d+-T\d+)\b/.test(content);
-  results['has_cross_refs'] = /\[.*\]\(.*\.md\)/.test(content);
-  results['has_version'] = /version[:\s]+\d+/i.test(content) || /^version:/m.test(content);
+  results.has_requirement_ids =
+    /\b(REQ-\d+|E\d+-S\d+|NFR-\d+|UC-\d+|FR-\d+|AC-\d+|M\d+-T\d+)\b/.test(content);
+  results.has_cross_refs = /\[.*\]\(.*\.md\)/.test(content);
+  results.has_version = /version[:\s]+\d+/i.test(content) || /^version:/m.test(content);
 
-  results['has_acceptance_criteria'] = /acceptance\s+criteria/i.test(content);
-  results['has_diagrams'] = /```mermaid|flowchart|sequenceDiagram|classDiagram|\!\[.*\]\(.*\)/i.test(content);
-  results['has_examples'] = /```\w+/.test(content) || /example[:\s]/i.test(content);
+  results.has_acceptance_criteria = /acceptance\s+criteria/i.test(content);
+  results.has_diagrams = /```mermaid|flowchart|sequenceDiagram|classDiagram|!\[.*\]\(.*\)/i.test(
+    content
+  );
+  results.has_examples = /```\w+/.test(content) || /example[:\s]/i.test(content);
 
-  const ambiguousTerms = ['should', 'might', 'could', 'may', 'possibly', 'potentially', 'TBD', 'TBA'];
+  const ambiguousTerms = [
+    'should',
+    'might',
+    'could',
+    'may',
+    'possibly',
+    'potentially',
+    'TBD',
+    'TBA',
+  ];
   let ambiguousCount = 0;
   for (const term of ambiguousTerms) {
     const pattern = new RegExp(`\\b${term}\\b`, 'gi');
     ambiguousCount += (content.match(pattern) ?? []).length;
   }
   const wordCount = content.split(/\s+/).length;
-  results['low_ambiguity'] = wordCount > 0 ? ambiguousCount / wordCount < 0.02 : true;
+  results.low_ambiguity = wordCount > 0 ? ambiguousCount / wordCount < 0.02 : true;
 
-  results['has_approval'] = /Phase Gate Approval/i.test(content);
-  results['is_approved'] = /- \[x\]/i.test(content) && /Approved by[:\s]+(?!Pending)/i.test(content);
-  results['has_dates'] = /\d{4}-\d{2}-\d{2}/.test(content);
+  results.has_approval = /Phase Gate Approval/i.test(content);
+  results.is_approved = /- \[x\]/i.test(content) && /Approved by[:\s]+(?!Pending)/i.test(content);
+  results.has_dates = /\d{4}-\d{2}-\d{2}/.test(content);
 
-  results['has_nfrs'] = /non-functional|NFR|performance|scalab|availab/i.test(content);
-  results['has_security'] = /security|auth|encryption|OWASP/i.test(content);
-  results['has_compliance'] = /compliance|regulatory|GDPR|HIPAA|SOC|audit/i.test(content);
+  results.has_nfrs = /non-functional|NFR|performance|scalab|availab/i.test(content);
+  results.has_security = /security|auth|encryption|OWASP/i.test(content);
+  results.has_compliance = /compliance|regulatory|GDPR|HIPAA|SOC|audit/i.test(content);
 
   return results;
 }
@@ -182,31 +216,41 @@ export interface MaturityResult {
   maturity_description?: string | undefined;
   category_scores?: Record<string, CategoryScore> | undefined;
   gaps?: Gap[] | undefined;
-  next_level?: {
-    level: number;
-    name: string;
-    points_needed: number;
-    description: string;
-  } | null | undefined;
+  next_level?:
+    | {
+        level: number;
+        name: string;
+        points_needed: number;
+        description: string;
+      }
+    | null
+    | undefined;
   total_checks?: number | undefined;
   checks_passed?: number | undefined;
   file?: string | undefined;
   error?: string | undefined;
 }
 
-export function assessMaturity(content: string, _options: Record<string, unknown> = {}): MaturityResult {
+export function assessMaturity(
+  content: string,
+  _options: Record<string, unknown> = {}
+): MaturityResult {
   const checkResults = runMaturityChecks(content);
   const categoryScores: Record<string, CategoryScore> = {};
   let totalWeightedScore = 0;
   const gaps: Gap[] = [];
 
   for (const [category, config] of Object.entries(MATURITY_CRITERIA)) {
-    const passed = config.checks.filter(c => checkResults[c.id]);
-    const score = config.checks.length > 0
-      ? Math.round((passed.length / config.checks.length) * 100)
-      : 0;
+    const passed = config.checks.filter((c) => checkResults[c.id]);
+    const score =
+      config.checks.length > 0 ? Math.round((passed.length / config.checks.length) * 100) : 0;
 
-    categoryScores[category] = { score, passed: passed.length, total: config.checks.length, weight: config.weight };
+    categoryScores[category] = {
+      score,
+      passed: passed.length,
+      total: config.checks.length,
+      weight: config.weight,
+    };
     totalWeightedScore += score * config.weight;
 
     for (const check of config.checks) {
@@ -217,10 +261,16 @@ export function assessMaturity(content: string, _options: Record<string, unknown
   }
 
   const overallScore = Math.round(totalWeightedScore);
+  const fallbackLevel: MaturityLevel = MATURITY_LEVELS[0] ?? {
+    level: 1,
+    name: 'Unknown',
+    min_score: 0,
+    description: 'Unknown maturity',
+  };
   const maturityLevel =
-    [...MATURITY_LEVELS].reverse().find(l => overallScore >= l.min_score) ?? MATURITY_LEVELS[0]!;
+    [...MATURITY_LEVELS].reverse().find((l) => overallScore >= l.min_score) ?? fallbackLevel;
 
-  const nextLevel = MATURITY_LEVELS.find(l => l.min_score > overallScore);
+  const nextLevel = MATURITY_LEVELS.find((l) => l.min_score > overallScore);
 
   return {
     success: true,
@@ -231,17 +281,25 @@ export function assessMaturity(content: string, _options: Record<string, unknown
     category_scores: categoryScores,
     gaps,
     next_level: nextLevel
-      ? { level: nextLevel.level, name: nextLevel.name, points_needed: nextLevel.min_score - overallScore, description: nextLevel.description }
+      ? {
+          level: nextLevel.level,
+          name: nextLevel.name,
+          points_needed: nextLevel.min_score - overallScore,
+          description: nextLevel.description,
+        }
       : null,
     total_checks: Object.values(MATURITY_CRITERIA).reduce((sum, c) => sum + c.checks.length, 0),
     checks_passed: Object.values(MATURITY_CRITERIA).reduce(
-      (sum, c) => sum + c.checks.filter(ck => checkResults[ck.id]).length,
-      0,
+      (sum, c) => sum + c.checks.filter((ck) => checkResults[ck.id]).length,
+      0
     ),
   };
 }
 
-export function assessFile(filePath: string, options: Record<string, unknown> = {}): MaturityResult {
+export function assessFile(
+  filePath: string,
+  options: Record<string, unknown> = {}
+): MaturityResult {
   if (!existsSync(filePath)) {
     return { success: false, error: `File not found: ${filePath}` };
   }
@@ -261,22 +319,33 @@ export interface ProjectMaturityResult {
   project_maturity?: string | undefined;
   project_level?: number | undefined;
   artifacts?: ArtifactMaturityResult[] | undefined;
-  summary?: {
-    artifacts_assessed: number;
-    average_score: number;
-    production_ready: number;
-    draft: number;
-  } | undefined;
+  summary?:
+    | {
+        artifacts_assessed: number;
+        average_score: number;
+        production_ready: number;
+        draft: number;
+      }
+    | undefined;
   error?: string | undefined;
 }
 
-export function assessProject(root: string, options: Record<string, unknown> = {}): ProjectMaturityResult {
+export function assessProject(
+  root: string,
+  options: Record<string, unknown> = {}
+): ProjectMaturityResult {
   const specsDir = join(root, 'specs');
   if (!existsSync(specsDir)) {
     return { success: false, error: 'specs/ directory not found' };
   }
 
-  const artifacts = ['challenger-brief.md', 'product-brief.md', 'prd.md', 'architecture.md', 'implementation-plan.md'];
+  const artifacts = [
+    'challenger-brief.md',
+    'product-brief.md',
+    'prd.md',
+    'architecture.md',
+    'implementation-plan.md',
+  ];
   const results: ArtifactMaturityResult[] = [];
 
   for (const artifact of artifacts) {
@@ -292,8 +361,14 @@ export function assessProject(root: string, options: Record<string, unknown> = {
       ? Math.round(results.reduce((sum, r) => sum + (r.overall_score ?? 0), 0) / results.length)
       : 0;
 
+  const avgFallback: MaturityLevel = MATURITY_LEVELS[0] ?? {
+    level: 1,
+    name: 'Unknown',
+    min_score: 0,
+    description: 'Unknown maturity',
+  };
   const avgLevel =
-    [...MATURITY_LEVELS].reverse().find(l => avgScore >= l.min_score) ?? MATURITY_LEVELS[0]!;
+    [...MATURITY_LEVELS].reverse().find((l) => avgScore >= l.min_score) ?? avgFallback;
 
   return {
     success: true,
@@ -304,8 +379,8 @@ export function assessProject(root: string, options: Record<string, unknown> = {
     summary: {
       artifacts_assessed: results.length,
       average_score: avgScore,
-      production_ready: results.filter(r => (r.maturity_level ?? 0) >= 5).length,
-      draft: results.filter(r => (r.maturity_level ?? 0) <= 1).length,
+      production_ready: results.filter((r) => (r.maturity_level ?? 0) >= 5).length,
+      draft: results.filter((r) => (r.maturity_level ?? 0) <= 1).length,
     },
   };
 }

--- a/src/lib/spec-maturity.ts
+++ b/src/lib/spec-maturity.ts
@@ -1,0 +1,311 @@
+/**
+ * spec-maturity.ts — Spec Maturity Model port (M11 batch 6).
+ *
+ * Pure-library port of `bin/lib/spec-maturity.js` (CJS). Public surface:
+ *   - `runMaturityChecks(content)` => MaturityChecks
+ *   - `assessMaturity(content, options?)` => MaturityResult
+ *   - `assessFile(filePath, options?)` => MaturityResult
+ *   - `assessProject(root, options?)` => ProjectMaturityResult
+ *   - `MATURITY_LEVELS`
+ *   - `MATURITY_CRITERIA`
+ *
+ * M3 hardening: No JSON state paths. Not applicable.
+ * Path-safety per ADR-009: `assessFile`/`assessProject` paths come from CLI.
+ *
+ * @see bin/lib/spec-maturity.js (legacy reference)
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface MaturityLevel {
+  level: number;
+  name: string;
+  min_score: number;
+  description: string;
+}
+
+export const MATURITY_LEVELS: MaturityLevel[] = [
+  { level: 1, name: 'Draft', min_score: 0, description: 'Initial capture, may contain placeholders and gaps' },
+  { level: 2, name: 'Reviewed', min_score: 30, description: 'Peer-reviewed, major gaps addressed' },
+  { level: 3, name: 'Approved', min_score: 55, description: 'Stakeholder-approved, phase gate passed' },
+  { level: 4, name: 'Implementation-Ready', min_score: 75, description: 'Detailed enough for developers to implement' },
+  { level: 5, name: 'Production-Ready', min_score: 90, description: 'Complete, validated, enterprise-ready' },
+];
+
+export interface CriterionDef {
+  id: string;
+  description: string;
+}
+
+export interface CriteriaCategory {
+  weight: number;
+  checks: CriterionDef[];
+}
+
+export const MATURITY_CRITERIA: Record<string, CriteriaCategory> = {
+  structure: {
+    weight: 0.15,
+    checks: [
+      { id: 'has_frontmatter', description: 'YAML frontmatter present' },
+      { id: 'has_toc', description: 'Table of contents present' },
+      { id: 'has_sections', description: 'Proper heading hierarchy' },
+      { id: 'no_empty_sections', description: 'No empty sections' },
+    ],
+  },
+  completeness: {
+    weight: 0.25,
+    checks: [
+      { id: 'no_placeholders', description: 'No TODO/TBD/placeholder markers' },
+      { id: 'no_clarifications', description: 'No [NEEDS CLARIFICATION] tags' },
+      { id: 'sufficient_length', description: 'Sufficient content (>1000 chars)' },
+      { id: 'has_detail', description: 'Detailed descriptions (avg paragraph >50 words)' },
+    ],
+  },
+  traceability: {
+    weight: 0.15,
+    checks: [
+      { id: 'has_requirement_ids', description: 'Contains requirement/story IDs' },
+      { id: 'has_cross_refs', description: 'Cross-references to other artifacts' },
+      { id: 'has_version', description: 'Version information present' },
+    ],
+  },
+  quality: {
+    weight: 0.20,
+    checks: [
+      { id: 'has_acceptance_criteria', description: 'Acceptance criteria defined' },
+      { id: 'has_diagrams', description: 'Diagrams included (Mermaid/images)' },
+      { id: 'has_examples', description: 'Examples or code samples' },
+      { id: 'low_ambiguity', description: 'Low ambiguity (minimal should/might/could)' },
+    ],
+  },
+  governance: {
+    weight: 0.15,
+    checks: [
+      { id: 'has_approval', description: 'Phase gate approval section' },
+      { id: 'is_approved', description: 'Actually approved (checkboxes checked)' },
+      { id: 'has_dates', description: 'Dates and timestamps present' },
+    ],
+  },
+  enterprise: {
+    weight: 0.10,
+    checks: [
+      { id: 'has_nfrs', description: 'Non-functional requirements addressed' },
+      { id: 'has_security', description: 'Security considerations' },
+      { id: 'has_compliance', description: 'Compliance/regulatory mentions' },
+    ],
+  },
+};
+
+export type MaturityChecks = Record<string, boolean>;
+
+export function runMaturityChecks(content: string): MaturityChecks {
+  const results: MaturityChecks = {};
+  const lines = content.split('\n');
+
+  results['has_frontmatter'] = content.startsWith('---');
+  results['has_toc'] = /table of contents|## contents|## toc/i.test(content);
+  const headings = lines.filter(l => /^#{1,4}\s+/.test(l));
+  results['has_sections'] = headings.length >= 3;
+
+  let emptyCount = 0;
+  let currentHeading: string | null = null;
+  let hasContentAfterHeading = false;
+  for (const line of lines) {
+    if (/^#{1,4}\s+/.test(line)) {
+      if (currentHeading && !hasContentAfterHeading) emptyCount++;
+      currentHeading = line;
+      hasContentAfterHeading = false;
+    } else if (line.trim().length > 0 && currentHeading) {
+      hasContentAfterHeading = true;
+    }
+  }
+  results['no_empty_sections'] = emptyCount === 0;
+
+  results['no_placeholders'] = !/\[TODO\]|\[TBD\]|\[PLACEHOLDER\]/i.test(content);
+  results['no_clarifications'] = !/\[NEEDS CLARIFICATION/i.test(content);
+  results['sufficient_length'] = content.length > 1000;
+
+  const paragraphs = content.split(/\n\n+/).filter(p => p.trim().length > 0 && !/^#/.test(p.trim()));
+  const avgWords =
+    paragraphs.length > 0
+      ? paragraphs.reduce((sum, p) => sum + p.split(/\s+/).length, 0) / paragraphs.length
+      : 0;
+  results['has_detail'] = avgWords > 20;
+
+  results['has_requirement_ids'] = /\b(REQ-\d+|E\d+-S\d+|NFR-\d+|UC-\d+|FR-\d+|AC-\d+|M\d+-T\d+)\b/.test(content);
+  results['has_cross_refs'] = /\[.*\]\(.*\.md\)/.test(content);
+  results['has_version'] = /version[:\s]+\d+/i.test(content) || /^version:/m.test(content);
+
+  results['has_acceptance_criteria'] = /acceptance\s+criteria/i.test(content);
+  results['has_diagrams'] = /```mermaid|flowchart|sequenceDiagram|classDiagram|\!\[.*\]\(.*\)/i.test(content);
+  results['has_examples'] = /```\w+/.test(content) || /example[:\s]/i.test(content);
+
+  const ambiguousTerms = ['should', 'might', 'could', 'may', 'possibly', 'potentially', 'TBD', 'TBA'];
+  let ambiguousCount = 0;
+  for (const term of ambiguousTerms) {
+    const pattern = new RegExp(`\\b${term}\\b`, 'gi');
+    ambiguousCount += (content.match(pattern) ?? []).length;
+  }
+  const wordCount = content.split(/\s+/).length;
+  results['low_ambiguity'] = wordCount > 0 ? ambiguousCount / wordCount < 0.02 : true;
+
+  results['has_approval'] = /Phase Gate Approval/i.test(content);
+  results['is_approved'] = /- \[x\]/i.test(content) && /Approved by[:\s]+(?!Pending)/i.test(content);
+  results['has_dates'] = /\d{4}-\d{2}-\d{2}/.test(content);
+
+  results['has_nfrs'] = /non-functional|NFR|performance|scalab|availab/i.test(content);
+  results['has_security'] = /security|auth|encryption|OWASP/i.test(content);
+  results['has_compliance'] = /compliance|regulatory|GDPR|HIPAA|SOC|audit/i.test(content);
+
+  return results;
+}
+
+export interface Gap {
+  category: string;
+  check: string;
+  description: string;
+}
+
+export interface CategoryScore {
+  score: number;
+  passed: number;
+  total: number;
+  weight: number;
+}
+
+export interface MaturityResult {
+  success: boolean;
+  overall_score?: number | undefined;
+  maturity_level?: number | undefined;
+  maturity_name?: string | undefined;
+  maturity_description?: string | undefined;
+  category_scores?: Record<string, CategoryScore> | undefined;
+  gaps?: Gap[] | undefined;
+  next_level?: {
+    level: number;
+    name: string;
+    points_needed: number;
+    description: string;
+  } | null | undefined;
+  total_checks?: number | undefined;
+  checks_passed?: number | undefined;
+  file?: string | undefined;
+  error?: string | undefined;
+}
+
+export function assessMaturity(content: string, _options: Record<string, unknown> = {}): MaturityResult {
+  const checkResults = runMaturityChecks(content);
+  const categoryScores: Record<string, CategoryScore> = {};
+  let totalWeightedScore = 0;
+  const gaps: Gap[] = [];
+
+  for (const [category, config] of Object.entries(MATURITY_CRITERIA)) {
+    const passed = config.checks.filter(c => checkResults[c.id]);
+    const score = config.checks.length > 0
+      ? Math.round((passed.length / config.checks.length) * 100)
+      : 0;
+
+    categoryScores[category] = { score, passed: passed.length, total: config.checks.length, weight: config.weight };
+    totalWeightedScore += score * config.weight;
+
+    for (const check of config.checks) {
+      if (!checkResults[check.id]) {
+        gaps.push({ category, check: check.id, description: check.description });
+      }
+    }
+  }
+
+  const overallScore = Math.round(totalWeightedScore);
+  const maturityLevel =
+    [...MATURITY_LEVELS].reverse().find(l => overallScore >= l.min_score) ?? MATURITY_LEVELS[0]!;
+
+  const nextLevel = MATURITY_LEVELS.find(l => l.min_score > overallScore);
+
+  return {
+    success: true,
+    overall_score: overallScore,
+    maturity_level: maturityLevel.level,
+    maturity_name: maturityLevel.name,
+    maturity_description: maturityLevel.description,
+    category_scores: categoryScores,
+    gaps,
+    next_level: nextLevel
+      ? { level: nextLevel.level, name: nextLevel.name, points_needed: nextLevel.min_score - overallScore, description: nextLevel.description }
+      : null,
+    total_checks: Object.values(MATURITY_CRITERIA).reduce((sum, c) => sum + c.checks.length, 0),
+    checks_passed: Object.values(MATURITY_CRITERIA).reduce(
+      (sum, c) => sum + c.checks.filter(ck => checkResults[ck.id]).length,
+      0,
+    ),
+  };
+}
+
+export function assessFile(filePath: string, options: Record<string, unknown> = {}): MaturityResult {
+  if (!existsSync(filePath)) {
+    return { success: false, error: `File not found: ${filePath}` };
+  }
+  const content = readFileSync(filePath, 'utf8');
+  const result = assessMaturity(content, options);
+  result.file = filePath;
+  return result;
+}
+
+export interface ArtifactMaturityResult extends MaturityResult {
+  artifact: string;
+}
+
+export interface ProjectMaturityResult {
+  success: boolean;
+  project_score?: number | undefined;
+  project_maturity?: string | undefined;
+  project_level?: number | undefined;
+  artifacts?: ArtifactMaturityResult[] | undefined;
+  summary?: {
+    artifacts_assessed: number;
+    average_score: number;
+    production_ready: number;
+    draft: number;
+  } | undefined;
+  error?: string | undefined;
+}
+
+export function assessProject(root: string, options: Record<string, unknown> = {}): ProjectMaturityResult {
+  const specsDir = join(root, 'specs');
+  if (!existsSync(specsDir)) {
+    return { success: false, error: 'specs/ directory not found' };
+  }
+
+  const artifacts = ['challenger-brief.md', 'product-brief.md', 'prd.md', 'architecture.md', 'implementation-plan.md'];
+  const results: ArtifactMaturityResult[] = [];
+
+  for (const artifact of artifacts) {
+    const fullPath = join(specsDir, artifact);
+    if (existsSync(fullPath)) {
+      const result = assessFile(fullPath, options);
+      results.push({ artifact, ...result });
+    }
+  }
+
+  const avgScore =
+    results.length > 0
+      ? Math.round(results.reduce((sum, r) => sum + (r.overall_score ?? 0), 0) / results.length)
+      : 0;
+
+  const avgLevel =
+    [...MATURITY_LEVELS].reverse().find(l => avgScore >= l.min_score) ?? MATURITY_LEVELS[0]!;
+
+  return {
+    success: true,
+    project_score: avgScore,
+    project_maturity: avgLevel.name,
+    project_level: avgLevel.level,
+    artifacts: results,
+    summary: {
+      artifacts_assessed: results.length,
+      average_score: avgScore,
+      production_ready: results.filter(r => (r.maturity_level ?? 0) >= 5).length,
+      draft: results.filter(r => (r.maturity_level ?? 0) <= 1).length,
+    },
+  };
+}

--- a/src/lib/sre-integration.ts
+++ b/src/lib/sre-integration.ts
@@ -1,0 +1,269 @@
+/**
+ * sre-integration.ts — SRE Integration port (M11 batch 6).
+ *
+ * Pure-library port of `bin/lib/sre-integration.js` (CJS). Public surface:
+ *   - `generateMonitor(name, type, options?)` => MonitorResult
+ *   - `generateAlert(name, severity, options?)` => AlertResult
+ *   - `generateRunbook(name, steps, options?)` => RunbookResult
+ *   - `configureErrorBudget(service, slo, options?)` => ErrorBudgetResult
+ *   - `generateReport(options?)` => SreReport
+ *   - `loadState(stateFile?)` => SreState
+ *   - `saveState(state, stateFile?)` => void
+ *   - `defaultState()` => SreState
+ *   - `MONITOR_TYPES`
+ *   - `ALERT_SEVERITIES`
+ *
+ * M3 hardening:
+ *   - `loadState` runs `rejectPollutionKeys` on parsed JSON.
+ *
+ * @see bin/lib/sre-integration.js (legacy reference)
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+const DEFAULT_STATE_FILE = join('.jumpstart', 'state', 'sre-integration.json');
+
+export const MONITOR_TYPES = ['uptime', 'latency', 'error-rate', 'saturation', 'custom'] as const;
+export const ALERT_SEVERITIES = ['critical', 'warning', 'info'] as const;
+export type AlertSeverity = (typeof ALERT_SEVERITIES)[number];
+
+export interface Monitor {
+  id: string;
+  name: string;
+  type: string;
+  threshold: unknown;
+  interval: string;
+  service: string | null;
+  created_at: string;
+}
+
+export interface Alert {
+  id: string;
+  name: string;
+  severity: AlertSeverity;
+  condition: unknown;
+  notification_channels: unknown[];
+  runbook_id: string | null;
+  created_at: string;
+}
+
+export interface RunbookStep {
+  order: number;
+  action: string;
+}
+
+export interface Runbook {
+  id: string;
+  name: string;
+  steps: RunbookStep[];
+  service: string | null;
+  created_at: string;
+}
+
+export interface ErrorBudget {
+  id: string;
+  service: string;
+  slo_target: number;
+  budget_remaining: number;
+  window: string;
+  created_at: string;
+}
+
+export interface SreState {
+  version: string;
+  monitors: Monitor[];
+  alerts: Alert[];
+  runbooks: Runbook[];
+  error_budgets: ErrorBudget[];
+  last_updated: string | null;
+}
+
+function rejectPollutionKeys(obj: unknown): void {
+  if (obj === null || typeof obj !== 'object') return;
+  const forbidden = new Set(['__proto__', 'constructor', 'prototype']);
+  for (const key of Object.keys(obj as Record<string, unknown>)) {
+    if (forbidden.has(key)) throw new Error(`Prototype-pollution key detected: "${key}"`);
+    rejectPollutionKeys((obj as Record<string, unknown>)[key]);
+  }
+}
+
+export function defaultState(): SreState {
+  return { version: '1.0.0', monitors: [], alerts: [], runbooks: [], error_budgets: [], last_updated: null };
+}
+
+export function loadState(stateFile?: string): SreState {
+  const fp = stateFile ?? DEFAULT_STATE_FILE;
+  if (!existsSync(fp)) return defaultState();
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(fp, 'utf8'));
+    rejectPollutionKeys(parsed);
+    return parsed as SreState;
+  } catch {
+    return defaultState();
+  }
+}
+
+export function saveState(state: SreState, stateFile?: string): void {
+  const fp = stateFile ?? DEFAULT_STATE_FILE;
+  const dir = dirname(fp);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  state.last_updated = new Date().toISOString();
+  writeFileSync(fp, JSON.stringify(state, null, 2) + '\n', 'utf8');
+}
+
+export interface MonitorResult {
+  success: boolean;
+  monitor?: Monitor | undefined;
+  error?: string | undefined;
+}
+
+export function generateMonitor(
+  name: string,
+  type: string,
+  options: { stateFile?: string | undefined; threshold?: unknown; interval?: string | undefined; service?: string | undefined } = {},
+): MonitorResult {
+  if (!name || !type) return { success: false, error: 'name and type are required' };
+  if (!MONITOR_TYPES.includes(type as typeof MONITOR_TYPES[number])) {
+    return { success: false, error: `Unknown type: ${type}. Valid: ${MONITOR_TYPES.join(', ')}` };
+  }
+
+  const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
+  const state = loadState(stateFile);
+
+  const monitor: Monitor = {
+    id: `MON-${Date.now()}`,
+    name,
+    type,
+    threshold: options.threshold ?? null,
+    interval: options.interval ?? '60s',
+    service: options.service ?? null,
+    created_at: new Date().toISOString(),
+  };
+
+  state.monitors.push(monitor);
+  saveState(state, stateFile);
+  return { success: true, monitor };
+}
+
+export interface AlertResult {
+  success: boolean;
+  alert?: Alert | undefined;
+  error?: string | undefined;
+}
+
+export function generateAlert(
+  name: string,
+  severity: string,
+  options: { stateFile?: string | undefined; condition?: unknown; channels?: unknown[]; runbook_id?: string | undefined } = {},
+): AlertResult {
+  if (!name || !severity) return { success: false, error: 'name and severity are required' };
+  if (!ALERT_SEVERITIES.includes(severity as AlertSeverity)) {
+    return { success: false, error: `Unknown severity: ${severity}. Valid: ${ALERT_SEVERITIES.join(', ')}` };
+  }
+
+  const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
+  const state = loadState(stateFile);
+
+  const alert: Alert = {
+    id: `ALERT-${Date.now()}`,
+    name,
+    severity: severity as AlertSeverity,
+    condition: options.condition ?? null,
+    notification_channels: options.channels ?? [],
+    runbook_id: options.runbook_id ?? null,
+    created_at: new Date().toISOString(),
+  };
+
+  state.alerts.push(alert);
+  saveState(state, stateFile);
+  return { success: true, alert };
+}
+
+export interface RunbookResult {
+  success: boolean;
+  runbook?: Runbook | undefined;
+  error?: string | undefined;
+}
+
+export function generateRunbook(
+  name: string,
+  steps: unknown,
+  options: { stateFile?: string | undefined; service?: string | undefined } = {},
+): RunbookResult {
+  if (!name || !steps) return { success: false, error: 'name and steps are required' };
+
+  const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
+  const state = loadState(stateFile);
+
+  const runbook: Runbook = {
+    id: `RB-${Date.now()}`,
+    name,
+    steps: Array.isArray(steps) ? steps.map((s, i) => ({ order: i + 1, action: String(s) })) : [],
+    service: options.service ?? null,
+    created_at: new Date().toISOString(),
+  };
+
+  state.runbooks.push(runbook);
+  saveState(state, stateFile);
+  return { success: true, runbook };
+}
+
+export interface ErrorBudgetResult {
+  success: boolean;
+  error_budget?: ErrorBudget | undefined;
+  error?: string | undefined;
+}
+
+export function configureErrorBudget(
+  service: string,
+  slo: number,
+  options: { stateFile?: string | undefined; remaining?: number | undefined; window?: string | undefined } = {},
+): ErrorBudgetResult {
+  if (!service || slo === undefined) return { success: false, error: 'service and slo are required' };
+
+  const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
+  const state = loadState(stateFile);
+
+  const budget: ErrorBudget = {
+    id: `EB-${Date.now()}`,
+    service,
+    slo_target: slo,
+    budget_remaining: options.remaining ?? 100,
+    window: options.window ?? '30d',
+    created_at: new Date().toISOString(),
+  };
+
+  state.error_budgets.push(budget);
+  saveState(state, stateFile);
+  return { success: true, error_budget: budget };
+}
+
+export interface SreReport {
+  success: true;
+  total_monitors: number;
+  total_alerts: number;
+  total_runbooks: number;
+  total_error_budgets: number;
+  monitors: Monitor[];
+  alerts: Alert[];
+  runbooks: Runbook[];
+  error_budgets: ErrorBudget[];
+}
+
+export function generateReport(options: { stateFile?: string | undefined } = {}): SreReport {
+  const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
+  const state = loadState(stateFile);
+
+  return {
+    success: true,
+    total_monitors: state.monitors.length,
+    total_alerts: state.alerts.length,
+    total_runbooks: state.runbooks.length,
+    total_error_budgets: state.error_budgets.length,
+    monitors: state.monitors,
+    alerts: state.alerts,
+    runbooks: state.runbooks,
+    error_budgets: state.error_budgets,
+  };
+}

--- a/src/lib/sre-integration.ts
+++ b/src/lib/sre-integration.ts
@@ -89,7 +89,14 @@ function rejectPollutionKeys(obj: unknown): void {
 }
 
 export function defaultState(): SreState {
-  return { version: '1.0.0', monitors: [], alerts: [], runbooks: [], error_budgets: [], last_updated: null };
+  return {
+    version: '1.0.0',
+    monitors: [],
+    alerts: [],
+    runbooks: [],
+    error_budgets: [],
+    last_updated: null,
+  };
 }
 
 export function loadState(stateFile?: string): SreState {
@@ -109,7 +116,7 @@ export function saveState(state: SreState, stateFile?: string): void {
   const dir = dirname(fp);
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
   state.last_updated = new Date().toISOString();
-  writeFileSync(fp, JSON.stringify(state, null, 2) + '\n', 'utf8');
+  writeFileSync(fp, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
 }
 
 export interface MonitorResult {
@@ -121,10 +128,15 @@ export interface MonitorResult {
 export function generateMonitor(
   name: string,
   type: string,
-  options: { stateFile?: string | undefined; threshold?: unknown; interval?: string | undefined; service?: string | undefined } = {},
+  options: {
+    stateFile?: string | undefined;
+    threshold?: unknown;
+    interval?: string | undefined;
+    service?: string | undefined;
+  } = {}
 ): MonitorResult {
   if (!name || !type) return { success: false, error: 'name and type are required' };
-  if (!MONITOR_TYPES.includes(type as typeof MONITOR_TYPES[number])) {
+  if (!MONITOR_TYPES.includes(type as (typeof MONITOR_TYPES)[number])) {
     return { success: false, error: `Unknown type: ${type}. Valid: ${MONITOR_TYPES.join(', ')}` };
   }
 
@@ -155,11 +167,19 @@ export interface AlertResult {
 export function generateAlert(
   name: string,
   severity: string,
-  options: { stateFile?: string | undefined; condition?: unknown; channels?: unknown[]; runbook_id?: string | undefined } = {},
+  options: {
+    stateFile?: string | undefined;
+    condition?: unknown;
+    channels?: unknown[];
+    runbook_id?: string | undefined;
+  } = {}
 ): AlertResult {
   if (!name || !severity) return { success: false, error: 'name and severity are required' };
   if (!ALERT_SEVERITIES.includes(severity as AlertSeverity)) {
-    return { success: false, error: `Unknown severity: ${severity}. Valid: ${ALERT_SEVERITIES.join(', ')}` };
+    return {
+      success: false,
+      error: `Unknown severity: ${severity}. Valid: ${ALERT_SEVERITIES.join(', ')}`,
+    };
   }
 
   const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
@@ -189,7 +209,7 @@ export interface RunbookResult {
 export function generateRunbook(
   name: string,
   steps: unknown,
-  options: { stateFile?: string | undefined; service?: string | undefined } = {},
+  options: { stateFile?: string | undefined; service?: string | undefined } = {}
 ): RunbookResult {
   if (!name || !steps) return { success: false, error: 'name and steps are required' };
 
@@ -218,9 +238,14 @@ export interface ErrorBudgetResult {
 export function configureErrorBudget(
   service: string,
   slo: number,
-  options: { stateFile?: string | undefined; remaining?: number | undefined; window?: string | undefined } = {},
+  options: {
+    stateFile?: string | undefined;
+    remaining?: number | undefined;
+    window?: string | undefined;
+  } = {}
 ): ErrorBudgetResult {
-  if (!service || slo === undefined) return { success: false, error: 'service and slo are required' };
+  if (!service || slo === undefined)
+    return { success: false, error: 'service and slo are required' };
 
   const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
   const state = loadState(stateFile);

--- a/src/lib/telemetry-feedback.ts
+++ b/src/lib/telemetry-feedback.ts
@@ -1,0 +1,182 @@
+/**
+ * telemetry-feedback.ts — Production Telemetry Feedback Loop port (M11 batch 6).
+ *
+ * Pure-library port of `bin/lib/telemetry-feedback.js` (CJS). Public surface:
+ *   - `ingestMetric(name, type, value, options?)` => IngestResult
+ *   - `analyzeMetrics(options?)` => AnalysisResult
+ *   - `generateFeedbackReport(options?)` => FeedbackReport
+ *   - `loadState(stateFile?)` => TelemetryState
+ *   - `saveState(state, stateFile?)` => void
+ *   - `defaultState()` => TelemetryState
+ *   - `METRIC_TYPES`
+ *
+ * M3 hardening:
+ *   - `loadState` runs `rejectPollutionKeys` on parsed JSON.
+ *
+ * @see bin/lib/telemetry-feedback.js (legacy reference)
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+const DEFAULT_STATE_FILE = join('.jumpstart', 'state', 'telemetry-feedback.json');
+
+export const METRIC_TYPES = ['latency', 'error-rate', 'throughput', 'availability', 'saturation', 'cost'] as const;
+export type MetricType = (typeof METRIC_TYPES)[number];
+
+export interface Metric {
+  id: string;
+  name: string;
+  type: string;
+  value: unknown;
+  unit: string | null;
+  service: string | null;
+  timestamp: string;
+}
+
+export interface TelemetryState {
+  version: string;
+  metrics: Metric[];
+  insights: unknown[];
+  last_updated: string | null;
+}
+
+function rejectPollutionKeys(obj: unknown): void {
+  if (obj === null || typeof obj !== 'object') return;
+  const forbidden = new Set(['__proto__', 'constructor', 'prototype']);
+  for (const key of Object.keys(obj as Record<string, unknown>)) {
+    if (forbidden.has(key)) throw new Error(`Prototype-pollution key detected: "${key}"`);
+    rejectPollutionKeys((obj as Record<string, unknown>)[key]);
+  }
+}
+
+export function defaultState(): TelemetryState {
+  return { version: '1.0.0', metrics: [], insights: [], last_updated: null };
+}
+
+export function loadState(stateFile?: string): TelemetryState {
+  const fp = stateFile ?? DEFAULT_STATE_FILE;
+  if (!existsSync(fp)) return defaultState();
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(fp, 'utf8'));
+    rejectPollutionKeys(parsed);
+    return parsed as TelemetryState;
+  } catch {
+    return defaultState();
+  }
+}
+
+export function saveState(state: TelemetryState, stateFile?: string): void {
+  const fp = stateFile ?? DEFAULT_STATE_FILE;
+  const dir = dirname(fp);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  state.last_updated = new Date().toISOString();
+  writeFileSync(fp, JSON.stringify(state, null, 2) + '\n', 'utf8');
+}
+
+export interface IngestResult {
+  success: boolean;
+  metric?: Metric | undefined;
+  error?: string | undefined;
+}
+
+export function ingestMetric(
+  name: string,
+  type: string,
+  value: unknown,
+  options: { stateFile?: string | undefined; unit?: string | undefined; service?: string | undefined } = {},
+): IngestResult {
+  if (!name || !type) return { success: false, error: 'name and type are required' };
+  if (!METRIC_TYPES.includes(type as MetricType)) {
+    return { success: false, error: `Unknown type: ${type}. Valid: ${METRIC_TYPES.join(', ')}` };
+  }
+
+  const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
+  const state = loadState(stateFile);
+
+  const metric: Metric = {
+    id: `TEL-${Date.now()}`,
+    name,
+    type,
+    value,
+    unit: options.unit ?? null,
+    service: options.service ?? null,
+    timestamp: new Date().toISOString(),
+  };
+
+  state.metrics.push(metric);
+  saveState(state, stateFile);
+  return { success: true, metric };
+}
+
+export interface MetricStats {
+  count: number;
+  avg: number;
+  min: number;
+  max: number;
+}
+
+export interface AnalysisResult {
+  success: true;
+  total_metrics: number;
+  analysis: Record<string, MetricStats>;
+}
+
+export function analyzeMetrics(options: { stateFile?: string | undefined } = {}): AnalysisResult {
+  const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
+  const state = loadState(stateFile);
+
+  const byType: Record<string, unknown[]> = {};
+  for (const m of state.metrics) {
+    byType[m.type] = byType[m.type] ?? [];
+    byType[m.type]!.push(m.value);
+  }
+
+  const analysis: Record<string, MetricStats> = {};
+  for (const [type, values] of Object.entries(byType)) {
+    const nums = values.filter((v): v is number => typeof v === 'number');
+    if (nums.length > 0) {
+      const sum = nums.reduce((a, b) => a + b, 0);
+      analysis[type] = {
+        count: nums.length,
+        avg: Math.round((sum / nums.length) * 100) / 100,
+        min: Math.min(...nums),
+        max: Math.max(...nums),
+      };
+    }
+  }
+
+  return { success: true, total_metrics: state.metrics.length, analysis };
+}
+
+export interface FeedbackReport {
+  success: true;
+  total_metrics: number;
+  total_insights: number;
+  analysis: Record<string, MetricStats>;
+  recommendations: string[];
+}
+
+export function generateFeedbackReport(options: { stateFile?: string | undefined } = {}): FeedbackReport {
+  const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
+  const state = loadState(stateFile);
+  const { analysis } = analyzeMetrics(options);
+
+  const recommendations: string[] = [];
+  const latencyStats = analysis['latency'];
+  const errorStats = analysis['error-rate'];
+  if (latencyStats && latencyStats.avg > 500) {
+    recommendations.push('High average latency detected — consider caching or query optimization');
+  }
+  if (errorStats && errorStats.avg > 5) {
+    recommendations.push('Elevated error rate — review error handling and resilience patterns');
+  }
+
+  return {
+    success: true,
+    total_metrics: state.metrics.length,
+    total_insights: state.insights.length,
+    analysis,
+    recommendations,
+  };
+}

--- a/src/lib/telemetry-feedback.ts
+++ b/src/lib/telemetry-feedback.ts
@@ -21,7 +21,14 @@ import { dirname, join } from 'node:path';
 
 const DEFAULT_STATE_FILE = join('.jumpstart', 'state', 'telemetry-feedback.json');
 
-export const METRIC_TYPES = ['latency', 'error-rate', 'throughput', 'availability', 'saturation', 'cost'] as const;
+export const METRIC_TYPES = [
+  'latency',
+  'error-rate',
+  'throughput',
+  'availability',
+  'saturation',
+  'cost',
+] as const;
 export type MetricType = (typeof METRIC_TYPES)[number];
 
 export interface Metric {
@@ -71,7 +78,7 @@ export function saveState(state: TelemetryState, stateFile?: string): void {
   const dir = dirname(fp);
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
   state.last_updated = new Date().toISOString();
-  writeFileSync(fp, JSON.stringify(state, null, 2) + '\n', 'utf8');
+  writeFileSync(fp, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
 }
 
 export interface IngestResult {
@@ -84,7 +91,11 @@ export function ingestMetric(
   name: string,
   type: string,
   value: unknown,
-  options: { stateFile?: string | undefined; unit?: string | undefined; service?: string | undefined } = {},
+  options: {
+    stateFile?: string | undefined;
+    unit?: string | undefined;
+    service?: string | undefined;
+  } = {}
 ): IngestResult {
   if (!name || !type) return { success: false, error: 'name and type are required' };
   if (!METRIC_TYPES.includes(type as MetricType)) {
@@ -129,7 +140,7 @@ export function analyzeMetrics(options: { stateFile?: string | undefined } = {})
   const byType: Record<string, unknown[]> = {};
   for (const m of state.metrics) {
     byType[m.type] = byType[m.type] ?? [];
-    byType[m.type]!.push(m.value);
+    byType[m.type]?.push(m.value);
   }
 
   const analysis: Record<string, MetricStats> = {};
@@ -157,13 +168,15 @@ export interface FeedbackReport {
   recommendations: string[];
 }
 
-export function generateFeedbackReport(options: { stateFile?: string | undefined } = {}): FeedbackReport {
+export function generateFeedbackReport(
+  options: { stateFile?: string | undefined } = {}
+): FeedbackReport {
   const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
   const state = loadState(stateFile);
   const { analysis } = analyzeMetrics(options);
 
   const recommendations: string[] = [];
-  const latencyStats = analysis['latency'];
+  const latencyStats = analysis.latency;
   const errorStats = analysis['error-rate'];
   if (latencyStats && latencyStats.avg > 500) {
     recommendations.push('High average latency detected — consider caching or query optimization');

--- a/src/lib/test-generator.ts
+++ b/src/lib/test-generator.ts
@@ -96,7 +96,7 @@ export interface StubResult {
 
 export function generateTestStubs(
   criteria: Criterion[],
-  options: { language?: string | undefined } = {},
+  options: { language?: string | undefined } = {}
 ): StubResult {
   const language = options.language ?? 'javascript';
   const fwConfig = TEST_FRAMEWORKS[language];
@@ -108,13 +108,13 @@ export function generateTestStubs(
   for (const c of criteria) {
     const story = c.story ?? 'general';
     byStory[story] = byStory[story] ?? [];
-    byStory[story]!.push(c);
+    byStory[story]?.push(c);
   }
 
   const testFiles: TestFileStub[] = [];
   for (const [story, storyCriteria] of Object.entries(byStory)) {
     const fileName = `${story.toLowerCase().replace(/[^a-z0-9]/g, '-')}${fwConfig.extension}`;
-    const tests = storyCriteria.map(c => {
+    const tests = storyCriteria.map((c) => {
       const testName = c.criterion.replace(/'/g, "\\'").substring(0, 100);
       return `  it('${testName}', () => {\n    // TODO: Implement test for ${c.type}\n    expect(true).toBe(true);\n  });`;
     });
@@ -141,7 +141,10 @@ export interface CoverageResult {
   error?: string | undefined;
 }
 
-export function checkCoverage(root: string, _options: Record<string, unknown> = {}): CoverageResult {
+export function checkCoverage(
+  root: string,
+  _options: Record<string, unknown> = {}
+): CoverageResult {
   const prdFile = join(root, 'specs', 'prd.md');
   if (!existsSync(prdFile)) {
     return { success: false, error: 'PRD not found at specs/prd.md' };
@@ -156,15 +159,20 @@ export function checkCoverage(root: string, _options: Record<string, unknown> = 
     for (const entry of readdirSync(testDir)) {
       if (entry.endsWith('.test.js') || entry.endsWith('.test.ts')) {
         try {
-          testContent += readFileSync(join(testDir, entry), 'utf8') + '\n';
-        } catch { /* skip */ }
+          testContent += `${readFileSync(join(testDir, entry), 'utf8')}\n`;
+        } catch {
+          /* skip */
+        }
       }
     }
   }
 
-  const covered = criteria.filter(c => {
-    const terms = c.criterion.toLowerCase().split(/\s+/).filter(t => t.length > 3);
-    return terms.some(t => testContent.toLowerCase().includes(t));
+  const covered = criteria.filter((c) => {
+    const terms = c.criterion
+      .toLowerCase()
+      .split(/\s+/)
+      .filter((t) => t.length > 3);
+    return terms.some((t) => testContent.toLowerCase().includes(t));
   });
 
   return {
@@ -172,6 +180,6 @@ export function checkCoverage(root: string, _options: Record<string, unknown> = 
     total_criteria: criteria.length,
     covered: covered.length,
     coverage: criteria.length > 0 ? Math.round((covered.length / criteria.length) * 100) : 0,
-    uncovered: criteria.filter(c => !covered.includes(c)),
+    uncovered: criteria.filter((c) => !covered.includes(c)),
   };
 }

--- a/src/lib/test-generator.ts
+++ b/src/lib/test-generator.ts
@@ -1,0 +1,177 @@
+/**
+ * test-generator.ts — Test Generation Tied to Acceptance Criteria port (M11 batch 6).
+ *
+ * Pure-library port of `bin/lib/test-generator.js` (CJS). Public surface:
+ *   - `extractCriteria(content)` => Criterion[]
+ *   - `generateTestStubs(criteria, options?)` => StubResult
+ *   - `checkCoverage(root, options?)` => CoverageResult
+ *   - `TEST_TYPES`
+ *   - `TEST_FRAMEWORKS`
+ *
+ * M3 hardening: No JSON state paths. Not applicable.
+ * Path-safety per ADR-009: `checkCoverage` uses project root from CLI wiring.
+ *
+ * @see bin/lib/test-generator.js (legacy reference)
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export const TEST_TYPES = ['unit', 'integration', 'api', 'ui', 'contract', 'e2e'] as const;
+
+export interface TestFrameworkConfig {
+  framework: string;
+  extension: string;
+  import: string;
+}
+
+export const TEST_FRAMEWORKS: Record<string, TestFrameworkConfig> = {
+  javascript: {
+    framework: 'vitest',
+    extension: '.test.js',
+    import: "import { describe, it, expect } from 'vitest';",
+  },
+  typescript: {
+    framework: 'vitest',
+    extension: '.test.ts',
+    import: "import { describe, it, expect } from 'vitest';",
+  },
+  python: {
+    framework: 'pytest',
+    extension: '_test.py',
+    import: 'import pytest',
+  },
+};
+
+export interface Criterion {
+  story: string | null;
+  criterion: string;
+  type: 'given' | 'when' | 'then' | 'acceptance';
+}
+
+export function extractCriteria(content: string): Criterion[] {
+  const criteria: Criterion[] = [];
+  const lines = content.split('\n');
+  let currentStory: string | null = null;
+
+  for (const line of lines) {
+    const storyMatch = line.match(/\*\*(E\d+-S\d+)\*\*/);
+    if (storyMatch) currentStory = storyMatch[1] ?? null;
+
+    const givenMatch = line.match(/^\s*[-*]\s*(Given\s+.+)/i);
+    const whenMatch = line.match(/^\s*[-*]\s*(When\s+.+)/i);
+    const thenMatch = line.match(/^\s*[-*]\s*(Then\s+.+)/i);
+    const acMatch = line.match(/^\s*[-*]\s*AC\d*:\s*(.+)/i);
+
+    const matched = givenMatch ?? whenMatch ?? thenMatch ?? acMatch;
+    if (matched) {
+      const criterion = matched[1];
+      if (!criterion) continue;
+      criteria.push({
+        story: currentStory,
+        criterion: criterion.trim(),
+        type: givenMatch ? 'given' : whenMatch ? 'when' : thenMatch ? 'then' : 'acceptance',
+      });
+    }
+  }
+
+  return criteria;
+}
+
+export interface TestFileStub {
+  fileName: string;
+  content: string;
+  story: string;
+  test_count: number;
+}
+
+export interface StubResult {
+  success: boolean;
+  total_criteria?: number | undefined;
+  test_files?: number | undefined;
+  files?: TestFileStub[] | undefined;
+  framework?: string | undefined;
+  error?: string | undefined;
+}
+
+export function generateTestStubs(
+  criteria: Criterion[],
+  options: { language?: string | undefined } = {},
+): StubResult {
+  const language = options.language ?? 'javascript';
+  const fwConfig = TEST_FRAMEWORKS[language];
+  if (!fwConfig) {
+    return { success: false, error: `Unsupported language: ${language}` };
+  }
+
+  const byStory: Record<string, Criterion[]> = {};
+  for (const c of criteria) {
+    const story = c.story ?? 'general';
+    byStory[story] = byStory[story] ?? [];
+    byStory[story]!.push(c);
+  }
+
+  const testFiles: TestFileStub[] = [];
+  for (const [story, storyCriteria] of Object.entries(byStory)) {
+    const fileName = `${story.toLowerCase().replace(/[^a-z0-9]/g, '-')}${fwConfig.extension}`;
+    const tests = storyCriteria.map(c => {
+      const testName = c.criterion.replace(/'/g, "\\'").substring(0, 100);
+      return `  it('${testName}', () => {\n    // TODO: Implement test for ${c.type}\n    expect(true).toBe(true);\n  });`;
+    });
+
+    const fileContent = `${fwConfig.import}\n\ndescribe('${story}', () => {\n${tests.join('\n\n')}\n});\n`;
+    testFiles.push({ fileName, content: fileContent, story, test_count: storyCriteria.length });
+  }
+
+  return {
+    success: true,
+    total_criteria: criteria.length,
+    test_files: testFiles.length,
+    files: testFiles,
+    framework: fwConfig.framework,
+  };
+}
+
+export interface CoverageResult {
+  success: boolean;
+  total_criteria?: number | undefined;
+  covered?: number | undefined;
+  coverage?: number | undefined;
+  uncovered?: Criterion[] | undefined;
+  error?: string | undefined;
+}
+
+export function checkCoverage(root: string, _options: Record<string, unknown> = {}): CoverageResult {
+  const prdFile = join(root, 'specs', 'prd.md');
+  if (!existsSync(prdFile)) {
+    return { success: false, error: 'PRD not found at specs/prd.md' };
+  }
+
+  const prdContent = readFileSync(prdFile, 'utf8');
+  const criteria = extractCriteria(prdContent);
+
+  const testDir = join(root, 'tests');
+  let testContent = '';
+  if (existsSync(testDir)) {
+    for (const entry of readdirSync(testDir)) {
+      if (entry.endsWith('.test.js') || entry.endsWith('.test.ts')) {
+        try {
+          testContent += readFileSync(join(testDir, entry), 'utf8') + '\n';
+        } catch { /* skip */ }
+      }
+    }
+  }
+
+  const covered = criteria.filter(c => {
+    const terms = c.criterion.toLowerCase().split(/\s+/).filter(t => t.length > 3);
+    return terms.some(t => testContent.toLowerCase().includes(t));
+  });
+
+  return {
+    success: true,
+    total_criteria: criteria.length,
+    covered: covered.length,
+    coverage: criteria.length > 0 ? Math.round((covered.length / criteria.length) * 100) : 0,
+    uncovered: criteria.filter(c => !covered.includes(c)),
+  };
+}

--- a/src/lib/tool-guardrails.ts
+++ b/src/lib/tool-guardrails.ts
@@ -1,0 +1,165 @@
+/**
+ * tool-guardrails.ts — Tool Execution Guardrails port (M11 batch 6).
+ *
+ * Pure-library port of `bin/lib/tool-guardrails.js` (CJS). Public surface:
+ *   - `checkOperation(operation, options?)` => OperationCheckResult
+ *   - `validateFileOperation(action, filePath, options?)` => FileOpResult
+ *   - `RISK_RULES`
+ *   - `PROTECTED_PATHS`
+ *
+ * M3 hardening: No JSON state paths. Not applicable.
+ * Path-safety per ADR-009: No user path-to-disk resolution here. Not applicable.
+ *
+ * @see bin/lib/tool-guardrails.js (legacy reference)
+ */
+
+import { extname } from 'node:path';
+
+export interface RiskRule {
+  id: string;
+  pattern: RegExp;
+  risk: 'critical' | 'high' | 'medium' | 'low';
+  description: string;
+}
+
+export const RISK_RULES: RiskRule[] = [
+  { id: 'delete-protection', pattern: /^(?:rm|del|remove)\s+/i, risk: 'high', description: 'File deletion operation' },
+  { id: 'recursive-delete', pattern: /rm\s+-rf?\s/i, risk: 'critical', description: 'Recursive deletion' },
+  { id: 'schema-change', pattern: /(?:ALTER|DROP|TRUNCATE)\s+(?:TABLE|DATABASE|SCHEMA)/i, risk: 'high', description: 'Database schema modification' },
+  { id: 'config-write', pattern: /(?:\.env|config|secrets?)\s*$/i, risk: 'high', description: 'Configuration file modification' },
+  { id: 'wide-glob', pattern: /\*\*\/\*|\*\.\*/i, risk: 'medium', description: 'Wide glob pattern' },
+  { id: 'sudo-usage', pattern: /\bsudo\b/i, risk: 'critical', description: 'Elevated privilege usage' },
+  { id: 'network-call', pattern: /\b(?:curl|wget|fetch)\s+http/i, risk: 'medium', description: 'External network call' },
+  { id: 'git-force', pattern: /git\s+(?:push\s+--force|reset\s+--hard)/i, risk: 'high', description: 'Force git operation' },
+];
+
+export const PROTECTED_PATHS = [
+  '.env', '.env.local', '.env.production',
+  '.git/', 'node_modules/',
+  'package-lock.json', 'yarn.lock',
+  '.jumpstart/state/',
+] as const;
+
+export interface Violation {
+  rule_id: string;
+  risk: string;
+  description: string;
+  matched: string;
+}
+
+const RISK_ORDER: Record<string, number> = { critical: 4, high: 3, medium: 2, low: 1 };
+
+export interface OperationCheckResult {
+  success: boolean;
+  operation?: string | undefined;
+  allowed?: boolean | undefined;
+  requires_approval?: boolean | undefined;
+  risk_level?: string | undefined;
+  violations?: Violation[] | undefined;
+  total_violations?: number | undefined;
+  error?: string | undefined;
+}
+
+export function checkOperation(
+  operation: string,
+  _options: Record<string, unknown> = {},
+): OperationCheckResult {
+  if (!operation) return { success: false, error: 'operation is required' };
+
+  const violations: Violation[] = [];
+
+  for (const rule of RISK_RULES) {
+    if (rule.pattern.test(operation)) {
+      violations.push({
+        rule_id: rule.id,
+        risk: rule.risk,
+        description: rule.description,
+        matched: operation.substring(0, 100),
+      });
+    }
+  }
+
+  for (const pp of PROTECTED_PATHS) {
+    if (operation.includes(pp)) {
+      violations.push({
+        rule_id: 'protected-path',
+        risk: 'high',
+        description: `Operation targets protected path: ${pp}`,
+        matched: pp,
+      });
+    }
+  }
+
+  const maxRisk = violations.reduce((max, v) => {
+    return (RISK_ORDER[v.risk] ?? 0) > (RISK_ORDER[max] ?? 0) ? v.risk : max;
+  }, 'low');
+
+  return {
+    success: true,
+    operation: operation.substring(0, 200),
+    allowed: violations.filter(v => v.risk === 'critical').length === 0,
+    requires_approval: violations.some(v => v.risk === 'high' || v.risk === 'critical'),
+    risk_level: violations.length > 0 ? maxRisk : 'none',
+    violations,
+    total_violations: violations.length,
+  };
+}
+
+export interface Warning {
+  level: string;
+  message: string;
+}
+
+export interface FileOpResult {
+  success: true;
+  allowed: boolean;
+  reason?: string | undefined;
+  action?: string | undefined;
+  file?: string | undefined;
+  warnings: Warning[];
+  requires_review?: boolean | undefined;
+}
+
+export function validateFileOperation(
+  action: string,
+  filePath: string,
+  options: { lines_changed?: number | undefined } = {},
+): FileOpResult {
+  const warnings: Warning[] = [];
+
+  if (action === 'delete') {
+    warnings.push({ level: 'high', message: `Deleting file: ${filePath}` });
+
+    for (const pp of PROTECTED_PATHS) {
+      if (filePath.includes(pp)) {
+        return {
+          success: true,
+          allowed: false,
+          reason: `Cannot delete protected path: ${pp}`,
+          warnings,
+        };
+      }
+    }
+  }
+
+  if (action === 'edit') {
+    const ext = extname(filePath).toLowerCase();
+    if (['.env', '.pem', '.key'].includes(ext)) {
+      warnings.push({ level: 'high', message: 'Editing sensitive file type' });
+    }
+  }
+
+  const linesChanged = options.lines_changed ?? 0;
+  if (linesChanged > 100) {
+    warnings.push({ level: 'medium', message: `Large edit: ${linesChanged} lines changed` });
+  }
+
+  return {
+    success: true,
+    allowed: true,
+    action,
+    file: filePath,
+    warnings,
+    requires_review: warnings.some(w => w.level === 'high'),
+  };
+}

--- a/src/lib/tool-guardrails.ts
+++ b/src/lib/tool-guardrails.ts
@@ -23,20 +23,64 @@ export interface RiskRule {
 }
 
 export const RISK_RULES: RiskRule[] = [
-  { id: 'delete-protection', pattern: /^(?:rm|del|remove)\s+/i, risk: 'high', description: 'File deletion operation' },
-  { id: 'recursive-delete', pattern: /rm\s+-rf?\s/i, risk: 'critical', description: 'Recursive deletion' },
-  { id: 'schema-change', pattern: /(?:ALTER|DROP|TRUNCATE)\s+(?:TABLE|DATABASE|SCHEMA)/i, risk: 'high', description: 'Database schema modification' },
-  { id: 'config-write', pattern: /(?:\.env|config|secrets?)\s*$/i, risk: 'high', description: 'Configuration file modification' },
-  { id: 'wide-glob', pattern: /\*\*\/\*|\*\.\*/i, risk: 'medium', description: 'Wide glob pattern' },
-  { id: 'sudo-usage', pattern: /\bsudo\b/i, risk: 'critical', description: 'Elevated privilege usage' },
-  { id: 'network-call', pattern: /\b(?:curl|wget|fetch)\s+http/i, risk: 'medium', description: 'External network call' },
-  { id: 'git-force', pattern: /git\s+(?:push\s+--force|reset\s+--hard)/i, risk: 'high', description: 'Force git operation' },
+  {
+    id: 'delete-protection',
+    pattern: /^(?:rm|del|remove)\s+/i,
+    risk: 'high',
+    description: 'File deletion operation',
+  },
+  {
+    id: 'recursive-delete',
+    pattern: /rm\s+-rf?\s/i,
+    risk: 'critical',
+    description: 'Recursive deletion',
+  },
+  {
+    id: 'schema-change',
+    pattern: /(?:ALTER|DROP|TRUNCATE)\s+(?:TABLE|DATABASE|SCHEMA)/i,
+    risk: 'high',
+    description: 'Database schema modification',
+  },
+  {
+    id: 'config-write',
+    pattern: /(?:\.env|config|secrets?)\s*$/i,
+    risk: 'high',
+    description: 'Configuration file modification',
+  },
+  {
+    id: 'wide-glob',
+    pattern: /\*\*\/\*|\*\.\*/i,
+    risk: 'medium',
+    description: 'Wide glob pattern',
+  },
+  {
+    id: 'sudo-usage',
+    pattern: /\bsudo\b/i,
+    risk: 'critical',
+    description: 'Elevated privilege usage',
+  },
+  {
+    id: 'network-call',
+    pattern: /\b(?:curl|wget|fetch)\s+http/i,
+    risk: 'medium',
+    description: 'External network call',
+  },
+  {
+    id: 'git-force',
+    pattern: /git\s+(?:push\s+--force|reset\s+--hard)/i,
+    risk: 'high',
+    description: 'Force git operation',
+  },
 ];
 
 export const PROTECTED_PATHS = [
-  '.env', '.env.local', '.env.production',
-  '.git/', 'node_modules/',
-  'package-lock.json', 'yarn.lock',
+  '.env',
+  '.env.local',
+  '.env.production',
+  '.git/',
+  'node_modules/',
+  'package-lock.json',
+  'yarn.lock',
   '.jumpstart/state/',
 ] as const;
 
@@ -62,7 +106,7 @@ export interface OperationCheckResult {
 
 export function checkOperation(
   operation: string,
-  _options: Record<string, unknown> = {},
+  _options: Record<string, unknown> = {}
 ): OperationCheckResult {
   if (!operation) return { success: false, error: 'operation is required' };
 
@@ -97,8 +141,8 @@ export function checkOperation(
   return {
     success: true,
     operation: operation.substring(0, 200),
-    allowed: violations.filter(v => v.risk === 'critical').length === 0,
-    requires_approval: violations.some(v => v.risk === 'high' || v.risk === 'critical'),
+    allowed: violations.filter((v) => v.risk === 'critical').length === 0,
+    requires_approval: violations.some((v) => v.risk === 'high' || v.risk === 'critical'),
     risk_level: violations.length > 0 ? maxRisk : 'none',
     violations,
     total_violations: violations.length,
@@ -123,7 +167,7 @@ export interface FileOpResult {
 export function validateFileOperation(
   action: string,
   filePath: string,
-  options: { lines_changed?: number | undefined } = {},
+  options: { lines_changed?: number | undefined } = {}
 ): FileOpResult {
   const warnings: Warning[] = [];
 
@@ -160,6 +204,6 @@ export function validateFileOperation(
     action,
     file: filePath,
     warnings,
-    requires_review: warnings.some(w => w.level === 'high'),
+    requires_review: warnings.some((w) => w.level === 'high'),
   };
 }

--- a/src/lib/transcript-ingestion.ts
+++ b/src/lib/transcript-ingestion.ts
@@ -1,0 +1,223 @@
+/**
+ * transcript-ingestion.ts — Meeting Transcript Ingestion port (M11 batch 6).
+ *
+ * Pure-library port of `bin/lib/transcript-ingestion.js` (CJS). Public surface:
+ *   - `ingestTranscript(text, options?)` => IngestResult
+ *   - `extractFromTranscript(transcriptId, options?)` => ExtractResult
+ *   - `listTranscripts(options?)` => ListResult
+ *   - `loadState(stateFile?)` => TranscriptState
+ *   - `saveState(state, stateFile?)` => void
+ *   - `defaultState()` => TranscriptState
+ *   - `ACTION_PATTERNS`
+ *   - `DECISION_PATTERNS`
+ *
+ * M3 hardening:
+ *   - `loadState` runs `rejectPollutionKeys` on parsed JSON.
+ *
+ * @see bin/lib/transcript-ingestion.js (legacy reference)
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+const DEFAULT_STATE_FILE = join('.jumpstart', 'state', 'transcripts.json');
+
+export const ACTION_PATTERNS: RegExp[] = [
+  /\baction(?:\s+item)?:\s*(.+)/gi,
+  /\bTODO:\s*(.+)/gi,
+  /\b(?:will|should|needs? to)\s+(.+?)(?:\.|$)/gi,
+];
+
+export const DECISION_PATTERNS: RegExp[] = [
+  /\bdecided?\s+(?:to\s+)?(.+?)(?:\.|$)/gi,
+  /\bdecision:\s*(.+)/gi,
+  /\bagreed\s+(?:to\s+)?(.+?)(?:\.|$)/gi,
+];
+
+export interface ActionItem {
+  text: string;
+  source_pattern: string;
+}
+
+export interface DecisionItem {
+  text: string;
+}
+
+export interface Transcript {
+  id: string;
+  title: string;
+  source: string;
+  text_length: number;
+  ingested_at: string;
+  actions: ActionItem[];
+  decisions: DecisionItem[];
+  key_topics: string[];
+}
+
+export interface TranscriptState {
+  version: string;
+  transcripts: Transcript[];
+  last_updated: string | null;
+}
+
+function rejectPollutionKeys(obj: unknown): void {
+  if (obj === null || typeof obj !== 'object') return;
+  const forbidden = new Set(['__proto__', 'constructor', 'prototype']);
+  for (const key of Object.keys(obj as Record<string, unknown>)) {
+    if (forbidden.has(key)) throw new Error(`Prototype-pollution key detected: "${key}"`);
+    rejectPollutionKeys((obj as Record<string, unknown>)[key]);
+  }
+}
+
+export function defaultState(): TranscriptState {
+  return { version: '1.0.0', transcripts: [], last_updated: null };
+}
+
+export function loadState(stateFile?: string): TranscriptState {
+  const fp = stateFile ?? DEFAULT_STATE_FILE;
+  if (!existsSync(fp)) return defaultState();
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(fp, 'utf8'));
+    rejectPollutionKeys(parsed);
+    return parsed as TranscriptState;
+  } catch {
+    return defaultState();
+  }
+}
+
+export function saveState(state: TranscriptState, stateFile?: string): void {
+  const fp = stateFile ?? DEFAULT_STATE_FILE;
+  const dir = dirname(fp);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  state.last_updated = new Date().toISOString();
+  writeFileSync(fp, JSON.stringify(state, null, 2) + '\n', 'utf8');
+}
+
+export interface IngestResult {
+  success: boolean;
+  transcript?: Transcript | undefined;
+  error?: string | undefined;
+}
+
+export function ingestTranscript(
+  text: string,
+  options: { stateFile?: string | undefined; title?: string | undefined; source?: string | undefined } = {},
+): IngestResult {
+  if (!text) return { success: false, error: 'Transcript text is required' };
+
+  const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
+  const state = loadState(stateFile);
+
+  const transcript: Transcript = {
+    id: `TR-${Date.now()}`,
+    title: options.title ?? 'Untitled Meeting',
+    source: options.source ?? 'manual',
+    text_length: text.length,
+    ingested_at: new Date().toISOString(),
+    actions: [],
+    decisions: [],
+    key_topics: [],
+  };
+
+  for (const pattern of ACTION_PATTERNS) {
+    let match: RegExpExecArray | null;
+    pattern.lastIndex = 0;
+    while ((match = pattern.exec(text)) !== null) {
+      const matchedText = match[1];
+      if (matchedText) {
+        transcript.actions.push({
+          text: matchedText.trim(),
+          source_pattern: pattern.source.substring(0, 30),
+        });
+      }
+    }
+  }
+
+  for (const pattern of DECISION_PATTERNS) {
+    let match: RegExpExecArray | null;
+    pattern.lastIndex = 0;
+    while ((match = pattern.exec(text)) !== null) {
+      const matchedText = match[1];
+      if (matchedText) {
+        transcript.decisions.push({ text: matchedText.trim() });
+      }
+    }
+  }
+
+  const headings = text.match(/^#+\s+(.+)$/gm);
+  if (headings) {
+    transcript.key_topics = headings.map(h => h.replace(/^#+\s+/, '').trim());
+  }
+
+  state.transcripts.push(transcript);
+  saveState(state, stateFile);
+
+  return { success: true, transcript };
+}
+
+export interface ExtractResult {
+  success: boolean;
+  id?: string | undefined;
+  title?: string | undefined;
+  actions?: ActionItem[] | undefined;
+  decisions?: DecisionItem[] | undefined;
+  key_topics?: string[] | undefined;
+  summary?: { action_count: number; decision_count: number; topic_count: number } | undefined;
+  error?: string | undefined;
+}
+
+export function extractFromTranscript(
+  transcriptId: string,
+  options: { stateFile?: string | undefined } = {},
+): ExtractResult {
+  const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
+  const state = loadState(stateFile);
+
+  const transcript = state.transcripts.find(t => t.id === transcriptId);
+  if (!transcript) return { success: false, error: `Transcript ${transcriptId} not found` };
+
+  return {
+    success: true,
+    id: transcript.id,
+    title: transcript.title,
+    actions: transcript.actions,
+    decisions: transcript.decisions,
+    key_topics: transcript.key_topics,
+    summary: {
+      action_count: transcript.actions.length,
+      decision_count: transcript.decisions.length,
+      topic_count: transcript.key_topics.length,
+    },
+  };
+}
+
+export interface TranscriptSummary {
+  id: string;
+  title: string;
+  actions: number;
+  decisions: number;
+  ingested_at: string;
+}
+
+export interface ListResult {
+  success: true;
+  total: number;
+  transcripts: TranscriptSummary[];
+}
+
+export function listTranscripts(options: { stateFile?: string | undefined } = {}): ListResult {
+  const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
+  const state = loadState(stateFile);
+
+  return {
+    success: true,
+    total: state.transcripts.length,
+    transcripts: state.transcripts.map(t => ({
+      id: t.id,
+      title: t.title,
+      actions: t.actions.length,
+      decisions: t.decisions.length,
+      ingested_at: t.ingested_at,
+    })),
+  };
+}

--- a/src/lib/transcript-ingestion.ts
+++ b/src/lib/transcript-ingestion.ts
@@ -90,7 +90,7 @@ export function saveState(state: TranscriptState, stateFile?: string): void {
   const dir = dirname(fp);
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
   state.last_updated = new Date().toISOString();
-  writeFileSync(fp, JSON.stringify(state, null, 2) + '\n', 'utf8');
+  writeFileSync(fp, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
 }
 
 export interface IngestResult {
@@ -101,7 +101,11 @@ export interface IngestResult {
 
 export function ingestTranscript(
   text: string,
-  options: { stateFile?: string | undefined; title?: string | undefined; source?: string | undefined } = {},
+  options: {
+    stateFile?: string | undefined;
+    title?: string | undefined;
+    source?: string | undefined;
+  } = {}
 ): IngestResult {
   if (!text) return { success: false, error: 'Transcript text is required' };
 
@@ -120,9 +124,8 @@ export function ingestTranscript(
   };
 
   for (const pattern of ACTION_PATTERNS) {
-    let match: RegExpExecArray | null;
-    pattern.lastIndex = 0;
-    while ((match = pattern.exec(text)) !== null) {
+    const re = new RegExp(pattern.source, pattern.flags);
+    for (const match of text.matchAll(re)) {
       const matchedText = match[1];
       if (matchedText) {
         transcript.actions.push({
@@ -134,9 +137,8 @@ export function ingestTranscript(
   }
 
   for (const pattern of DECISION_PATTERNS) {
-    let match: RegExpExecArray | null;
-    pattern.lastIndex = 0;
-    while ((match = pattern.exec(text)) !== null) {
+    const re = new RegExp(pattern.source, pattern.flags);
+    for (const match of text.matchAll(re)) {
       const matchedText = match[1];
       if (matchedText) {
         transcript.decisions.push({ text: matchedText.trim() });
@@ -146,7 +148,7 @@ export function ingestTranscript(
 
   const headings = text.match(/^#+\s+(.+)$/gm);
   if (headings) {
-    transcript.key_topics = headings.map(h => h.replace(/^#+\s+/, '').trim());
+    transcript.key_topics = headings.map((h) => h.replace(/^#+\s+/, '').trim());
   }
 
   state.transcripts.push(transcript);
@@ -168,12 +170,12 @@ export interface ExtractResult {
 
 export function extractFromTranscript(
   transcriptId: string,
-  options: { stateFile?: string | undefined } = {},
+  options: { stateFile?: string | undefined } = {}
 ): ExtractResult {
   const stateFile = options.stateFile ?? DEFAULT_STATE_FILE;
   const state = loadState(stateFile);
 
-  const transcript = state.transcripts.find(t => t.id === transcriptId);
+  const transcript = state.transcripts.find((t) => t.id === transcriptId);
   if (!transcript) return { success: false, error: `Transcript ${transcriptId} not found` };
 
   return {
@@ -212,7 +214,7 @@ export function listTranscripts(options: { stateFile?: string | undefined } = {}
   return {
     success: true,
     total: state.transcripts.length,
-    transcripts: state.transcripts.map(t => ({
+    transcripts: state.transcripts.map((t) => ({
       id: t.id,
       title: t.title,
       actions: t.actions.length,

--- a/src/lib/web-dashboard.ts
+++ b/src/lib/web-dashboard.ts
@@ -1,0 +1,171 @@
+/**
+ * web-dashboard.ts — Rich Web UI / Local Dashboard port (M11 batch 6).
+ *
+ * Pure-library port of `bin/lib/web-dashboard.js` (CJS). Public surface:
+ *   - `generateConfig(root, options?)` => ConfigResult
+ *   - `gatherDashboardData(root, options?)` => DashboardData
+ *   - `generateStaticDashboard(data)` => HtmlResult
+ *   - `getServerStatus(options?)` => StatusResult
+ *   - `DASHBOARD_SECTIONS`
+ *   - `DEFAULT_PORT`
+ *   - `DEFAULT_HOST`
+ *
+ * M3 hardening: No JSON state paths. Not applicable.
+ * Path-safety per ADR-009: `root` comes from CLI wiring (assertUserPath).
+ *
+ * ADR-006: No process.exit() in library code. Not applicable here.
+ *
+ * @see bin/lib/web-dashboard.js (legacy reference)
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+export const DEFAULT_PORT = 3000;
+export const DEFAULT_HOST = 'localhost';
+
+export const DASHBOARD_SECTIONS = ['phases', 'artifacts', 'governance', 'timeline', 'risks', 'metrics'] as const;
+export type DashboardSection = (typeof DASHBOARD_SECTIONS)[number];
+
+export interface DashboardConfig {
+  port: number;
+  host: string;
+  root: string;
+  sections: string[];
+  theme: string;
+  auth: { enabled: boolean };
+  refresh_interval: number;
+  generated_at: string;
+}
+
+export interface ConfigResult {
+  success: true;
+  config: DashboardConfig;
+}
+
+export function generateConfig(
+  root: string,
+  options: {
+    port?: number | undefined;
+    host?: string | undefined;
+    sections?: string[] | undefined;
+    theme?: string | undefined;
+    auth?: { enabled: boolean } | undefined;
+    refresh_interval?: number | undefined;
+  } = {},
+): ConfigResult {
+  const config: DashboardConfig = {
+    port: options.port ?? DEFAULT_PORT,
+    host: options.host ?? DEFAULT_HOST,
+    root: resolve(root),
+    sections: options.sections ?? [...DASHBOARD_SECTIONS],
+    theme: options.theme ?? 'default',
+    auth: options.auth ?? { enabled: false },
+    refresh_interval: options.refresh_interval ?? 30,
+    generated_at: new Date().toISOString(),
+  };
+
+  return { success: true, config };
+}
+
+export interface ArtifactEntry {
+  name: string;
+  size: number;
+  modified: string;
+}
+
+export interface DashboardData {
+  success: true;
+  project_root: string;
+  generated_at: string;
+  sections: {
+    phases: { current_phase: number | string; current_agent?: string | null; last_completed_step?: string | null };
+    artifacts: { total: number; files: ArtifactEntry[] };
+    config: { exists: boolean };
+  };
+}
+
+export function gatherDashboardData(
+  root: string,
+  _options: Record<string, unknown> = {},
+): DashboardData {
+  const data: DashboardData = {
+    success: true,
+    project_root: root,
+    generated_at: new Date().toISOString(),
+    sections: {
+      phases: { current_phase: 0 },
+      artifacts: { total: 0, files: [] },
+      config: { exists: false },
+    },
+  };
+
+  const stateFile = join(root, '.jumpstart', 'state', 'state.json');
+  if (existsSync(stateFile)) {
+    try {
+      const state = JSON.parse(readFileSync(stateFile, 'utf8')) as Record<string, unknown>;
+      data.sections.phases = {
+        current_phase: (state['current_phase'] as number | string | undefined) ?? 0,
+        current_agent: (state['current_agent'] as string | null | undefined) ?? null,
+        last_completed_step: (state['last_completed_step'] as string | null | undefined) ?? null,
+      };
+    } catch {
+      data.sections.phases = { current_phase: 0 };
+    }
+  }
+
+  const specsDir = join(root, 'specs');
+  const artifacts: ArtifactEntry[] = [];
+  if (existsSync(specsDir)) {
+    for (const f of readdirSync(specsDir).filter(f => f.endsWith('.md'))) {
+      const fp = join(specsDir, f);
+      const st = statSync(fp);
+      artifacts.push({ name: f, size: st.size, modified: st.mtime.toISOString() });
+    }
+  }
+  data.sections.artifacts = { total: artifacts.length, files: artifacts };
+
+  const configFile = join(root, '.jumpstart', 'config.yaml');
+  data.sections.config = { exists: existsSync(configFile) };
+
+  return data;
+}
+
+export interface HtmlResult {
+  success: true;
+  html: string;
+}
+
+export function generateStaticDashboard(data: DashboardData): HtmlResult {
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Jump Start Dashboard</title></head>
+<body>
+<h1>Jump Start Dashboard</h1>
+<p>Generated: ${data.generated_at}</p>
+<h2>Phase Status</h2>
+<p>Current Phase: ${data.sections.phases.current_phase}</p>
+<h2>Artifacts (${data.sections.artifacts.total})</h2>
+<ul>${data.sections.artifacts.files.map(f => `<li>${f.name} (${f.size} bytes)</li>`).join('')}</ul>
+</body>
+</html>`;
+  return { success: true, html };
+}
+
+export interface StatusResult {
+  success: true;
+  running: boolean;
+  port: number;
+  host: string;
+  uptime: null;
+}
+
+export function getServerStatus(options: { port?: number | undefined; host?: string | undefined } = {}): StatusResult {
+  return {
+    success: true,
+    running: false,
+    port: options.port ?? DEFAULT_PORT,
+    host: options.host ?? DEFAULT_HOST,
+    uptime: null,
+  };
+}

--- a/src/lib/web-dashboard.ts
+++ b/src/lib/web-dashboard.ts
@@ -18,13 +18,20 @@
  * @see bin/lib/web-dashboard.js (legacy reference)
  */
 
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 
 export const DEFAULT_PORT = 3000;
 export const DEFAULT_HOST = 'localhost';
 
-export const DASHBOARD_SECTIONS = ['phases', 'artifacts', 'governance', 'timeline', 'risks', 'metrics'] as const;
+export const DASHBOARD_SECTIONS = [
+  'phases',
+  'artifacts',
+  'governance',
+  'timeline',
+  'risks',
+  'metrics',
+] as const;
 export type DashboardSection = (typeof DASHBOARD_SECTIONS)[number];
 
 export interface DashboardConfig {
@@ -52,7 +59,7 @@ export function generateConfig(
     theme?: string | undefined;
     auth?: { enabled: boolean } | undefined;
     refresh_interval?: number | undefined;
-  } = {},
+  } = {}
 ): ConfigResult {
   const config: DashboardConfig = {
     port: options.port ?? DEFAULT_PORT,
@@ -79,7 +86,11 @@ export interface DashboardData {
   project_root: string;
   generated_at: string;
   sections: {
-    phases: { current_phase: number | string; current_agent?: string | null; last_completed_step?: string | null };
+    phases: {
+      current_phase: number | string;
+      current_agent?: string | null;
+      last_completed_step?: string | null;
+    };
     artifacts: { total: number; files: ArtifactEntry[] };
     config: { exists: boolean };
   };
@@ -87,7 +98,7 @@ export interface DashboardData {
 
 export function gatherDashboardData(
   root: string,
-  _options: Record<string, unknown> = {},
+  _options: Record<string, unknown> = {}
 ): DashboardData {
   const data: DashboardData = {
     success: true,
@@ -105,9 +116,9 @@ export function gatherDashboardData(
     try {
       const state = JSON.parse(readFileSync(stateFile, 'utf8')) as Record<string, unknown>;
       data.sections.phases = {
-        current_phase: (state['current_phase'] as number | string | undefined) ?? 0,
-        current_agent: (state['current_agent'] as string | null | undefined) ?? null,
-        last_completed_step: (state['last_completed_step'] as string | null | undefined) ?? null,
+        current_phase: (state.current_phase as number | string | undefined) ?? 0,
+        current_agent: (state.current_agent as string | null | undefined) ?? null,
+        last_completed_step: (state.last_completed_step as string | null | undefined) ?? null,
       };
     } catch {
       data.sections.phases = { current_phase: 0 };
@@ -117,7 +128,7 @@ export function gatherDashboardData(
   const specsDir = join(root, 'specs');
   const artifacts: ArtifactEntry[] = [];
   if (existsSync(specsDir)) {
-    for (const f of readdirSync(specsDir).filter(f => f.endsWith('.md'))) {
+    for (const f of readdirSync(specsDir).filter((f) => f.endsWith('.md'))) {
       const fp = join(specsDir, f);
       const st = statSync(fp);
       artifacts.push({ name: f, size: st.size, modified: st.mtime.toISOString() });
@@ -146,7 +157,7 @@ export function generateStaticDashboard(data: DashboardData): HtmlResult {
 <h2>Phase Status</h2>
 <p>Current Phase: ${data.sections.phases.current_phase}</p>
 <h2>Artifacts (${data.sections.artifacts.total})</h2>
-<ul>${data.sections.artifacts.files.map(f => `<li>${f.name} (${f.size} bytes)</li>`).join('')}</ul>
+<ul>${data.sections.artifacts.files.map((f) => `<li>${f.name} (${f.size} bytes)</li>`).join('')}</ul>
 </body>
 </html>`;
   return { success: true, html };
@@ -160,7 +171,9 @@ export interface StatusResult {
   uptime: null;
 }
 
-export function getServerStatus(options: { port?: number | undefined; host?: string | undefined } = {}): StatusResult {
+export function getServerStatus(
+  options: { port?: number | undefined; host?: string | undefined } = {}
+): StatusResult {
   return {
     success: true,
     running: false,

--- a/tests/test-guided-handoff.test.ts
+++ b/tests/test-guided-handoff.test.ts
@@ -3,9 +3,9 @@
  */
 import { describe, expect, it } from 'vitest';
 import {
+  generateHandoff,
   HANDOFF_CHECKLISTS,
   HANDOFF_TYPES,
-  generateHandoff,
   listHandoffTypes,
   validateHandoff,
 } from '../src/lib/guided-handoff.js';
@@ -46,7 +46,7 @@ describe('generateHandoff', () => {
 
   it('marks provided items as provided', () => {
     const result = generateHandoff('product-to-engineering', '/tmp', { user_stories: true });
-    const item = result.items?.find(i => i.name === 'user_stories');
+    const item = result.items?.find((i) => i.name === 'user_stories');
     expect(item?.status).toBe('provided');
   });
 
@@ -141,8 +141,8 @@ describe('validateHandoff', () => {
 
   it('coverage_pct is between 0 and 100', () => {
     const result = validateHandoff('ops-to-support', ['known_issues']);
-    expect((result.coverage_pct ?? 0)).toBeGreaterThanOrEqual(0);
-    expect((result.coverage_pct ?? 0)).toBeLessThanOrEqual(100);
+    expect(result.coverage_pct ?? 0).toBeGreaterThanOrEqual(0);
+    expect(result.coverage_pct ?? 0).toBeLessThanOrEqual(100);
   });
 
   // Pollution key tests

--- a/tests/test-guided-handoff.test.ts
+++ b/tests/test-guided-handoff.test.ts
@@ -1,0 +1,158 @@
+/**
+ * tests/test-guided-handoff.test.ts — Guided Handoff port tests (M11 batch 6).
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  HANDOFF_CHECKLISTS,
+  HANDOFF_TYPES,
+  generateHandoff,
+  listHandoffTypes,
+  validateHandoff,
+} from '../src/lib/guided-handoff.js';
+
+describe('HANDOFF_TYPES', () => {
+  it('contains the four expected types', () => {
+    expect(HANDOFF_TYPES).toContain('product-to-engineering');
+    expect(HANDOFF_TYPES).toContain('engineering-to-qa');
+    expect(HANDOFF_TYPES).toContain('engineering-to-ops');
+    expect(HANDOFF_TYPES).toContain('ops-to-support');
+  });
+});
+
+describe('HANDOFF_CHECKLISTS', () => {
+  it('each type has required and optional arrays', () => {
+    for (const t of HANDOFF_TYPES) {
+      const cl = HANDOFF_CHECKLISTS[t];
+      expect(Array.isArray(cl.required)).toBe(true);
+      expect(Array.isArray(cl.optional)).toBe(true);
+      expect(cl.required.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('generateHandoff', () => {
+  it('returns success for valid type', () => {
+    const result = generateHandoff('product-to-engineering', '/tmp');
+    expect(result.success).toBe(true);
+    expect(result.type).toBe('product-to-engineering');
+    expect(Array.isArray(result.items)).toBe(true);
+  });
+
+  it('returns error for unknown type', () => {
+    const result = generateHandoff('unknown-type', '/tmp');
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Unknown handoff type/);
+  });
+
+  it('marks provided items as provided', () => {
+    const result = generateHandoff('product-to-engineering', '/tmp', { user_stories: true });
+    const item = result.items?.find(i => i.name === 'user_stories');
+    expect(item?.status).toBe('provided');
+  });
+
+  it('marks missing required items', () => {
+    const result = generateHandoff('product-to-engineering', '/tmp');
+    expect(result.complete).toBe(false);
+    expect((result.missing_required ?? []).length).toBeGreaterThan(0);
+  });
+
+  it('marks complete when all required are provided', () => {
+    const opts: Record<string, boolean> = {};
+    for (const req of HANDOFF_CHECKLISTS['product-to-engineering'].required) {
+      opts[req] = true;
+    }
+    const result = generateHandoff('product-to-engineering', '/tmp', opts);
+    expect(result.complete).toBe(true);
+    expect(result.missing_required?.length).toBe(0);
+  });
+
+  it('sets generated_at timestamp', () => {
+    const result = generateHandoff('engineering-to-qa', '/tmp');
+    expect(result.generated_at).toBeTruthy();
+  });
+
+  it('handles all four handoff types', () => {
+    for (const t of HANDOFF_TYPES) {
+      const result = generateHandoff(t, '/tmp');
+      expect(result.success).toBe(true);
+    }
+  });
+
+  // Prototype pollution — raw __proto__ key (not JSON.stringify which strips it)
+  it('does not accept __proto__ as a handoff type', () => {
+    const result = generateHandoff('__proto__', '/tmp');
+    expect(result.success).toBe(false);
+  });
+
+  it('does not accept constructor as a handoff type', () => {
+    const result = generateHandoff('constructor', '/tmp');
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('listHandoffTypes', () => {
+  it('returns all types with counts', () => {
+    const result = listHandoffTypes();
+    expect(result.success).toBe(true);
+    expect(result.types.length).toBe(HANDOFF_TYPES.length);
+    for (const t of result.types) {
+      expect(t.required_count).toBeGreaterThan(0);
+    }
+  });
+
+  it('includes labels for all types', () => {
+    const result = listHandoffTypes();
+    for (const t of result.types) {
+      expect(typeof t.label).toBe('string');
+      expect(t.label.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('validateHandoff', () => {
+  it('returns success false for unknown type', () => {
+    const result = validateHandoff('bad', []);
+    expect(result.success).toBe(false);
+  });
+
+  it('identifies missing required items', () => {
+    const result = validateHandoff('product-to-engineering', []);
+    expect(result.complete).toBe(false);
+    expect((result.missing ?? []).length).toBeGreaterThan(0);
+  });
+
+  it('reports complete when all required provided', () => {
+    const required = HANDOFF_CHECKLISTS['product-to-engineering'].required;
+    const result = validateHandoff('product-to-engineering', [...required]);
+    expect(result.complete).toBe(true);
+    expect(result.coverage_pct).toBe(100);
+  });
+
+  it('handles null provided list', () => {
+    const result = validateHandoff('engineering-to-qa', null);
+    expect(result.success).toBe(true);
+    expect(result.complete).toBe(false);
+  });
+
+  it('includes provided set in output', () => {
+    const result = validateHandoff('engineering-to-ops', ['runbooks', 'deployment_guide']);
+    expect(result.provided).toContain('runbooks');
+  });
+
+  it('coverage_pct is between 0 and 100', () => {
+    const result = validateHandoff('ops-to-support', ['known_issues']);
+    expect((result.coverage_pct ?? 0)).toBeGreaterThanOrEqual(0);
+    expect((result.coverage_pct ?? 0)).toBeLessThanOrEqual(100);
+  });
+
+  // Pollution key tests
+  it('does not accept __proto__ as type for validate', () => {
+    const result = validateHandoff('__proto__', []);
+    expect(result.success).toBe(false);
+  });
+
+  it('does not accept prototype as type for validate', () => {
+    const result = validateHandoff('prototype', []);
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/test-portfolio-reporting.test.ts
+++ b/tests/test-portfolio-reporting.test.ts
@@ -6,11 +6,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
-  PHASES,
-  PORTFOLIO_STATUSES,
   defaultPortfolio,
   getPortfolioStatus,
   loadPortfolio,
+  PHASES,
+  PORTFOLIO_STATUSES,
   registerInitiative,
   removeInitiative,
   savePortfolio,
@@ -53,7 +53,10 @@ describe('loadPortfolio', () => {
   // Prototype pollution: raw __proto__ key injection in JSON bytes
   it('rejects __proto__ pollution key in JSON', () => {
     const f = join(tmpDir, 'polluted.json');
-    writeFileSync(f, '{"__proto__":{"x":1},"initiatives":[],"snapshots":[],"version":"1.0.0","created_at":"2024-01-01T00:00:00.000Z","last_updated":null}');
+    writeFileSync(
+      f,
+      '{"__proto__":{"x":1},"initiatives":[],"snapshots":[],"version":"1.0.0","created_at":"2024-01-01T00:00:00.000Z","last_updated":null}'
+    );
     const p = loadPortfolio(f);
     // Should return defaultPortfolio() due to pollution rejection
     expect(p.initiatives).toEqual([]);
@@ -61,7 +64,10 @@ describe('loadPortfolio', () => {
 
   it('rejects constructor pollution key in JSON', () => {
     const f = join(tmpDir, 'polluted2.json');
-    writeFileSync(f, '{"constructor":{},"initiatives":[],"snapshots":[],"version":"1.0.0","created_at":"2024-01-01T00:00:00.000Z","last_updated":null}');
+    writeFileSync(
+      f,
+      '{"constructor":{},"initiatives":[],"snapshots":[],"version":"1.0.0","created_at":"2024-01-01T00:00:00.000Z","last_updated":null}'
+    );
     const p = loadPortfolio(f);
     expect(p.initiatives).toEqual([]);
   });
@@ -159,7 +165,7 @@ describe('takeSnapshot', () => {
 
 describe('PHASES', () => {
   it('includes expected phase IDs', () => {
-    const ids = PHASES.map(p => p.id);
+    const ids = PHASES.map((p) => p.id);
     expect(ids).toContain('phase-0');
     expect(ids).toContain('phase-4');
   });

--- a/tests/test-portfolio-reporting.test.ts
+++ b/tests/test-portfolio-reporting.test.ts
@@ -1,0 +1,173 @@
+/**
+ * tests/test-portfolio-reporting.test.ts — Portfolio Reporting port tests (M11 batch 6).
+ */
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  PHASES,
+  PORTFOLIO_STATUSES,
+  defaultPortfolio,
+  getPortfolioStatus,
+  loadPortfolio,
+  registerInitiative,
+  removeInitiative,
+  savePortfolio,
+  takeSnapshot,
+} from '../src/lib/portfolio-reporting.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = join(tmpdir(), `test-portfolio-${Date.now()}`);
+  mkdirSync(tmpDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('defaultPortfolio', () => {
+  it('returns version 1.0.0', () => {
+    const p = defaultPortfolio();
+    expect(p.version).toBe('1.0.0');
+    expect(p.initiatives).toEqual([]);
+    expect(p.snapshots).toEqual([]);
+  });
+});
+
+describe('loadPortfolio', () => {
+  it('returns defaultPortfolio when file missing', () => {
+    const p = loadPortfolio(join(tmpDir, 'nonexistent.json'));
+    expect(p.version).toBe('1.0.0');
+  });
+
+  it('returns defaultPortfolio on invalid JSON', () => {
+    const f = join(tmpDir, 'bad.json');
+    writeFileSync(f, 'not json');
+    const p = loadPortfolio(f);
+    expect(p.initiatives).toEqual([]);
+  });
+
+  // Prototype pollution: raw __proto__ key injection in JSON bytes
+  it('rejects __proto__ pollution key in JSON', () => {
+    const f = join(tmpDir, 'polluted.json');
+    writeFileSync(f, '{"__proto__":{"x":1},"initiatives":[],"snapshots":[],"version":"1.0.0","created_at":"2024-01-01T00:00:00.000Z","last_updated":null}');
+    const p = loadPortfolio(f);
+    // Should return defaultPortfolio() due to pollution rejection
+    expect(p.initiatives).toEqual([]);
+  });
+
+  it('rejects constructor pollution key in JSON', () => {
+    const f = join(tmpDir, 'polluted2.json');
+    writeFileSync(f, '{"constructor":{},"initiatives":[],"snapshots":[],"version":"1.0.0","created_at":"2024-01-01T00:00:00.000Z","last_updated":null}');
+    const p = loadPortfolio(f);
+    expect(p.initiatives).toEqual([]);
+  });
+});
+
+describe('savePortfolio / loadPortfolio round-trip', () => {
+  it('saves and loads correctly', () => {
+    const f = join(tmpDir, 'portfolio.json');
+    const p = defaultPortfolio();
+    savePortfolio(p, f);
+    const loaded = loadPortfolio(f);
+    expect(loaded.version).toBe('1.0.0');
+    expect(loaded.last_updated).toBeTruthy();
+  });
+});
+
+describe('registerInitiative', () => {
+  it('registers a new initiative', () => {
+    const f = join(tmpDir, 'portfolio.json');
+    const result = registerInitiative({ name: 'Test Initiative' }, { portfolioFile: f });
+    expect(result.success).toBe(true);
+    expect(result.initiative?.id).toBe('test-initiative');
+  });
+
+  it('rejects missing name', () => {
+    const f = join(tmpDir, 'portfolio.json');
+    const result = registerInitiative({ name: '' }, { portfolioFile: f });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects duplicate id', () => {
+    const f = join(tmpDir, 'portfolio.json');
+    registerInitiative({ name: 'My Project' }, { portfolioFile: f });
+    const result = registerInitiative({ name: 'My Project' }, { portfolioFile: f });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/already exists/);
+  });
+
+  it('sets status to on-track by default', () => {
+    const f = join(tmpDir, 'portfolio.json');
+    const result = registerInitiative({ name: 'Alpha' }, { portfolioFile: f });
+    expect(result.initiative?.status).toBe('on-track');
+  });
+});
+
+describe('removeInitiative', () => {
+  it('removes existing initiative', () => {
+    const f = join(tmpDir, 'portfolio.json');
+    registerInitiative({ name: 'Remove Me' }, { portfolioFile: f });
+    const result = removeInitiative('remove-me', { portfolioFile: f });
+    expect(result.success).toBe(true);
+    expect(result.removed).toBe('Remove Me');
+  });
+
+  it('returns error for missing initiative', () => {
+    const f = join(tmpDir, 'portfolio.json');
+    const result = removeInitiative('nonexistent', { portfolioFile: f });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not found/);
+  });
+});
+
+describe('getPortfolioStatus', () => {
+  it('returns success with empty portfolio', () => {
+    const f = join(tmpDir, 'portfolio.json');
+    const result = getPortfolioStatus({ portfolioFile: f });
+    expect(result.success).toBe(true);
+    expect(result.total_initiatives).toBe(0);
+  });
+
+  it('includes all status counts', () => {
+    const f = join(tmpDir, 'portfolio.json');
+    const result = getPortfolioStatus({ portfolioFile: f });
+    for (const s of PORTFOLIO_STATUSES) {
+      expect(typeof result.status_counts[s]).toBe('number');
+    }
+  });
+});
+
+describe('takeSnapshot', () => {
+  it('creates a snapshot', () => {
+    const f = join(tmpDir, 'portfolio.json');
+    const result = takeSnapshot({ portfolioFile: f });
+    expect(result.success).toBe(true);
+    expect(result.snapshot.taken_at).toBeTruthy();
+  });
+
+  it('snapshot caps at 100 entries', () => {
+    const f = join(tmpDir, 'portfolio.json');
+    for (let i = 0; i < 105; i++) takeSnapshot({ portfolioFile: f });
+    const p = loadPortfolio(f);
+    expect(p.snapshots.length).toBe(100);
+  });
+});
+
+describe('PHASES', () => {
+  it('includes expected phase IDs', () => {
+    const ids = PHASES.map(p => p.id);
+    expect(ids).toContain('phase-0');
+    expect(ids).toContain('phase-4');
+  });
+});
+
+describe('PORTFOLIO_STATUSES', () => {
+  it('includes on-track and blocked', () => {
+    expect(PORTFOLIO_STATUSES).toContain('on-track');
+    expect(PORTFOLIO_STATUSES).toContain('blocked');
+  });
+});

--- a/tests/test-requirements-baseline.test.ts
+++ b/tests/test-requirements-baseline.test.ts
@@ -1,0 +1,184 @@
+/**
+ * tests/test-requirements-baseline.test.ts — Requirements Baseline port tests.
+ */
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  ARTIFACT_TYPES,
+  assessImpact,
+  checkBaseline,
+  defaultBaseline,
+  extractRequirementIds,
+  freezeBaseline,
+  getBaselineStatus,
+  hashContent,
+  loadBaseline,
+  saveBaseline,
+} from '../src/lib/requirements-baseline.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = join(tmpdir(), `test-baseline-${Date.now()}`);
+  mkdirSync(tmpDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('defaultBaseline', () => {
+  it('returns unfrozen baseline', () => {
+    const b = defaultBaseline();
+    expect(b.frozen).toBe(false);
+    expect(b.baselines).toEqual([]);
+    expect(b.change_requests).toEqual([]);
+  });
+});
+
+describe('loadBaseline', () => {
+  it('returns defaultBaseline when file missing', () => {
+    const b = loadBaseline(join(tmpDir, 'missing.json'));
+    expect(b.frozen).toBe(false);
+  });
+
+  it('returns defaultBaseline on invalid JSON', () => {
+    const f = join(tmpDir, 'bad.json');
+    writeFileSync(f, 'not json');
+    const b = loadBaseline(f);
+    expect(b.baselines).toEqual([]);
+  });
+
+  // Pollution key tests using raw bytes (not JSON.stringify which strips __proto__)
+  it('rejects __proto__ pollution key', () => {
+    const f = join(tmpDir, 'polluted.json');
+    writeFileSync(f, '{"__proto__":{"evil":true},"version":"1.0.0","created_at":"2024-01-01T00:00:00.000Z","last_updated":null,"frozen":false,"baselines":[],"change_requests":[]}');
+    const b = loadBaseline(f);
+    expect(b.baselines).toEqual([]);
+  });
+
+  it('rejects constructor pollution key', () => {
+    const f = join(tmpDir, 'polluted2.json');
+    writeFileSync(f, '{"constructor":{},"version":"1.0.0","created_at":"2024-01-01T00:00:00.000Z","last_updated":null,"frozen":false,"baselines":[],"change_requests":[]}');
+    const b = loadBaseline(f);
+    expect(b.baselines).toEqual([]);
+  });
+});
+
+describe('saveBaseline / loadBaseline round-trip', () => {
+  it('saves and loads correctly', () => {
+    const f = join(tmpDir, 'baseline.json');
+    const b = defaultBaseline();
+    saveBaseline(b, f);
+    const loaded = loadBaseline(f);
+    expect(loaded.version).toBe('1.0.0');
+    expect(loaded.last_updated).toBeTruthy();
+  });
+});
+
+describe('hashContent', () => {
+  it('produces a 64-char hex string', () => {
+    const h = hashContent('hello world');
+    expect(h).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('is deterministic', () => {
+    expect(hashContent('abc')).toBe(hashContent('abc'));
+  });
+
+  it('differs for different content', () => {
+    expect(hashContent('abc')).not.toBe(hashContent('xyz'));
+  });
+});
+
+describe('extractRequirementIds', () => {
+  it('extracts REQ- ids', () => {
+    const ids = extractRequirementIds('See REQ-001 and REQ-042');
+    expect(ids).toContain('REQ-001');
+    expect(ids).toContain('REQ-042');
+  });
+
+  it('extracts E-S ids', () => {
+    const ids = extractRequirementIds('Story E01-S02 is key');
+    expect(ids).toContain('E01-S02');
+  });
+
+  it('deduplicates', () => {
+    const ids = extractRequirementIds('REQ-001 REQ-001 REQ-002');
+    expect(ids.filter(id => id === 'REQ-001').length).toBe(1);
+  });
+
+  it('returns sorted array', () => {
+    const ids = extractRequirementIds('REQ-003 REQ-001 REQ-002');
+    expect(ids).toEqual([...ids].sort());
+  });
+});
+
+describe('freezeBaseline', () => {
+  it('returns error when specs dir missing', () => {
+    const result = freezeBaseline(tmpDir);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/specs/);
+  });
+
+  it('freezes with existing spec files', () => {
+    const specsDir = join(tmpDir, 'specs');
+    mkdirSync(specsDir);
+    writeFileSync(join(specsDir, 'prd.md'), '# PRD\n\nREQ-001 some requirement\n\n## Phase Gate Approval\n- [x] done\nApproved by: Alice');
+    const result = freezeBaseline(tmpDir);
+    expect(result.success).toBe(true);
+    expect(result.artifacts_frozen).toBeGreaterThan(0);
+  });
+});
+
+describe('checkBaseline', () => {
+  it('returns frozen=false when no baseline', () => {
+    const result = checkBaseline(tmpDir);
+    expect(result.frozen).toBe(false);
+  });
+
+  it('detects unchanged after freeze', () => {
+    const specsDir = join(tmpDir, 'specs');
+    mkdirSync(specsDir);
+    writeFileSync(join(specsDir, 'prd.md'), '# PRD\n\nContent');
+    freezeBaseline(tmpDir);
+    const result = checkBaseline(tmpDir);
+    expect(result.frozen).toBe(true);
+    expect(result.drifted).toBe(false);
+  });
+
+  it('detects drift after file change', () => {
+    const specsDir = join(tmpDir, 'specs');
+    mkdirSync(specsDir);
+    writeFileSync(join(specsDir, 'prd.md'), '# PRD\n\nOriginal');
+    freezeBaseline(tmpDir);
+    writeFileSync(join(specsDir, 'prd.md'), '# PRD\n\nModified content here');
+    const result = checkBaseline(tmpDir);
+    expect(result.drifted).toBe(true);
+  });
+});
+
+describe('assessImpact', () => {
+  it('returns none when no baseline exists', () => {
+    const result = assessImpact('specs/prd.md', tmpDir);
+    expect(result.impact).toBe('none');
+  });
+});
+
+describe('getBaselineStatus', () => {
+  it('returns unfrozen status for empty state', () => {
+    const f = join(tmpDir, 'bl.json');
+    const result = getBaselineStatus({ baselineFile: f });
+    expect(result.frozen).toBe(false);
+    expect(result.total_baselines).toBe(0);
+  });
+});
+
+describe('ARTIFACT_TYPES', () => {
+  it('includes prd and architecture', () => {
+    expect(ARTIFACT_TYPES).toContain('prd');
+    expect(ARTIFACT_TYPES).toContain('architecture');
+  });
+});

--- a/tests/test-requirements-baseline.test.ts
+++ b/tests/test-requirements-baseline.test.ts
@@ -54,14 +54,20 @@ describe('loadBaseline', () => {
   // Pollution key tests using raw bytes (not JSON.stringify which strips __proto__)
   it('rejects __proto__ pollution key', () => {
     const f = join(tmpDir, 'polluted.json');
-    writeFileSync(f, '{"__proto__":{"evil":true},"version":"1.0.0","created_at":"2024-01-01T00:00:00.000Z","last_updated":null,"frozen":false,"baselines":[],"change_requests":[]}');
+    writeFileSync(
+      f,
+      '{"__proto__":{"evil":true},"version":"1.0.0","created_at":"2024-01-01T00:00:00.000Z","last_updated":null,"frozen":false,"baselines":[],"change_requests":[]}'
+    );
     const b = loadBaseline(f);
     expect(b.baselines).toEqual([]);
   });
 
   it('rejects constructor pollution key', () => {
     const f = join(tmpDir, 'polluted2.json');
-    writeFileSync(f, '{"constructor":{},"version":"1.0.0","created_at":"2024-01-01T00:00:00.000Z","last_updated":null,"frozen":false,"baselines":[],"change_requests":[]}');
+    writeFileSync(
+      f,
+      '{"constructor":{},"version":"1.0.0","created_at":"2024-01-01T00:00:00.000Z","last_updated":null,"frozen":false,"baselines":[],"change_requests":[]}'
+    );
     const b = loadBaseline(f);
     expect(b.baselines).toEqual([]);
   });
@@ -107,7 +113,7 @@ describe('extractRequirementIds', () => {
 
   it('deduplicates', () => {
     const ids = extractRequirementIds('REQ-001 REQ-001 REQ-002');
-    expect(ids.filter(id => id === 'REQ-001').length).toBe(1);
+    expect(ids.filter((id) => id === 'REQ-001').length).toBe(1);
   });
 
   it('returns sorted array', () => {
@@ -126,7 +132,10 @@ describe('freezeBaseline', () => {
   it('freezes with existing spec files', () => {
     const specsDir = join(tmpDir, 'specs');
     mkdirSync(specsDir);
-    writeFileSync(join(specsDir, 'prd.md'), '# PRD\n\nREQ-001 some requirement\n\n## Phase Gate Approval\n- [x] done\nApproved by: Alice');
+    writeFileSync(
+      join(specsDir, 'prd.md'),
+      '# PRD\n\nREQ-001 some requirement\n\n## Phase Gate Approval\n- [x] done\nApproved by: Alice'
+    );
     const result = freezeBaseline(tmpDir);
     expect(result.success).toBe(true);
     expect(result.artifacts_frozen).toBeGreaterThan(0);

--- a/tests/test-root-cause-analysis.test.ts
+++ b/tests/test-root-cause-analysis.test.ts
@@ -1,0 +1,107 @@
+/**
+ * tests/test-root-cause-analysis.test.ts — Root Cause Analysis port tests.
+ */
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  FAILURE_PATTERNS,
+  analyzeFailure,
+  analyzeTestFile,
+  generateReport,
+} from '../src/lib/root-cause-analysis.js';
+
+let tmpDir: string;
+beforeEach(() => { tmpDir = join(tmpdir(), `test-rca-${Date.now()}`); mkdirSync(tmpDir, { recursive: true }); });
+afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+
+describe('FAILURE_PATTERNS', () => {
+  it('contains at least 5 patterns', () => expect(FAILURE_PATTERNS.length).toBeGreaterThanOrEqual(5));
+  it('each pattern has category and fix', () => {
+    for (const p of FAILURE_PATTERNS) {
+      expect(typeof p.category).toBe('string');
+      expect(typeof p.fix).toBe('string');
+    }
+  });
+});
+
+describe('analyzeFailure', () => {
+  it('returns error on empty output', () => {
+    const r = analyzeFailure('');
+    expect(r.success).toBe(false);
+  });
+
+  it('detects syntax error', () => {
+    const r = analyzeFailure("SyntaxError: Unexpected token '>'");
+    expect(r.success).toBe(true);
+    expect(r.categories).toContain('syntax-error');
+  });
+
+  it('detects missing module', () => {
+    const r = analyzeFailure("Cannot find module 'lodash'");
+    expect(r.categories).toContain('missing-dependency');
+  });
+
+  it('detects type error', () => {
+    const r = analyzeFailure("TypeError: foo is not a function");
+    expect(r.categories).toContain('type-error');
+  });
+
+  it('detects reference error', () => {
+    const r = analyzeFailure("ReferenceError: myVar is not defined");
+    expect(r.categories).toContain('reference-error');
+  });
+
+  it('returns primary_cause null for empty hypotheses', () => {
+    const r = analyzeFailure('all good no errors here');
+    expect(r.primary_cause).toBeNull();
+  });
+
+  it('provides recommended_actions for up to 3 hypotheses', () => {
+    const r = analyzeFailure("SyntaxError: bad\nCannot find module 'a'\nReferenceError: x is not defined");
+    expect((r.recommended_actions ?? []).length).toBeLessThanOrEqual(3);
+  });
+
+  it('deduplicates same category+detail', () => {
+    const r = analyzeFailure("SyntaxError: bad\nSyntaxError: bad\nSyntaxError: bad");
+    const syntaxCount = r.hypotheses?.filter(h => h.category === 'syntax-error').length ?? 0;
+    expect(syntaxCount).toBe(1);
+  });
+});
+
+describe('analyzeTestFile', () => {
+  it('returns error for missing file', () => {
+    const r = analyzeTestFile(join(tmpDir, 'missing.txt'));
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/File not found/);
+  });
+
+  it('analyzes an actual file', () => {
+    const f = join(tmpDir, 'output.txt');
+    writeFileSync(f, "SyntaxError: Unexpected end of input");
+    const r = analyzeTestFile(f);
+    expect(r.success).toBe(true);
+    expect(r.file).toBe(f);
+  });
+});
+
+describe('generateReport', () => {
+  it('returns error for invalid analysis', () => {
+    const r = generateReport({ success: false } as any);
+    expect(r.success).toBe(false);
+  });
+
+  it('summarizes by category', () => {
+    const analysis = analyzeFailure("SyntaxError: bad\nCannot find module 'x'");
+    const r = generateReport(analysis);
+    expect(r.success).toBe(true);
+    expect(Object.keys(r.by_category ?? {}).length).toBeGreaterThan(0);
+  });
+
+  it('action_plan has at most 3 items', () => {
+    const analysis = analyzeFailure("SyntaxError: bad\nCannot find module 'x'\nReferenceError: y is not defined\nTypeError: z is not a function");
+    const r = generateReport(analysis);
+    expect((r.action_plan ?? []).length).toBeLessThanOrEqual(3);
+  });
+});

--- a/tests/test-root-cause-analysis.test.ts
+++ b/tests/test-root-cause-analysis.test.ts
@@ -6,18 +6,24 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
-  FAILURE_PATTERNS,
   analyzeFailure,
   analyzeTestFile,
+  FAILURE_PATTERNS,
   generateReport,
 } from '../src/lib/root-cause-analysis.js';
 
 let tmpDir: string;
-beforeEach(() => { tmpDir = join(tmpdir(), `test-rca-${Date.now()}`); mkdirSync(tmpDir, { recursive: true }); });
-afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+beforeEach(() => {
+  tmpDir = join(tmpdir(), `test-rca-${Date.now()}`);
+  mkdirSync(tmpDir, { recursive: true });
+});
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
 
 describe('FAILURE_PATTERNS', () => {
-  it('contains at least 5 patterns', () => expect(FAILURE_PATTERNS.length).toBeGreaterThanOrEqual(5));
+  it('contains at least 5 patterns', () =>
+    expect(FAILURE_PATTERNS.length).toBeGreaterThanOrEqual(5));
   it('each pattern has category and fix', () => {
     for (const p of FAILURE_PATTERNS) {
       expect(typeof p.category).toBe('string');
@@ -44,12 +50,12 @@ describe('analyzeFailure', () => {
   });
 
   it('detects type error', () => {
-    const r = analyzeFailure("TypeError: foo is not a function");
+    const r = analyzeFailure('TypeError: foo is not a function');
     expect(r.categories).toContain('type-error');
   });
 
   it('detects reference error', () => {
-    const r = analyzeFailure("ReferenceError: myVar is not defined");
+    const r = analyzeFailure('ReferenceError: myVar is not defined');
     expect(r.categories).toContain('reference-error');
   });
 
@@ -59,13 +65,15 @@ describe('analyzeFailure', () => {
   });
 
   it('provides recommended_actions for up to 3 hypotheses', () => {
-    const r = analyzeFailure("SyntaxError: bad\nCannot find module 'a'\nReferenceError: x is not defined");
+    const r = analyzeFailure(
+      "SyntaxError: bad\nCannot find module 'a'\nReferenceError: x is not defined"
+    );
     expect((r.recommended_actions ?? []).length).toBeLessThanOrEqual(3);
   });
 
   it('deduplicates same category+detail', () => {
-    const r = analyzeFailure("SyntaxError: bad\nSyntaxError: bad\nSyntaxError: bad");
-    const syntaxCount = r.hypotheses?.filter(h => h.category === 'syntax-error').length ?? 0;
+    const r = analyzeFailure('SyntaxError: bad\nSyntaxError: bad\nSyntaxError: bad');
+    const syntaxCount = r.hypotheses?.filter((h) => h.category === 'syntax-error').length ?? 0;
     expect(syntaxCount).toBe(1);
   });
 });
@@ -79,7 +87,7 @@ describe('analyzeTestFile', () => {
 
   it('analyzes an actual file', () => {
     const f = join(tmpDir, 'output.txt');
-    writeFileSync(f, "SyntaxError: Unexpected end of input");
+    writeFileSync(f, 'SyntaxError: Unexpected end of input');
     const r = analyzeTestFile(f);
     expect(r.success).toBe(true);
     expect(r.file).toBe(f);
@@ -100,7 +108,9 @@ describe('generateReport', () => {
   });
 
   it('action_plan has at most 3 items', () => {
-    const analysis = analyzeFailure("SyntaxError: bad\nCannot find module 'x'\nReferenceError: y is not defined\nTypeError: z is not a function");
+    const analysis = analyzeFailure(
+      "SyntaxError: bad\nCannot find module 'x'\nReferenceError: y is not defined\nTypeError: z is not a function"
+    );
     const r = generateReport(analysis);
     expect((r.action_plan ?? []).length).toBeLessThanOrEqual(3);
   });

--- a/tests/test-runtime-debugger.test.ts
+++ b/tests/test-runtime-debugger.test.ts
@@ -1,0 +1,121 @@
+/**
+ * tests/test-runtime-debugger.test.ts — Runtime Debugger port tests.
+ */
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  LOG_PATTERNS,
+  analyzeLogFile,
+  analyzeLogs,
+  correlateWithSource,
+  generateHypotheses,
+} from '../src/lib/runtime-debugger.js';
+
+let tmpDir: string;
+beforeEach(() => { tmpDir = join(tmpdir(), `test-rdbg-${Date.now()}`); mkdirSync(tmpDir, { recursive: true }); });
+afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+
+describe('LOG_PATTERNS', () => {
+  it('contains error and warning patterns', () => {
+    expect(LOG_PATTERNS['error']).toBeTruthy();
+    expect(LOG_PATTERNS['warning']).toBeTruthy();
+  });
+});
+
+describe('analyzeLogs', () => {
+  it('detects ERROR line', () => {
+    const r = analyzeLogs('2024-01-01 ERROR something went wrong');
+    expect(r.success).toBe(true);
+    expect((r.summary?.errors ?? 0)).toBeGreaterThan(0);
+  });
+
+  it('detects WARN line', () => {
+    const r = analyzeLogs('2024-01-01 WARN low disk space');
+    expect((r.summary?.warnings ?? 0)).toBeGreaterThan(0);
+  });
+
+  it('detects OOM', () => {
+    const r = analyzeLogs('heap allocation failed OOM');
+    expect((r.summary?.oom ?? 0)).toBeGreaterThan(0);
+  });
+
+  it('detects ECONNREFUSED', () => {
+    const r = analyzeLogs('connect ECONNREFUSED 127.0.0.1:5432');
+    expect((r.summary?.connection_issues ?? 0)).toBeGreaterThan(0);
+  });
+
+  it('detects timeout', () => {
+    const r = analyzeLogs('request timed out after 30s');
+    expect((r.summary?.timeouts ?? 0)).toBeGreaterThan(0);
+  });
+
+  it('returns total_findings count', () => {
+    const r = analyzeLogs('ERROR a\nERROR b\nWARN c');
+    expect((r.total_findings ?? 0)).toBeGreaterThanOrEqual(2);
+  });
+
+  it('handles empty log', () => {
+    const r = analyzeLogs('');
+    expect(r.total_findings).toBe(0);
+  });
+
+  it('truncates content to 200 chars', () => {
+    const longLine = 'ERROR ' + 'x'.repeat(300);
+    const r = analyzeLogs(longLine);
+    for (const f of r.findings ?? []) {
+      expect(f.content.length).toBeLessThanOrEqual(200);
+    }
+  });
+});
+
+describe('analyzeLogFile', () => {
+  it('returns error for missing file', () => {
+    const r = analyzeLogFile(join(tmpDir, 'nope.log'));
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/not found/);
+  });
+
+  it('analyzes real file', () => {
+    const f = join(tmpDir, 'app.log');
+    writeFileSync(f, 'ERROR something failed\nWARN low memory');
+    const r = analyzeLogFile(f);
+    expect(r.success).toBe(true);
+    expect(r.file).toBe(f);
+  });
+});
+
+describe('correlateWithSource', () => {
+  it('extracts file references from findings', () => {
+    const findings = [{ type: 'error', line: 1, content: 'at src/app.ts:42', severity: 'high' as const }];
+    const r = correlateWithSource(findings, tmpDir);
+    expect(r.success).toBe(true);
+    expect(r.total).toBeGreaterThan(0);
+  });
+
+  it('returns empty for no file refs', () => {
+    const findings = [{ type: 'error', line: 1, content: 'no file ref here', severity: 'high' as const }];
+    const r = correlateWithSource(findings, tmpDir);
+    expect(r.correlations).toHaveLength(0);
+  });
+});
+
+describe('generateHypotheses', () => {
+  it('suggests memory hypothesis for OOM', () => {
+    const analysis = analyzeLogs('heap allocation failed OOM');
+    const r = generateHypotheses(analysis);
+    expect(r.hypotheses.some(h => h.hypothesis.toLowerCase().includes('memory'))).toBe(true);
+  });
+
+  it('suggests connection hypothesis for ECONNREFUSED', () => {
+    const analysis = analyzeLogs('ECONNREFUSED');
+    const r = generateHypotheses(analysis);
+    expect(r.hypotheses.some(h => h.hypothesis.toLowerCase().includes('service'))).toBe(true);
+  });
+
+  it('returns success true', () => {
+    const r = generateHypotheses(analyzeLogs('ERROR test'));
+    expect(r.success).toBe(true);
+  });
+});

--- a/tests/test-runtime-debugger.test.ts
+++ b/tests/test-runtime-debugger.test.ts
@@ -6,21 +6,26 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
-  LOG_PATTERNS,
   analyzeLogFile,
   analyzeLogs,
   correlateWithSource,
   generateHypotheses,
+  LOG_PATTERNS,
 } from '../src/lib/runtime-debugger.js';
 
 let tmpDir: string;
-beforeEach(() => { tmpDir = join(tmpdir(), `test-rdbg-${Date.now()}`); mkdirSync(tmpDir, { recursive: true }); });
-afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+beforeEach(() => {
+  tmpDir = join(tmpdir(), `test-rdbg-${Date.now()}`);
+  mkdirSync(tmpDir, { recursive: true });
+});
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
 
 describe('LOG_PATTERNS', () => {
   it('contains error and warning patterns', () => {
-    expect(LOG_PATTERNS['error']).toBeTruthy();
-    expect(LOG_PATTERNS['warning']).toBeTruthy();
+    expect(LOG_PATTERNS.error).toBeTruthy();
+    expect(LOG_PATTERNS.warning).toBeTruthy();
   });
 });
 
@@ -28,32 +33,32 @@ describe('analyzeLogs', () => {
   it('detects ERROR line', () => {
     const r = analyzeLogs('2024-01-01 ERROR something went wrong');
     expect(r.success).toBe(true);
-    expect((r.summary?.errors ?? 0)).toBeGreaterThan(0);
+    expect(r.summary?.errors ?? 0).toBeGreaterThan(0);
   });
 
   it('detects WARN line', () => {
     const r = analyzeLogs('2024-01-01 WARN low disk space');
-    expect((r.summary?.warnings ?? 0)).toBeGreaterThan(0);
+    expect(r.summary?.warnings ?? 0).toBeGreaterThan(0);
   });
 
   it('detects OOM', () => {
     const r = analyzeLogs('heap allocation failed OOM');
-    expect((r.summary?.oom ?? 0)).toBeGreaterThan(0);
+    expect(r.summary?.oom ?? 0).toBeGreaterThan(0);
   });
 
   it('detects ECONNREFUSED', () => {
     const r = analyzeLogs('connect ECONNREFUSED 127.0.0.1:5432');
-    expect((r.summary?.connection_issues ?? 0)).toBeGreaterThan(0);
+    expect(r.summary?.connection_issues ?? 0).toBeGreaterThan(0);
   });
 
   it('detects timeout', () => {
     const r = analyzeLogs('request timed out after 30s');
-    expect((r.summary?.timeouts ?? 0)).toBeGreaterThan(0);
+    expect(r.summary?.timeouts ?? 0).toBeGreaterThan(0);
   });
 
   it('returns total_findings count', () => {
     const r = analyzeLogs('ERROR a\nERROR b\nWARN c');
-    expect((r.total_findings ?? 0)).toBeGreaterThanOrEqual(2);
+    expect(r.total_findings ?? 0).toBeGreaterThanOrEqual(2);
   });
 
   it('handles empty log', () => {
@@ -62,7 +67,7 @@ describe('analyzeLogs', () => {
   });
 
   it('truncates content to 200 chars', () => {
-    const longLine = 'ERROR ' + 'x'.repeat(300);
+    const longLine = `ERROR ${'x'.repeat(300)}`;
     const r = analyzeLogs(longLine);
     for (const f of r.findings ?? []) {
       expect(f.content.length).toBeLessThanOrEqual(200);
@@ -88,14 +93,18 @@ describe('analyzeLogFile', () => {
 
 describe('correlateWithSource', () => {
   it('extracts file references from findings', () => {
-    const findings = [{ type: 'error', line: 1, content: 'at src/app.ts:42', severity: 'high' as const }];
+    const findings = [
+      { type: 'error', line: 1, content: 'at src/app.ts:42', severity: 'high' as const },
+    ];
     const r = correlateWithSource(findings, tmpDir);
     expect(r.success).toBe(true);
     expect(r.total).toBeGreaterThan(0);
   });
 
   it('returns empty for no file refs', () => {
-    const findings = [{ type: 'error', line: 1, content: 'no file ref here', severity: 'high' as const }];
+    const findings = [
+      { type: 'error', line: 1, content: 'no file ref here', severity: 'high' as const },
+    ];
     const r = correlateWithSource(findings, tmpDir);
     expect(r.correlations).toHaveLength(0);
   });
@@ -105,13 +114,13 @@ describe('generateHypotheses', () => {
   it('suggests memory hypothesis for OOM', () => {
     const analysis = analyzeLogs('heap allocation failed OOM');
     const r = generateHypotheses(analysis);
-    expect(r.hypotheses.some(h => h.hypothesis.toLowerCase().includes('memory'))).toBe(true);
+    expect(r.hypotheses.some((h) => h.hypothesis.toLowerCase().includes('memory'))).toBe(true);
   });
 
   it('suggests connection hypothesis for ECONNREFUSED', () => {
     const analysis = analyzeLogs('ECONNREFUSED');
     const r = generateHypotheses(analysis);
-    expect(r.hypotheses.some(h => h.hypothesis.toLowerCase().includes('service'))).toBe(true);
+    expect(r.hypotheses.some((h) => h.hypothesis.toLowerCase().includes('service'))).toBe(true);
   });
 
   it('returns success true', () => {

--- a/tests/test-scanner.test.ts
+++ b/tests/test-scanner.test.ts
@@ -1,0 +1,135 @@
+/**
+ * tests/test-scanner.test.ts — Scanner port tests (M11 batch 6).
+ */
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  countDebtMarkers,
+  detectStack,
+  identifyRisks,
+  scan,
+  scanDir,
+} from '../src/lib/scanner.js';
+
+let tmpDir: string;
+beforeEach(() => { tmpDir = join(tmpdir(), `test-scanner-${Date.now()}`); mkdirSync(tmpDir, { recursive: true }); });
+afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+
+describe('scanDir', () => {
+  it('returns empty for nonexistent dir', () => {
+    const r = scanDir(join(tmpDir, 'nope'), [], tmpDir);
+    expect(r.files).toEqual([]);
+    expect(r.dirs).toEqual([]);
+  });
+
+  it('finds files in directory', () => {
+    writeFileSync(join(tmpDir, 'foo.ts'), '// content');
+    const r = scanDir(tmpDir, [], tmpDir);
+    expect(r.files).toContain('foo.ts');
+  });
+
+  it('skips ignored directories', () => {
+    mkdirSync(join(tmpDir, 'node_modules'));
+    writeFileSync(join(tmpDir, 'node_modules', 'pkg.js'), '');
+    const r = scanDir(tmpDir, ['node_modules'], tmpDir);
+    expect(r.files.some(f => f.includes('node_modules'))).toBe(false);
+  });
+
+  it('skips dotfiles except .env.example', () => {
+    writeFileSync(join(tmpDir, '.env'), 'SECRET=x');
+    writeFileSync(join(tmpDir, '.env.example'), 'SECRET=');
+    const r = scanDir(tmpDir, [], tmpDir);
+    expect(r.files).toContain('.env.example');
+    expect(r.files).not.toContain('.env');
+  });
+});
+
+describe('detectStack', () => {
+  it('detects TypeScript from package.json', () => {
+    writeFileSync(join(tmpDir, 'package.json'), JSON.stringify({ devDependencies: { typescript: '^5.0.0' } }));
+    const s = detectStack(tmpDir, ['index.ts']);
+    expect(s.language).toBe('TypeScript');
+    expect(s.runtime).toBe('Node.js');
+  });
+
+  it('detects pnpm from lockfile', () => {
+    writeFileSync(join(tmpDir, 'package.json'), JSON.stringify({ dependencies: {} }));
+    writeFileSync(join(tmpDir, 'pnpm-lock.yaml'), '');
+    const s = detectStack(tmpDir, []);
+    expect(s.package_manager).toBe('pnpm');
+  });
+
+  it('detects Python from requirements.txt', () => {
+    const s = detectStack(tmpDir, ['requirements.txt']);
+    expect(s.language).toBe('Python');
+  });
+
+  it('detects Go from go.mod', () => {
+    const s = detectStack(tmpDir, ['go.mod']);
+    expect(s.language).toBe('Go');
+  });
+
+  it('handles invalid package.json gracefully', () => {
+    writeFileSync(join(tmpDir, 'package.json'), 'not json');
+    const s = detectStack(tmpDir, []);
+    expect(s.language).toBeNull();
+  });
+});
+
+describe('countDebtMarkers', () => {
+  it('counts TODO markers', () => {
+    writeFileSync(join(tmpDir, 'app.ts'), '// TODO: fix this\nconst x = 1; // TODO: cleanup');
+    const d = countDebtMarkers(tmpDir, ['app.ts']);
+    expect(d.TODO).toBe(2);
+  });
+
+  it('counts FIXME markers', () => {
+    writeFileSync(join(tmpDir, 'src.js'), '// FIXME: broken');
+    const d = countDebtMarkers(tmpDir, ['src.js']);
+    expect(d.FIXME).toBe(1);
+  });
+
+  it('ignores non-source files', () => {
+    writeFileSync(join(tmpDir, 'README.md'), 'TODO: update docs');
+    const d = countDebtMarkers(tmpDir, ['README.md']);
+    expect(d.TODO).toBe(0);
+  });
+});
+
+describe('identifyRisks', () => {
+  it('identifies no-test risk', () => {
+    const risks = identifyRisks(tmpDir, ['src/app.ts'], { runtime: 'Node.js', language: 'TypeScript', language_version: null, runtime_version: null, framework: null, framework_version: null, package_manager: 'npm', test_framework: null, database: null });
+    expect(risks.some(r => r.risk.includes('test'))).toBe(true);
+  });
+
+  it('identifies .env risk', () => {
+    const risks = identifyRisks(tmpDir, ['.env', 'src/app.ts'], { runtime: 'Node.js', language: 'TypeScript', language_version: null, runtime_version: null, framework: null, framework_version: null, package_manager: 'npm', test_framework: null, database: null });
+    expect(risks.some(r => r.risk.includes('.env'))).toBe(true);
+  });
+});
+
+describe('scan', () => {
+  it('returns full scan result', () => {
+    writeFileSync(join(tmpDir, 'package.json'), JSON.stringify({ devDependencies: { vitest: '^1.0.0' } }));
+    writeFileSync(join(tmpDir, 'app.test.ts'), 'it("ok", () => {})');
+    const r = scan({ root: tmpDir });
+    expect(r.scanned_at).toBeTruthy();
+    expect(r.stack).toBeTruthy();
+    expect(r.stats.files).toBeGreaterThan(0);
+  });
+
+  it('uses default ignore list', () => {
+    mkdirSync(join(tmpDir, 'dist'));
+    writeFileSync(join(tmpDir, 'dist', 'bundle.js'), '');
+    const r = scan({ root: tmpDir });
+    expect(r.structure.top_level).not.toContain('dist/');
+  });
+
+  it('detects test framework from devDeps', () => {
+    writeFileSync(join(tmpDir, 'package.json'), JSON.stringify({ devDependencies: { vitest: '^1.0.0', typescript: '^5.0.0' } }));
+    const r = scan({ root: tmpDir });
+    expect(r.stack.test_framework).toBe('Vitest');
+  });
+});

--- a/tests/test-scanner.test.ts
+++ b/tests/test-scanner.test.ts
@@ -5,17 +5,16 @@ import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import {
-  countDebtMarkers,
-  detectStack,
-  identifyRisks,
-  scan,
-  scanDir,
-} from '../src/lib/scanner.js';
+import { countDebtMarkers, detectStack, identifyRisks, scan, scanDir } from '../src/lib/scanner.js';
 
 let tmpDir: string;
-beforeEach(() => { tmpDir = join(tmpdir(), `test-scanner-${Date.now()}`); mkdirSync(tmpDir, { recursive: true }); });
-afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+beforeEach(() => {
+  tmpDir = join(tmpdir(), `test-scanner-${Date.now()}`);
+  mkdirSync(tmpDir, { recursive: true });
+});
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
 
 describe('scanDir', () => {
   it('returns empty for nonexistent dir', () => {
@@ -34,7 +33,7 @@ describe('scanDir', () => {
     mkdirSync(join(tmpDir, 'node_modules'));
     writeFileSync(join(tmpDir, 'node_modules', 'pkg.js'), '');
     const r = scanDir(tmpDir, ['node_modules'], tmpDir);
-    expect(r.files.some(f => f.includes('node_modules'))).toBe(false);
+    expect(r.files.some((f) => f.includes('node_modules'))).toBe(false);
   });
 
   it('skips dotfiles except .env.example', () => {
@@ -48,7 +47,10 @@ describe('scanDir', () => {
 
 describe('detectStack', () => {
   it('detects TypeScript from package.json', () => {
-    writeFileSync(join(tmpDir, 'package.json'), JSON.stringify({ devDependencies: { typescript: '^5.0.0' } }));
+    writeFileSync(
+      join(tmpDir, 'package.json'),
+      JSON.stringify({ devDependencies: { typescript: '^5.0.0' } })
+    );
     const s = detectStack(tmpDir, ['index.ts']);
     expect(s.language).toBe('TypeScript');
     expect(s.runtime).toBe('Node.js');
@@ -100,19 +102,42 @@ describe('countDebtMarkers', () => {
 
 describe('identifyRisks', () => {
   it('identifies no-test risk', () => {
-    const risks = identifyRisks(tmpDir, ['src/app.ts'], { runtime: 'Node.js', language: 'TypeScript', language_version: null, runtime_version: null, framework: null, framework_version: null, package_manager: 'npm', test_framework: null, database: null });
-    expect(risks.some(r => r.risk.includes('test'))).toBe(true);
+    const risks = identifyRisks(tmpDir, ['src/app.ts'], {
+      runtime: 'Node.js',
+      language: 'TypeScript',
+      language_version: null,
+      runtime_version: null,
+      framework: null,
+      framework_version: null,
+      package_manager: 'npm',
+      test_framework: null,
+      database: null,
+    });
+    expect(risks.some((r) => r.risk.includes('test'))).toBe(true);
   });
 
   it('identifies .env risk', () => {
-    const risks = identifyRisks(tmpDir, ['.env', 'src/app.ts'], { runtime: 'Node.js', language: 'TypeScript', language_version: null, runtime_version: null, framework: null, framework_version: null, package_manager: 'npm', test_framework: null, database: null });
-    expect(risks.some(r => r.risk.includes('.env'))).toBe(true);
+    const risks = identifyRisks(tmpDir, ['.env', 'src/app.ts'], {
+      runtime: 'Node.js',
+      language: 'TypeScript',
+      language_version: null,
+      runtime_version: null,
+      framework: null,
+      framework_version: null,
+      package_manager: 'npm',
+      test_framework: null,
+      database: null,
+    });
+    expect(risks.some((r) => r.risk.includes('.env'))).toBe(true);
   });
 });
 
 describe('scan', () => {
   it('returns full scan result', () => {
-    writeFileSync(join(tmpDir, 'package.json'), JSON.stringify({ devDependencies: { vitest: '^1.0.0' } }));
+    writeFileSync(
+      join(tmpDir, 'package.json'),
+      JSON.stringify({ devDependencies: { vitest: '^1.0.0' } })
+    );
     writeFileSync(join(tmpDir, 'app.test.ts'), 'it("ok", () => {})');
     const r = scan({ root: tmpDir });
     expect(r.scanned_at).toBeTruthy();
@@ -128,7 +153,10 @@ describe('scan', () => {
   });
 
   it('detects test framework from devDeps', () => {
-    writeFileSync(join(tmpDir, 'package.json'), JSON.stringify({ devDependencies: { vitest: '^1.0.0', typescript: '^5.0.0' } }));
+    writeFileSync(
+      join(tmpDir, 'package.json'),
+      JSON.stringify({ devDependencies: { vitest: '^1.0.0', typescript: '^5.0.0' } })
+    );
     const r = scan({ root: tmpDir });
     expect(r.stack.test_framework).toBe('Vitest');
   });

--- a/tests/test-semantic-diff.test.ts
+++ b/tests/test-semantic-diff.test.ts
@@ -1,0 +1,159 @@
+/**
+ * tests/test-semantic-diff.test.ts — Semantic Diff port tests (M11 batch 6).
+ */
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  compareArtifacts,
+  compareFiles,
+  crossArtifactDiff,
+  extractApiEndpoints,
+  extractRequirements,
+  extractSections,
+  extractTableData,
+  normalizeText,
+  textSimilarity,
+} from '../src/lib/semantic-diff.js';
+
+let tmpDir: string;
+beforeEach(() => { tmpDir = join(tmpdir(), `test-sdiff-${Date.now()}`); mkdirSync(tmpDir, { recursive: true }); });
+afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+
+describe('extractSections', () => {
+  it('returns preamble for content without headings', () => {
+    const s = extractSections('just some text');
+    expect(s.length).toBeGreaterThan(0);
+  });
+
+  it('parses headings correctly', () => {
+    const s = extractSections('# H1\ncontent\n## H2\nmore');
+    expect(s.some(sec => sec.heading === 'H1')).toBe(true);
+    expect(s.some(sec => sec.heading === 'H2')).toBe(true);
+  });
+});
+
+describe('extractRequirements', () => {
+  it('extracts REQ ids', () => {
+    const ids = extractRequirements('See REQ-001 and NFR-002');
+    expect(ids).toContain('REQ-001');
+    expect(ids).toContain('NFR-002');
+  });
+
+  it('deduplicates', () => {
+    const ids = extractRequirements('REQ-001 REQ-001');
+    expect(ids.filter(i => i === 'REQ-001').length).toBe(1);
+  });
+
+  it('returns empty for no matches', () => {
+    expect(extractRequirements('no requirements here')).toEqual([]);
+  });
+});
+
+describe('extractApiEndpoints', () => {
+  it('extracts GET endpoints', () => {
+    const endpoints = extractApiEndpoints('GET /api/users\nPOST /api/login');
+    expect(endpoints.length).toBe(2);
+    expect(endpoints[0]?.method).toBe('GET');
+  });
+
+  it('returns empty for no endpoints', () => {
+    expect(extractApiEndpoints('no api here')).toEqual([]);
+  });
+});
+
+describe('extractTableData', () => {
+  it('extracts table rows', () => {
+    const rows = extractTableData('| Col1 | Col2 |\n|------|------|\n| A | B |');
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.some(r => r.includes('A'))).toBe(true);
+  });
+});
+
+describe('normalizeText', () => {
+  it('lowercases and strips punctuation', () => {
+    expect(normalizeText('Hello, World!')).toBe('hello world');
+  });
+
+  it('collapses whitespace', () => {
+    expect(normalizeText('  foo   bar  ')).toBe('foo bar');
+  });
+});
+
+describe('textSimilarity', () => {
+  it('returns 1 for identical texts', () => {
+    expect(textSimilarity('hello world', 'hello world')).toBe(1);
+  });
+
+  it('returns 0 for completely different texts', () => {
+    expect(textSimilarity('abc def ghi', 'xyz uvw rst')).toBe(0);
+  });
+
+  it('returns 1 for both empty', () => {
+    expect(textSimilarity('', '')).toBe(1);
+  });
+
+  it('returns between 0 and 1 for partial overlap', () => {
+    const s = textSimilarity('hello world foo', 'hello world bar');
+    expect(s).toBeGreaterThan(0);
+    expect(s).toBeLessThan(1);
+  });
+});
+
+describe('compareArtifacts', () => {
+  it('returns success for identical content', () => {
+    const r = compareArtifacts('# PRD\n\nContent', '# PRD\n\nContent');
+    expect(r.success).toBe(true);
+    expect(r.overall_similarity).toBe(100);
+    expect(r.has_breaking_changes).toBe(false);
+  });
+
+  it('detects added sections', () => {
+    const r = compareArtifacts('# Sec A\nContent', '# Sec A\nContent\n# Sec B\nNew');
+    expect(r.section_changes.some(c => c.type === 'section_added')).toBe(true);
+  });
+
+  it('detects removed sections', () => {
+    const r = compareArtifacts('# Sec A\nContent\n# Sec B\nOld', '# Sec A\nContent');
+    expect(r.section_changes.some(c => c.type === 'section_removed')).toBe(true);
+  });
+
+  it('detects added requirements', () => {
+    const r = compareArtifacts('# PRD\n\nold', '# PRD\n\nREQ-001 new requirement');
+    expect(r.requirement_changes.added).toContain('REQ-001');
+  });
+
+  it('detects breaking changes when reqs removed', () => {
+    const r = compareArtifacts('# PRD\n\nREQ-001 existing', '# PRD\n\nchanged');
+    expect(r.has_breaking_changes).toBe(true);
+  });
+});
+
+describe('compareFiles', () => {
+  it('returns error for missing file', () => {
+    const r = compareFiles(join(tmpDir, 'a.md'), join(tmpDir, 'b.md'));
+    expect(r.success).toBe(false);
+  });
+
+  it('compares real files', () => {
+    writeFileSync(join(tmpDir, 'a.md'), '# Doc\n\nContent A');
+    writeFileSync(join(tmpDir, 'b.md'), '# Doc\n\nContent B');
+    const r = compareFiles(join(tmpDir, 'a.md'), join(tmpDir, 'b.md'));
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('crossArtifactDiff', () => {
+  it('returns error when specs dir missing', () => {
+    const r = crossArtifactDiff(tmpDir);
+    expect(r.success).toBe(false);
+  });
+
+  it('returns success with specs dir', () => {
+    mkdirSync(join(tmpDir, 'specs'));
+    writeFileSync(join(tmpDir, 'specs', 'prd.md'), '# PRD\n\nREQ-001');
+    const r = crossArtifactDiff(tmpDir);
+    expect(r.success).toBe(true);
+  });
+});

--- a/tests/test-semantic-diff.test.ts
+++ b/tests/test-semantic-diff.test.ts
@@ -18,8 +18,13 @@ import {
 } from '../src/lib/semantic-diff.js';
 
 let tmpDir: string;
-beforeEach(() => { tmpDir = join(tmpdir(), `test-sdiff-${Date.now()}`); mkdirSync(tmpDir, { recursive: true }); });
-afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+beforeEach(() => {
+  tmpDir = join(tmpdir(), `test-sdiff-${Date.now()}`);
+  mkdirSync(tmpDir, { recursive: true });
+});
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
 
 describe('extractSections', () => {
   it('returns preamble for content without headings', () => {
@@ -29,8 +34,8 @@ describe('extractSections', () => {
 
   it('parses headings correctly', () => {
     const s = extractSections('# H1\ncontent\n## H2\nmore');
-    expect(s.some(sec => sec.heading === 'H1')).toBe(true);
-    expect(s.some(sec => sec.heading === 'H2')).toBe(true);
+    expect(s.some((sec) => sec.heading === 'H1')).toBe(true);
+    expect(s.some((sec) => sec.heading === 'H2')).toBe(true);
   });
 });
 
@@ -43,7 +48,7 @@ describe('extractRequirements', () => {
 
   it('deduplicates', () => {
     const ids = extractRequirements('REQ-001 REQ-001');
-    expect(ids.filter(i => i === 'REQ-001').length).toBe(1);
+    expect(ids.filter((i) => i === 'REQ-001').length).toBe(1);
   });
 
   it('returns empty for no matches', () => {
@@ -67,7 +72,7 @@ describe('extractTableData', () => {
   it('extracts table rows', () => {
     const rows = extractTableData('| Col1 | Col2 |\n|------|------|\n| A | B |');
     expect(rows.length).toBeGreaterThan(0);
-    expect(rows.some(r => r.includes('A'))).toBe(true);
+    expect(rows.some((r) => r.includes('A'))).toBe(true);
   });
 });
 
@@ -111,12 +116,12 @@ describe('compareArtifacts', () => {
 
   it('detects added sections', () => {
     const r = compareArtifacts('# Sec A\nContent', '# Sec A\nContent\n# Sec B\nNew');
-    expect(r.section_changes.some(c => c.type === 'section_added')).toBe(true);
+    expect(r.section_changes.some((c) => c.type === 'section_added')).toBe(true);
   });
 
   it('detects removed sections', () => {
     const r = compareArtifacts('# Sec A\nContent\n# Sec B\nOld', '# Sec A\nContent');
-    expect(r.section_changes.some(c => c.type === 'section_removed')).toBe(true);
+    expect(r.section_changes.some((c) => c.type === 'section_removed')).toBe(true);
   });
 
   it('detects added requirements', () => {

--- a/tests/test-sla-slo.test.ts
+++ b/tests/test-sla-slo.test.ts
@@ -6,20 +6,25 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
-  DEFAULT_SLO_TEMPLATES,
-  SLO_TYPES,
   applyTemplate,
   checkSLOCoverage,
+  DEFAULT_SLO_TEMPLATES,
   defaultState,
   defineSLO,
   generateReport,
   loadState,
+  SLO_TYPES,
   saveState,
 } from '../src/lib/sla-slo.js';
 
 let tmpDir: string;
-beforeEach(() => { tmpDir = join(tmpdir(), `test-sla-${Date.now()}`); mkdirSync(tmpDir, { recursive: true }); });
-afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+beforeEach(() => {
+  tmpDir = join(tmpdir(), `test-sla-${Date.now()}`);
+  mkdirSync(tmpDir, { recursive: true });
+});
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
 
 describe('defaultState', () => {
   it('returns empty SLOs/SLAs', () => {
@@ -45,14 +50,20 @@ describe('loadState', () => {
   // Pollution key tests
   it('rejects __proto__ key in JSON', () => {
     const f = join(tmpDir, 'polluted.json');
-    writeFileSync(f, '{"__proto__":{"x":1},"version":"1.0.0","created_at":"2024-01-01T00:00:00.000Z","last_updated":null,"slos":[],"slas":[],"error_budgets":[]}');
+    writeFileSync(
+      f,
+      '{"__proto__":{"x":1},"version":"1.0.0","created_at":"2024-01-01T00:00:00.000Z","last_updated":null,"slos":[],"slas":[],"error_budgets":[]}'
+    );
     const s = loadState(f);
     expect(s.slos).toEqual([]);
   });
 
   it('rejects constructor key in JSON', () => {
     const f = join(tmpDir, 'polluted2.json');
-    writeFileSync(f, '{"constructor":{},"version":"1.0.0","created_at":"2024-01-01T00:00:00.000Z","last_updated":null,"slos":[],"slas":[],"error_budgets":[]}');
+    writeFileSync(
+      f,
+      '{"constructor":{},"version":"1.0.0","created_at":"2024-01-01T00:00:00.000Z","last_updated":null,"slos":[],"slas":[],"error_budgets":[]}'
+    );
     const s = loadState(f);
     expect(s.slos).toEqual([]);
   });
@@ -78,14 +89,20 @@ describe('defineSLO', () => {
 
   it('rejects invalid type', () => {
     const f = join(tmpDir, 'state.json');
-    const r = defineSLO({ name: 'SLO', service: 'api', target: 99, type: 'invalid' }, { stateFile: f });
+    const r = defineSLO(
+      { name: 'SLO', service: 'api', target: 99, type: 'invalid' },
+      { stateFile: f }
+    );
     expect(r.success).toBe(false);
     expect(r.error).toMatch(/Invalid type/);
   });
 
   it('creates SLO with valid inputs', () => {
     const f = join(tmpDir, 'state.json');
-    const r = defineSLO({ name: 'API Availability', service: 'api', target: 99.9, type: 'availability' }, { stateFile: f });
+    const r = defineSLO(
+      { name: 'API Availability', service: 'api', target: 99.9, type: 'availability' },
+      { stateFile: f }
+    );
     expect(r.success).toBe(true);
     expect(r.slo?.id).toMatch(/^SLO-/);
   });
@@ -109,7 +126,7 @@ describe('applyTemplate', () => {
     const f = join(tmpDir, 'state.json');
     const r = applyTemplate('my-api', 'web-api', { stateFile: f });
     expect(r.success).toBe(true);
-    expect((r.slos_created ?? 0)).toBeGreaterThan(0);
+    expect(r.slos_created ?? 0).toBeGreaterThan(0);
   });
 });
 
@@ -141,6 +158,6 @@ describe('SLO_TYPES', () => {
 describe('DEFAULT_SLO_TEMPLATES', () => {
   it('has web-api template', () => {
     expect(DEFAULT_SLO_TEMPLATES['web-api']).toBeTruthy();
-    expect(DEFAULT_SLO_TEMPLATES['web-api']!.length).toBeGreaterThan(0);
+    expect(DEFAULT_SLO_TEMPLATES['web-api']?.length).toBeGreaterThan(0);
   });
 });

--- a/tests/test-sla-slo.test.ts
+++ b/tests/test-sla-slo.test.ts
@@ -1,0 +1,146 @@
+/**
+ * tests/test-sla-slo.test.ts — SLA/SLO port tests (M11 batch 6).
+ */
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  DEFAULT_SLO_TEMPLATES,
+  SLO_TYPES,
+  applyTemplate,
+  checkSLOCoverage,
+  defaultState,
+  defineSLO,
+  generateReport,
+  loadState,
+  saveState,
+} from '../src/lib/sla-slo.js';
+
+let tmpDir: string;
+beforeEach(() => { tmpDir = join(tmpdir(), `test-sla-${Date.now()}`); mkdirSync(tmpDir, { recursive: true }); });
+afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+
+describe('defaultState', () => {
+  it('returns empty SLOs/SLAs', () => {
+    const s = defaultState();
+    expect(s.slos).toEqual([]);
+    expect(s.slas).toEqual([]);
+  });
+});
+
+describe('loadState', () => {
+  it('returns defaultState for missing file', () => {
+    const s = loadState(join(tmpDir, 'missing.json'));
+    expect(s.slos).toEqual([]);
+  });
+
+  it('returns defaultState for invalid JSON', () => {
+    const f = join(tmpDir, 'bad.json');
+    writeFileSync(f, 'not json');
+    const s = loadState(f);
+    expect(s.slos).toEqual([]);
+  });
+
+  // Pollution key tests
+  it('rejects __proto__ key in JSON', () => {
+    const f = join(tmpDir, 'polluted.json');
+    writeFileSync(f, '{"__proto__":{"x":1},"version":"1.0.0","created_at":"2024-01-01T00:00:00.000Z","last_updated":null,"slos":[],"slas":[],"error_budgets":[]}');
+    const s = loadState(f);
+    expect(s.slos).toEqual([]);
+  });
+
+  it('rejects constructor key in JSON', () => {
+    const f = join(tmpDir, 'polluted2.json');
+    writeFileSync(f, '{"constructor":{},"version":"1.0.0","created_at":"2024-01-01T00:00:00.000Z","last_updated":null,"slos":[],"slas":[],"error_budgets":[]}');
+    const s = loadState(f);
+    expect(s.slos).toEqual([]);
+  });
+});
+
+describe('saveState / loadState round-trip', () => {
+  it('saves and loads', () => {
+    const f = join(tmpDir, 'state.json');
+    const s = defaultState();
+    saveState(s, f);
+    const loaded = loadState(f);
+    expect(loaded.version).toBe('1.0.0');
+    expect(loaded.last_updated).toBeTruthy();
+  });
+});
+
+describe('defineSLO', () => {
+  it('requires name, service, target', () => {
+    const f = join(tmpDir, 'state.json');
+    const r = defineSLO({ name: '', service: 'api', target: 99 }, { stateFile: f });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects invalid type', () => {
+    const f = join(tmpDir, 'state.json');
+    const r = defineSLO({ name: 'SLO', service: 'api', target: 99, type: 'invalid' }, { stateFile: f });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/Invalid type/);
+  });
+
+  it('creates SLO with valid inputs', () => {
+    const f = join(tmpDir, 'state.json');
+    const r = defineSLO({ name: 'API Availability', service: 'api', target: 99.9, type: 'availability' }, { stateFile: f });
+    expect(r.success).toBe(true);
+    expect(r.slo?.id).toMatch(/^SLO-/);
+  });
+
+  it('persists to state file', () => {
+    const f = join(tmpDir, 'state.json');
+    defineSLO({ name: 'SLO1', service: 'svc', target: 99 }, { stateFile: f });
+    const state = loadState(f);
+    expect(state.slos.length).toBe(1);
+  });
+});
+
+describe('applyTemplate', () => {
+  it('rejects unknown template', () => {
+    const f = join(tmpDir, 'state.json');
+    const r = applyTemplate('my-svc', 'unknown-template', { stateFile: f });
+    expect(r.success).toBe(false);
+  });
+
+  it('creates SLOs from web-api template', () => {
+    const f = join(tmpDir, 'state.json');
+    const r = applyTemplate('my-api', 'web-api', { stateFile: f });
+    expect(r.success).toBe(true);
+    expect((r.slos_created ?? 0)).toBeGreaterThan(0);
+  });
+});
+
+describe('checkSLOCoverage', () => {
+  it('returns coverage=missing when no SLOs defined', () => {
+    const r = checkSLOCoverage(tmpDir);
+    expect(r.success).toBe(true);
+    expect(r.coverage).toBe('missing');
+    expect(r.recommendations.length).toBeGreaterThan(0);
+  });
+});
+
+describe('generateReport', () => {
+  it('returns empty report for empty state', () => {
+    const f = join(tmpDir, 'state.json');
+    const r = generateReport({ stateFile: f });
+    expect(r.total_slos).toBe(0);
+    expect(r.by_service).toEqual({});
+  });
+});
+
+describe('SLO_TYPES', () => {
+  it('includes availability and latency', () => {
+    expect(SLO_TYPES).toContain('availability');
+    expect(SLO_TYPES).toContain('latency');
+  });
+});
+
+describe('DEFAULT_SLO_TEMPLATES', () => {
+  it('has web-api template', () => {
+    expect(DEFAULT_SLO_TEMPLATES['web-api']).toBeTruthy();
+    expect(DEFAULT_SLO_TEMPLATES['web-api']!.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/test-spec-comments.test.ts
+++ b/tests/test-spec-comments.test.ts
@@ -1,0 +1,153 @@
+/**
+ * tests/test-spec-comments.test.ts — Spec Comments port tests (M11 batch 6).
+ */
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  COMMENT_STATUSES,
+  addComment,
+  assignComment,
+  defaultState,
+  listComments,
+  loadState,
+  resolveComment,
+  saveState,
+} from '../src/lib/spec-comments.js';
+
+let tmpDir: string;
+beforeEach(() => { tmpDir = join(tmpdir(), `test-speccomm-${Date.now()}`); mkdirSync(tmpDir, { recursive: true }); });
+afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+
+describe('defaultState', () => {
+  it('returns empty comments array', () => {
+    const s = defaultState();
+    expect(s.comments).toEqual([]);
+  });
+});
+
+describe('loadState', () => {
+  it('returns defaultState for missing file', () => {
+    const s = loadState(join(tmpDir, 'missing.json'));
+    expect(s.comments).toEqual([]);
+  });
+
+  it('returns defaultState for invalid JSON', () => {
+    const f = join(tmpDir, 'bad.json');
+    writeFileSync(f, '{{}}');
+    const s = loadState(f);
+    expect(s.comments).toEqual([]);
+  });
+
+  it('rejects __proto__ pollution key', () => {
+    const f = join(tmpDir, 'polluted.json');
+    writeFileSync(f, '{"__proto__":{"evil":true},"version":"1.0.0","created_at":"2024-01-01T00:00:00.000Z","last_updated":null,"comments":[]}');
+    const s = loadState(f);
+    expect(s.comments).toEqual([]);
+  });
+
+  it('rejects prototype pollution key', () => {
+    const f = join(tmpDir, 'polluted2.json');
+    writeFileSync(f, '{"prototype":{},"version":"1.0.0","created_at":"2024-01-01T00:00:00.000Z","last_updated":null,"comments":[]}');
+    const s = loadState(f);
+    expect(s.comments).toEqual([]);
+  });
+});
+
+describe('addComment', () => {
+  it('requires artifact and text', () => {
+    const f = join(tmpDir, 's.json');
+    const r = addComment('', null, '', { stateFile: f });
+    expect(r.success).toBe(false);
+  });
+
+  it('creates a comment', () => {
+    const f = join(tmpDir, 's.json');
+    const r = addComment('specs/prd.md', 'Section 1', 'Review needed', { stateFile: f });
+    expect(r.success).toBe(true);
+    expect(r.comment?.id).toMatch(/^C-/);
+    expect(r.comment?.status).toBe('open');
+  });
+
+  it('persists to state', () => {
+    const f = join(tmpDir, 's.json');
+    addComment('prd.md', null, 'First comment', { stateFile: f });
+    const s = loadState(f);
+    expect(s.comments.length).toBe(1);
+  });
+});
+
+describe('resolveComment', () => {
+  it('requires commentId', () => {
+    const f = join(tmpDir, 's.json');
+    const r = resolveComment('', undefined, { stateFile: f });
+    expect(r.success).toBe(false);
+  });
+
+  it('returns error for nonexistent comment', () => {
+    const f = join(tmpDir, 's.json');
+    const r = resolveComment('C-999', undefined, { stateFile: f });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/not found/);
+  });
+
+  it('resolves an existing comment', () => {
+    const f = join(tmpDir, 's.json');
+    const added = addComment('prd.md', null, 'Fix this', { stateFile: f });
+    const id = added.comment!.id;
+    const resolved = resolveComment(id, 'Fixed it', { stateFile: f });
+    expect(resolved.success).toBe(true);
+    expect(resolved.comment?.status).toBe('resolved');
+    expect(resolved.comment?.resolution).toBe('Fixed it');
+  });
+});
+
+describe('listComments', () => {
+  it('returns all comments when no filter', () => {
+    const f = join(tmpDir, 's.json');
+    addComment('a.md', null, 'c1', { stateFile: f });
+    addComment('b.md', null, 'c2', { stateFile: f });
+    const r = listComments({ stateFile: f });
+    expect(r.total).toBe(2);
+  });
+
+  it('filters by artifact', () => {
+    const f = join(tmpDir, 's.json');
+    addComment('a.md', null, 'c1', { stateFile: f });
+    addComment('b.md', null, 'c2', { stateFile: f });
+    const r = listComments({ stateFile: f, artifact: 'a.md' });
+    expect(r.total).toBe(1);
+  });
+
+  it('filters by status', () => {
+    const f = join(tmpDir, 's.json');
+    const added = addComment('a.md', null, 'c1', { stateFile: f });
+    resolveComment(added.comment!.id, 'done', { stateFile: f });
+    const r = listComments({ stateFile: f, status: 'resolved' });
+    expect(r.total).toBe(1);
+  });
+});
+
+describe('assignComment', () => {
+  it('requires commentId and assignee', () => {
+    const f = join(tmpDir, 's.json');
+    const r = assignComment('', '', { stateFile: f });
+    expect(r.success).toBe(false);
+  });
+
+  it('assigns comment to reviewer', () => {
+    const f = join(tmpDir, 's.json');
+    const added = addComment('prd.md', null, 'review needed', { stateFile: f });
+    const r = assignComment(added.comment!.id, 'alice', { stateFile: f });
+    expect(r.success).toBe(true);
+    expect(r.comment?.assignee).toBe('alice');
+  });
+});
+
+describe('COMMENT_STATUSES', () => {
+  it('includes open and resolved', () => {
+    expect(COMMENT_STATUSES).toContain('open');
+    expect(COMMENT_STATUSES).toContain('resolved');
+  });
+});

--- a/tests/test-spec-comments.test.ts
+++ b/tests/test-spec-comments.test.ts
@@ -6,19 +6,23 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
-  COMMENT_STATUSES,
   addComment,
   assignComment,
+  COMMENT_STATUSES,
   defaultState,
   listComments,
   loadState,
   resolveComment,
-  saveState,
 } from '../src/lib/spec-comments.js';
 
 let tmpDir: string;
-beforeEach(() => { tmpDir = join(tmpdir(), `test-speccomm-${Date.now()}`); mkdirSync(tmpDir, { recursive: true }); });
-afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+beforeEach(() => {
+  tmpDir = join(tmpdir(), `test-speccomm-${Date.now()}`);
+  mkdirSync(tmpDir, { recursive: true });
+});
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
 
 describe('defaultState', () => {
   it('returns empty comments array', () => {
@@ -42,14 +46,20 @@ describe('loadState', () => {
 
   it('rejects __proto__ pollution key', () => {
     const f = join(tmpDir, 'polluted.json');
-    writeFileSync(f, '{"__proto__":{"evil":true},"version":"1.0.0","created_at":"2024-01-01T00:00:00.000Z","last_updated":null,"comments":[]}');
+    writeFileSync(
+      f,
+      '{"__proto__":{"evil":true},"version":"1.0.0","created_at":"2024-01-01T00:00:00.000Z","last_updated":null,"comments":[]}'
+    );
     const s = loadState(f);
     expect(s.comments).toEqual([]);
   });
 
   it('rejects prototype pollution key', () => {
     const f = join(tmpDir, 'polluted2.json');
-    writeFileSync(f, '{"prototype":{},"version":"1.0.0","created_at":"2024-01-01T00:00:00.000Z","last_updated":null,"comments":[]}');
+    writeFileSync(
+      f,
+      '{"prototype":{},"version":"1.0.0","created_at":"2024-01-01T00:00:00.000Z","last_updated":null,"comments":[]}'
+    );
     const s = loadState(f);
     expect(s.comments).toEqual([]);
   });
@@ -95,7 +105,7 @@ describe('resolveComment', () => {
   it('resolves an existing comment', () => {
     const f = join(tmpDir, 's.json');
     const added = addComment('prd.md', null, 'Fix this', { stateFile: f });
-    const id = added.comment!.id;
+    const id = added.comment?.id ?? '';
     const resolved = resolveComment(id, 'Fixed it', { stateFile: f });
     expect(resolved.success).toBe(true);
     expect(resolved.comment?.status).toBe('resolved');
@@ -123,7 +133,7 @@ describe('listComments', () => {
   it('filters by status', () => {
     const f = join(tmpDir, 's.json');
     const added = addComment('a.md', null, 'c1', { stateFile: f });
-    resolveComment(added.comment!.id, 'done', { stateFile: f });
+    resolveComment(added.comment?.id ?? '', 'done', { stateFile: f });
     const r = listComments({ stateFile: f, status: 'resolved' });
     expect(r.total).toBe(1);
   });
@@ -139,7 +149,7 @@ describe('assignComment', () => {
   it('assigns comment to reviewer', () => {
     const f = join(tmpDir, 's.json');
     const added = addComment('prd.md', null, 'review needed', { stateFile: f });
-    const r = assignComment(added.comment!.id, 'alice', { stateFile: f });
+    const r = assignComment(added.comment?.id ?? '', 'alice', { stateFile: f });
     expect(r.success).toBe(true);
     expect(r.comment?.assignee).toBe('alice');
   });

--- a/tests/test-spec-maturity.test.ts
+++ b/tests/test-spec-maturity.test.ts
@@ -1,0 +1,163 @@
+/**
+ * tests/test-spec-maturity.test.ts — Spec Maturity port tests (M11 batch 6).
+ */
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  MATURITY_CRITERIA,
+  MATURITY_LEVELS,
+  assessFile,
+  assessMaturity,
+  assessProject,
+  runMaturityChecks,
+} from '../src/lib/spec-maturity.js';
+
+let tmpDir: string;
+beforeEach(() => { tmpDir = join(tmpdir(), `test-maturity-${Date.now()}`); mkdirSync(tmpDir, { recursive: true }); });
+afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+
+describe('MATURITY_LEVELS', () => {
+  it('has 5 levels from Draft to Production-Ready', () => {
+    expect(MATURITY_LEVELS.length).toBe(5);
+    expect(MATURITY_LEVELS[0]?.name).toBe('Draft');
+    expect(MATURITY_LEVELS[4]?.name).toBe('Production-Ready');
+  });
+});
+
+describe('MATURITY_CRITERIA', () => {
+  it('has required categories', () => {
+    expect(MATURITY_CRITERIA['structure']).toBeTruthy();
+    expect(MATURITY_CRITERIA['completeness']).toBeTruthy();
+    expect(MATURITY_CRITERIA['governance']).toBeTruthy();
+  });
+});
+
+describe('runMaturityChecks', () => {
+  it('detects frontmatter', () => {
+    const r = runMaturityChecks('---\ntitle: test\n---\n# Heading');
+    expect(r['has_frontmatter']).toBe(true);
+  });
+
+  it('no_placeholders true for clean content', () => {
+    const r = runMaturityChecks('# Clean\n\nNo placeholders here');
+    expect(r['no_placeholders']).toBe(true);
+  });
+
+  it('no_placeholders false when TODO present', () => {
+    const r = runMaturityChecks('# Doc\n\n[TODO] fix this');
+    expect(r['no_placeholders']).toBe(false);
+  });
+
+  it('has_requirement_ids detects REQ pattern', () => {
+    const r = runMaturityChecks('See REQ-001 for details');
+    expect(r['has_requirement_ids']).toBe(true);
+  });
+
+  it('has_approval detects Phase Gate Approval', () => {
+    const r = runMaturityChecks('## Phase Gate Approval\n- [x] done\nApproved by: Alice');
+    expect(r['has_approval']).toBe(true);
+    expect(r['is_approved']).toBe(true);
+  });
+
+  it('sufficient_length true for long content', () => {
+    const r = runMaturityChecks('x'.repeat(1100));
+    expect(r['sufficient_length']).toBe(true);
+  });
+
+  it('has_security detects security keyword', () => {
+    const r = runMaturityChecks('Security considerations include auth');
+    expect(r['has_security']).toBe(true);
+  });
+});
+
+describe('assessMaturity', () => {
+  it('returns success', () => {
+    const r = assessMaturity('# Simple doc\n\nContent');
+    expect(r.success).toBe(true);
+  });
+
+  it('overall_score between 0 and 100', () => {
+    const r = assessMaturity('# Simple\n\nContent');
+    expect((r.overall_score ?? 0)).toBeGreaterThanOrEqual(0);
+    expect((r.overall_score ?? 0)).toBeLessThanOrEqual(100);
+  });
+
+  it('higher score for richer content', () => {
+    const minimal = assessMaturity('hello');
+    const rich = assessMaturity(`---
+title: test
+---
+# Section A
+## Section B
+### Section C
+
+See REQ-001 and NFR-001.
+
+Acceptance criteria: done.
+
+\`\`\`typescript
+const x = 1;
+\`\`\`
+
+Security considerations: use auth.
+Compliance: GDPR applies.
+
+2024-01-01
+
+## Phase Gate Approval
+- [x] done
+Approved by: Alice
+
+Version: 1.0
+
+[See prd](specs/prd.md)
+`.repeat(5));
+    expect((rich.overall_score ?? 0)).toBeGreaterThan((minimal.overall_score ?? 0));
+  });
+
+  it('includes gaps array', () => {
+    const r = assessMaturity('hello');
+    expect(Array.isArray(r.gaps)).toBe(true);
+  });
+
+  it('next_level is null when at max score', () => {
+    // A document unlikely to be at max, so just check the type
+    const r = assessMaturity('minimal');
+    // next_level should be either an object or null (not undefined structurally)
+    expect(r.next_level !== undefined).toBe(true);
+  });
+});
+
+describe('assessFile', () => {
+  it('returns error for missing file', () => {
+    const r = assessFile(join(tmpDir, 'missing.md'));
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/File not found/);
+  });
+
+  it('assesses an actual file', () => {
+    const f = join(tmpDir, 'spec.md');
+    writeFileSync(f, '# My Spec\n\nSome content\n\nREQ-001 requirement');
+    const r = assessFile(f);
+    expect(r.success).toBe(true);
+    expect(r.file).toBe(f);
+  });
+});
+
+describe('assessProject', () => {
+  it('returns error when specs dir missing', () => {
+    const r = assessProject(tmpDir);
+    expect(r.success).toBe(false);
+  });
+
+  it('assesses with existing artifacts', () => {
+    const specsDir = join(tmpDir, 'specs');
+    mkdirSync(specsDir);
+    writeFileSync(join(specsDir, 'prd.md'), '# PRD\n\nContent\n\nREQ-001');
+    const r = assessProject(tmpDir);
+    expect(r.success).toBe(true);
+    expect((r.artifacts ?? []).length).toBeGreaterThan(0);
+  });
+});

--- a/tests/test-spec-maturity.test.ts
+++ b/tests/test-spec-maturity.test.ts
@@ -6,17 +6,22 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
-  MATURITY_CRITERIA,
-  MATURITY_LEVELS,
   assessFile,
   assessMaturity,
   assessProject,
+  MATURITY_CRITERIA,
+  MATURITY_LEVELS,
   runMaturityChecks,
 } from '../src/lib/spec-maturity.js';
 
 let tmpDir: string;
-beforeEach(() => { tmpDir = join(tmpdir(), `test-maturity-${Date.now()}`); mkdirSync(tmpDir, { recursive: true }); });
-afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+beforeEach(() => {
+  tmpDir = join(tmpdir(), `test-maturity-${Date.now()}`);
+  mkdirSync(tmpDir, { recursive: true });
+});
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
 
 describe('MATURITY_LEVELS', () => {
   it('has 5 levels from Draft to Production-Ready', () => {
@@ -28,47 +33,47 @@ describe('MATURITY_LEVELS', () => {
 
 describe('MATURITY_CRITERIA', () => {
   it('has required categories', () => {
-    expect(MATURITY_CRITERIA['structure']).toBeTruthy();
-    expect(MATURITY_CRITERIA['completeness']).toBeTruthy();
-    expect(MATURITY_CRITERIA['governance']).toBeTruthy();
+    expect(MATURITY_CRITERIA.structure).toBeTruthy();
+    expect(MATURITY_CRITERIA.completeness).toBeTruthy();
+    expect(MATURITY_CRITERIA.governance).toBeTruthy();
   });
 });
 
 describe('runMaturityChecks', () => {
   it('detects frontmatter', () => {
     const r = runMaturityChecks('---\ntitle: test\n---\n# Heading');
-    expect(r['has_frontmatter']).toBe(true);
+    expect(r.has_frontmatter).toBe(true);
   });
 
   it('no_placeholders true for clean content', () => {
     const r = runMaturityChecks('# Clean\n\nNo placeholders here');
-    expect(r['no_placeholders']).toBe(true);
+    expect(r.no_placeholders).toBe(true);
   });
 
   it('no_placeholders false when TODO present', () => {
     const r = runMaturityChecks('# Doc\n\n[TODO] fix this');
-    expect(r['no_placeholders']).toBe(false);
+    expect(r.no_placeholders).toBe(false);
   });
 
   it('has_requirement_ids detects REQ pattern', () => {
     const r = runMaturityChecks('See REQ-001 for details');
-    expect(r['has_requirement_ids']).toBe(true);
+    expect(r.has_requirement_ids).toBe(true);
   });
 
   it('has_approval detects Phase Gate Approval', () => {
     const r = runMaturityChecks('## Phase Gate Approval\n- [x] done\nApproved by: Alice');
-    expect(r['has_approval']).toBe(true);
-    expect(r['is_approved']).toBe(true);
+    expect(r.has_approval).toBe(true);
+    expect(r.is_approved).toBe(true);
   });
 
   it('sufficient_length true for long content', () => {
     const r = runMaturityChecks('x'.repeat(1100));
-    expect(r['sufficient_length']).toBe(true);
+    expect(r.sufficient_length).toBe(true);
   });
 
   it('has_security detects security keyword', () => {
     const r = runMaturityChecks('Security considerations include auth');
-    expect(r['has_security']).toBe(true);
+    expect(r.has_security).toBe(true);
   });
 });
 
@@ -80,13 +85,14 @@ describe('assessMaturity', () => {
 
   it('overall_score between 0 and 100', () => {
     const r = assessMaturity('# Simple\n\nContent');
-    expect((r.overall_score ?? 0)).toBeGreaterThanOrEqual(0);
-    expect((r.overall_score ?? 0)).toBeLessThanOrEqual(100);
+    expect(r.overall_score ?? 0).toBeGreaterThanOrEqual(0);
+    expect(r.overall_score ?? 0).toBeLessThanOrEqual(100);
   });
 
   it('higher score for richer content', () => {
     const minimal = assessMaturity('hello');
-    const rich = assessMaturity(`---
+    const rich = assessMaturity(
+      `---
 title: test
 ---
 # Section A
@@ -113,8 +119,9 @@ Approved by: Alice
 Version: 1.0
 
 [See prd](specs/prd.md)
-`.repeat(5));
-    expect((rich.overall_score ?? 0)).toBeGreaterThan((minimal.overall_score ?? 0));
+`.repeat(5)
+    );
+    expect(rich.overall_score ?? 0).toBeGreaterThan(minimal.overall_score ?? 0);
   });
 
   it('includes gaps array', () => {

--- a/tests/test-sre-integration.test.ts
+++ b/tests/test-sre-integration.test.ts
@@ -7,7 +7,6 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   ALERT_SEVERITIES,
-  MONITOR_TYPES,
   configureErrorBudget,
   defaultState,
   generateAlert,
@@ -15,12 +14,17 @@ import {
   generateReport,
   generateRunbook,
   loadState,
-  saveState,
+  MONITOR_TYPES,
 } from '../src/lib/sre-integration.js';
 
 let tmpDir: string;
-beforeEach(() => { tmpDir = join(tmpdir(), `test-sre-${Date.now()}`); mkdirSync(tmpDir, { recursive: true }); });
-afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+beforeEach(() => {
+  tmpDir = join(tmpdir(), `test-sre-${Date.now()}`);
+  mkdirSync(tmpDir, { recursive: true });
+});
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
 
 describe('defaultState', () => {
   it('returns empty state', () => {
@@ -40,14 +44,20 @@ describe('loadState', () => {
 
   it('rejects __proto__ pollution key', () => {
     const f = join(tmpDir, 'polluted.json');
-    writeFileSync(f, '{"__proto__":{"x":1},"version":"1.0.0","monitors":[],"alerts":[],"runbooks":[],"error_budgets":[],"last_updated":null}');
+    writeFileSync(
+      f,
+      '{"__proto__":{"x":1},"version":"1.0.0","monitors":[],"alerts":[],"runbooks":[],"error_budgets":[],"last_updated":null}'
+    );
     const s = loadState(f);
     expect(s.monitors).toEqual([]);
   });
 
   it('rejects constructor pollution key', () => {
     const f = join(tmpDir, 'polluted2.json');
-    writeFileSync(f, '{"constructor":{},"version":"1.0.0","monitors":[],"alerts":[],"runbooks":[],"error_budgets":[],"last_updated":null}');
+    writeFileSync(
+      f,
+      '{"constructor":{},"version":"1.0.0","monitors":[],"alerts":[],"runbooks":[],"error_budgets":[],"last_updated":null}'
+    );
     const s = loadState(f);
     expect(s.monitors).toEqual([]);
   });
@@ -95,7 +105,9 @@ describe('generateRunbook', () => {
 
   it('creates runbook with steps', () => {
     const f = join(tmpDir, 's.json');
-    const r = generateRunbook('Restart Service', ['Stop the pod', 'Scale down', 'Scale up'], { stateFile: f });
+    const r = generateRunbook('Restart Service', ['Stop the pod', 'Scale down', 'Scale up'], {
+      stateFile: f,
+    });
     expect(r.success).toBe(true);
     expect(r.runbook?.steps.length).toBe(3);
   });
@@ -103,7 +115,9 @@ describe('generateRunbook', () => {
 
 describe('configureErrorBudget', () => {
   it('requires service and slo', () => {
-    const r = configureErrorBudget('', undefined as unknown as number, { stateFile: join(tmpDir, 's.json') });
+    const r = configureErrorBudget('', undefined as unknown as number, {
+      stateFile: join(tmpDir, 's.json'),
+    });
     expect(r.success).toBe(false);
   });
 

--- a/tests/test-sre-integration.test.ts
+++ b/tests/test-sre-integration.test.ts
@@ -1,0 +1,131 @@
+/**
+ * tests/test-sre-integration.test.ts — SRE Integration port tests (M11 batch 6).
+ */
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  ALERT_SEVERITIES,
+  MONITOR_TYPES,
+  configureErrorBudget,
+  defaultState,
+  generateAlert,
+  generateMonitor,
+  generateReport,
+  generateRunbook,
+  loadState,
+  saveState,
+} from '../src/lib/sre-integration.js';
+
+let tmpDir: string;
+beforeEach(() => { tmpDir = join(tmpdir(), `test-sre-${Date.now()}`); mkdirSync(tmpDir, { recursive: true }); });
+afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+
+describe('defaultState', () => {
+  it('returns empty state', () => {
+    const s = defaultState();
+    expect(s.monitors).toEqual([]);
+    expect(s.alerts).toEqual([]);
+    expect(s.runbooks).toEqual([]);
+    expect(s.error_budgets).toEqual([]);
+  });
+});
+
+describe('loadState', () => {
+  it('returns defaultState for missing file', () => {
+    const s = loadState(join(tmpDir, 'missing.json'));
+    expect(s.monitors).toEqual([]);
+  });
+
+  it('rejects __proto__ pollution key', () => {
+    const f = join(tmpDir, 'polluted.json');
+    writeFileSync(f, '{"__proto__":{"x":1},"version":"1.0.0","monitors":[],"alerts":[],"runbooks":[],"error_budgets":[],"last_updated":null}');
+    const s = loadState(f);
+    expect(s.monitors).toEqual([]);
+  });
+
+  it('rejects constructor pollution key', () => {
+    const f = join(tmpDir, 'polluted2.json');
+    writeFileSync(f, '{"constructor":{},"version":"1.0.0","monitors":[],"alerts":[],"runbooks":[],"error_budgets":[],"last_updated":null}');
+    const s = loadState(f);
+    expect(s.monitors).toEqual([]);
+  });
+});
+
+describe('generateMonitor', () => {
+  it('requires name and type', () => {
+    const r = generateMonitor('', 'uptime', { stateFile: join(tmpDir, 's.json') });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects unknown type', () => {
+    const r = generateMonitor('My Monitor', 'badtype', { stateFile: join(tmpDir, 's.json') });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/Unknown type/);
+  });
+
+  it('creates monitor with valid inputs', () => {
+    const f = join(tmpDir, 's.json');
+    const r = generateMonitor('API uptime', 'uptime', { stateFile: f });
+    expect(r.success).toBe(true);
+    expect(r.monitor?.id).toMatch(/^MON-/);
+  });
+});
+
+describe('generateAlert', () => {
+  it('rejects unknown severity', () => {
+    const r = generateAlert('Alert', 'unknown', { stateFile: join(tmpDir, 's.json') });
+    expect(r.success).toBe(false);
+  });
+
+  it('creates alert with critical severity', () => {
+    const f = join(tmpDir, 's.json');
+    const r = generateAlert('CPU Alert', 'critical', { stateFile: f });
+    expect(r.success).toBe(true);
+    expect(r.alert?.id).toMatch(/^ALERT-/);
+  });
+});
+
+describe('generateRunbook', () => {
+  it('requires name and steps', () => {
+    const r = generateRunbook('', null, { stateFile: join(tmpDir, 's.json') });
+    expect(r.success).toBe(false);
+  });
+
+  it('creates runbook with steps', () => {
+    const f = join(tmpDir, 's.json');
+    const r = generateRunbook('Restart Service', ['Stop the pod', 'Scale down', 'Scale up'], { stateFile: f });
+    expect(r.success).toBe(true);
+    expect(r.runbook?.steps.length).toBe(3);
+  });
+});
+
+describe('configureErrorBudget', () => {
+  it('requires service and slo', () => {
+    const r = configureErrorBudget('', undefined as unknown as number, { stateFile: join(tmpDir, 's.json') });
+    expect(r.success).toBe(false);
+  });
+
+  it('creates error budget', () => {
+    const f = join(tmpDir, 's.json');
+    const r = configureErrorBudget('api', 99.9, { stateFile: f });
+    expect(r.success).toBe(true);
+    expect(r.error_budget?.id).toMatch(/^EB-/);
+  });
+});
+
+describe('generateReport', () => {
+  it('returns counts for empty state', () => {
+    const f = join(tmpDir, 's.json');
+    const r = generateReport({ stateFile: f });
+    expect(r.total_monitors).toBe(0);
+    expect(r.total_alerts).toBe(0);
+    expect(r.total_runbooks).toBe(0);
+  });
+});
+
+describe('MONITOR_TYPES / ALERT_SEVERITIES', () => {
+  it('MONITOR_TYPES contains uptime', () => expect(MONITOR_TYPES).toContain('uptime'));
+  it('ALERT_SEVERITIES contains critical', () => expect(ALERT_SEVERITIES).toContain('critical'));
+});

--- a/tests/test-telemetry-feedback.test.ts
+++ b/tests/test-telemetry-feedback.test.ts
@@ -1,0 +1,133 @@
+/**
+ * tests/test-telemetry-feedback.test.ts — Telemetry Feedback port tests.
+ */
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  METRIC_TYPES,
+  analyzeMetrics,
+  defaultState,
+  generateFeedbackReport,
+  ingestMetric,
+  loadState,
+  saveState,
+} from '../src/lib/telemetry-feedback.js';
+
+let tmpDir: string;
+beforeEach(() => { tmpDir = join(tmpdir(), `test-tel-${Date.now()}`); mkdirSync(tmpDir, { recursive: true }); });
+afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+
+describe('defaultState', () => {
+  it('returns empty metrics and insights', () => {
+    const s = defaultState();
+    expect(s.metrics).toEqual([]);
+    expect(s.insights).toEqual([]);
+  });
+});
+
+describe('loadState', () => {
+  it('returns defaultState for missing file', () => {
+    const s = loadState(join(tmpDir, 'missing.json'));
+    expect(s.metrics).toEqual([]);
+  });
+
+  it('returns defaultState for invalid JSON', () => {
+    const f = join(tmpDir, 'bad.json');
+    writeFileSync(f, 'not valid');
+    const s = loadState(f);
+    expect(s.metrics).toEqual([]);
+  });
+
+  it('rejects __proto__ pollution key', () => {
+    const f = join(tmpDir, 'polluted.json');
+    writeFileSync(f, '{"__proto__":{"x":1},"version":"1.0.0","metrics":[],"insights":[],"last_updated":null}');
+    const s = loadState(f);
+    expect(s.metrics).toEqual([]);
+  });
+
+  it('rejects constructor pollution key', () => {
+    const f = join(tmpDir, 'polluted2.json');
+    writeFileSync(f, '{"constructor":{},"version":"1.0.0","metrics":[],"insights":[],"last_updated":null}');
+    const s = loadState(f);
+    expect(s.metrics).toEqual([]);
+  });
+});
+
+describe('ingestMetric', () => {
+  it('requires name and type', () => {
+    const r = ingestMetric('', 'latency', 100, { stateFile: join(tmpDir, 's.json') });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects unknown type', () => {
+    const r = ingestMetric('metric', 'unknown', 10, { stateFile: join(tmpDir, 's.json') });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/Unknown type/);
+  });
+
+  it('creates metric with valid inputs', () => {
+    const f = join(tmpDir, 's.json');
+    const r = ingestMetric('api_latency', 'latency', 150, { stateFile: f });
+    expect(r.success).toBe(true);
+    expect(r.metric?.id).toMatch(/^TEL-/);
+  });
+
+  it('persists metric', () => {
+    const f = join(tmpDir, 's.json');
+    ingestMetric('m1', 'latency', 100, { stateFile: f });
+    const s = loadState(f);
+    expect(s.metrics.length).toBe(1);
+  });
+});
+
+describe('analyzeMetrics', () => {
+  it('returns empty analysis for no metrics', () => {
+    const f = join(tmpDir, 's.json');
+    const r = analyzeMetrics({ stateFile: f });
+    expect(r.total_metrics).toBe(0);
+    expect(r.analysis).toEqual({});
+  });
+
+  it('calculates avg, min, max', () => {
+    const f = join(tmpDir, 's.json');
+    ingestMetric('m', 'latency', 100, { stateFile: f });
+    ingestMetric('m', 'latency', 200, { stateFile: f });
+    const r = analyzeMetrics({ stateFile: f });
+    const stats = r.analysis['latency'];
+    expect(stats?.avg).toBe(150);
+    expect(stats?.min).toBe(100);
+    expect(stats?.max).toBe(200);
+  });
+});
+
+describe('generateFeedbackReport', () => {
+  it('returns success for empty state', () => {
+    const f = join(tmpDir, 's.json');
+    const r = generateFeedbackReport({ stateFile: f });
+    expect(r.success).toBe(true);
+    expect(r.recommendations).toEqual([]);
+  });
+
+  it('generates recommendation for high latency', () => {
+    const f = join(tmpDir, 's.json');
+    ingestMetric('api', 'latency', 600, { stateFile: f });
+    const r = generateFeedbackReport({ stateFile: f });
+    expect(r.recommendations.some(rec => rec.includes('latency'))).toBe(true);
+  });
+
+  it('generates recommendation for high error rate', () => {
+    const f = join(tmpDir, 's.json');
+    ingestMetric('api', 'error-rate', 10, { stateFile: f });
+    const r = generateFeedbackReport({ stateFile: f });
+    expect(r.recommendations.some(rec => rec.includes('error'))).toBe(true);
+  });
+});
+
+describe('METRIC_TYPES', () => {
+  it('includes latency and error-rate', () => {
+    expect(METRIC_TYPES).toContain('latency');
+    expect(METRIC_TYPES).toContain('error-rate');
+  });
+});

--- a/tests/test-telemetry-feedback.test.ts
+++ b/tests/test-telemetry-feedback.test.ts
@@ -6,18 +6,22 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
-  METRIC_TYPES,
   analyzeMetrics,
   defaultState,
   generateFeedbackReport,
   ingestMetric,
   loadState,
-  saveState,
+  METRIC_TYPES,
 } from '../src/lib/telemetry-feedback.js';
 
 let tmpDir: string;
-beforeEach(() => { tmpDir = join(tmpdir(), `test-tel-${Date.now()}`); mkdirSync(tmpDir, { recursive: true }); });
-afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+beforeEach(() => {
+  tmpDir = join(tmpdir(), `test-tel-${Date.now()}`);
+  mkdirSync(tmpDir, { recursive: true });
+});
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
 
 describe('defaultState', () => {
   it('returns empty metrics and insights', () => {
@@ -42,14 +46,20 @@ describe('loadState', () => {
 
   it('rejects __proto__ pollution key', () => {
     const f = join(tmpDir, 'polluted.json');
-    writeFileSync(f, '{"__proto__":{"x":1},"version":"1.0.0","metrics":[],"insights":[],"last_updated":null}');
+    writeFileSync(
+      f,
+      '{"__proto__":{"x":1},"version":"1.0.0","metrics":[],"insights":[],"last_updated":null}'
+    );
     const s = loadState(f);
     expect(s.metrics).toEqual([]);
   });
 
   it('rejects constructor pollution key', () => {
     const f = join(tmpDir, 'polluted2.json');
-    writeFileSync(f, '{"constructor":{},"version":"1.0.0","metrics":[],"insights":[],"last_updated":null}');
+    writeFileSync(
+      f,
+      '{"constructor":{},"version":"1.0.0","metrics":[],"insights":[],"last_updated":null}'
+    );
     const s = loadState(f);
     expect(s.metrics).toEqual([]);
   });
@@ -95,7 +105,7 @@ describe('analyzeMetrics', () => {
     ingestMetric('m', 'latency', 100, { stateFile: f });
     ingestMetric('m', 'latency', 200, { stateFile: f });
     const r = analyzeMetrics({ stateFile: f });
-    const stats = r.analysis['latency'];
+    const stats = r.analysis.latency;
     expect(stats?.avg).toBe(150);
     expect(stats?.min).toBe(100);
     expect(stats?.max).toBe(200);
@@ -114,14 +124,14 @@ describe('generateFeedbackReport', () => {
     const f = join(tmpDir, 's.json');
     ingestMetric('api', 'latency', 600, { stateFile: f });
     const r = generateFeedbackReport({ stateFile: f });
-    expect(r.recommendations.some(rec => rec.includes('latency'))).toBe(true);
+    expect(r.recommendations.some((rec) => rec.includes('latency'))).toBe(true);
   });
 
   it('generates recommendation for high error rate', () => {
     const f = join(tmpDir, 's.json');
     ingestMetric('api', 'error-rate', 10, { stateFile: f });
     const r = generateFeedbackReport({ stateFile: f });
-    expect(r.recommendations.some(rec => rec.includes('error'))).toBe(true);
+    expect(r.recommendations.some((rec) => rec.includes('error'))).toBe(true);
   });
 });
 

--- a/tests/test-test-generator.test.ts
+++ b/tests/test-test-generator.test.ts
@@ -1,0 +1,139 @@
+/**
+ * tests/test-test-generator.test.ts — Test Generator port tests (M11 batch 6).
+ */
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  TEST_FRAMEWORKS,
+  TEST_TYPES,
+  checkCoverage,
+  extractCriteria,
+  generateTestStubs,
+} from '../src/lib/test-generator.js';
+
+let tmpDir: string;
+beforeEach(() => { tmpDir = join(tmpdir(), `test-testgen-${Date.now()}`); mkdirSync(tmpDir, { recursive: true }); });
+afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+
+const SAMPLE_PRD = `
+## User Stories
+
+**E01-S01** - Login feature
+
+- Given user visits login page
+- When user submits valid credentials
+- Then user is redirected to dashboard
+- AC1: Login should work
+
+**E01-S02** - Logout feature
+
+- Given user is logged in
+- When user clicks logout
+- Then user is signed out
+`;
+
+describe('extractCriteria', () => {
+  it('extracts Given/When/Then criteria', () => {
+    const criteria = extractCriteria(SAMPLE_PRD);
+    expect(criteria.length).toBeGreaterThan(0);
+    expect(criteria.some(c => c.type === 'given')).toBe(true);
+    expect(criteria.some(c => c.type === 'when')).toBe(true);
+    expect(criteria.some(c => c.type === 'then')).toBe(true);
+  });
+
+  it('extracts AC criteria', () => {
+    const criteria = extractCriteria(SAMPLE_PRD);
+    expect(criteria.some(c => c.type === 'acceptance')).toBe(true);
+  });
+
+  it('associates story IDs with criteria', () => {
+    const criteria = extractCriteria(SAMPLE_PRD);
+    expect(criteria.some(c => c.story === 'E01-S01')).toBe(true);
+  });
+
+  it('returns empty for content without criteria', () => {
+    expect(extractCriteria('# Plain doc\n\nNo criteria here')).toEqual([]);
+  });
+});
+
+describe('generateTestStubs', () => {
+  it('returns error for unsupported language', () => {
+    const r = generateTestStubs([], { language: 'cobol' });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/Unsupported/);
+  });
+
+  it('generates TypeScript test files', () => {
+    const criteria = extractCriteria(SAMPLE_PRD);
+    const r = generateTestStubs(criteria, { language: 'typescript' });
+    expect(r.success).toBe(true);
+    expect((r.test_files ?? 0)).toBeGreaterThan(0);
+    expect(r.framework).toBe('vitest');
+  });
+
+  it('files have correct extension for TypeScript', () => {
+    const criteria = extractCriteria(SAMPLE_PRD);
+    const r = generateTestStubs(criteria, { language: 'typescript' });
+    for (const f of r.files ?? []) {
+      expect(f.fileName).toMatch(/\.test\.ts$/);
+    }
+  });
+
+  it('generates Python test files', () => {
+    const criteria = extractCriteria(SAMPLE_PRD);
+    const r = generateTestStubs(criteria, { language: 'python' });
+    expect(r.success).toBe(true);
+    expect(r.framework).toBe('pytest');
+  });
+
+  it('groups criteria by story', () => {
+    const criteria = extractCriteria(SAMPLE_PRD);
+    const r = generateTestStubs(criteria, { language: 'javascript' });
+    // E01-S01 and E01-S02 should produce separate files
+    expect((r.test_files ?? 0)).toBeGreaterThanOrEqual(2);
+  });
+
+  it('includes total_criteria count', () => {
+    const criteria = extractCriteria(SAMPLE_PRD);
+    const r = generateTestStubs(criteria, { language: 'javascript' });
+    expect(r.total_criteria).toBe(criteria.length);
+  });
+});
+
+describe('checkCoverage', () => {
+  it('returns error when PRD missing', () => {
+    const r = checkCoverage(tmpDir);
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/PRD not found/);
+  });
+
+  it('returns coverage when PRD exists', () => {
+    const specsDir = join(tmpDir, 'specs');
+    mkdirSync(specsDir);
+    writeFileSync(join(specsDir, 'prd.md'), SAMPLE_PRD);
+    const r = checkCoverage(tmpDir);
+    expect(r.success).toBe(true);
+    expect(typeof r.coverage).toBe('number');
+    expect((r.coverage ?? 0)).toBeGreaterThanOrEqual(0);
+    expect((r.coverage ?? 0)).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('TEST_TYPES', () => {
+  it('includes unit and integration', () => {
+    expect(TEST_TYPES).toContain('unit');
+    expect(TEST_TYPES).toContain('integration');
+  });
+});
+
+describe('TEST_FRAMEWORKS', () => {
+  it('has typescript framework config', () => {
+    expect(TEST_FRAMEWORKS['typescript']?.framework).toBe('vitest');
+  });
+
+  it('has python framework config', () => {
+    expect(TEST_FRAMEWORKS['python']?.framework).toBe('pytest');
+  });
+});

--- a/tests/test-test-generator.test.ts
+++ b/tests/test-test-generator.test.ts
@@ -6,16 +6,21 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
-  TEST_FRAMEWORKS,
-  TEST_TYPES,
   checkCoverage,
   extractCriteria,
   generateTestStubs,
+  TEST_FRAMEWORKS,
+  TEST_TYPES,
 } from '../src/lib/test-generator.js';
 
 let tmpDir: string;
-beforeEach(() => { tmpDir = join(tmpdir(), `test-testgen-${Date.now()}`); mkdirSync(tmpDir, { recursive: true }); });
-afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+beforeEach(() => {
+  tmpDir = join(tmpdir(), `test-testgen-${Date.now()}`);
+  mkdirSync(tmpDir, { recursive: true });
+});
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
 
 const SAMPLE_PRD = `
 ## User Stories
@@ -38,19 +43,19 @@ describe('extractCriteria', () => {
   it('extracts Given/When/Then criteria', () => {
     const criteria = extractCriteria(SAMPLE_PRD);
     expect(criteria.length).toBeGreaterThan(0);
-    expect(criteria.some(c => c.type === 'given')).toBe(true);
-    expect(criteria.some(c => c.type === 'when')).toBe(true);
-    expect(criteria.some(c => c.type === 'then')).toBe(true);
+    expect(criteria.some((c) => c.type === 'given')).toBe(true);
+    expect(criteria.some((c) => c.type === 'when')).toBe(true);
+    expect(criteria.some((c) => c.type === 'then')).toBe(true);
   });
 
   it('extracts AC criteria', () => {
     const criteria = extractCriteria(SAMPLE_PRD);
-    expect(criteria.some(c => c.type === 'acceptance')).toBe(true);
+    expect(criteria.some((c) => c.type === 'acceptance')).toBe(true);
   });
 
   it('associates story IDs with criteria', () => {
     const criteria = extractCriteria(SAMPLE_PRD);
-    expect(criteria.some(c => c.story === 'E01-S01')).toBe(true);
+    expect(criteria.some((c) => c.story === 'E01-S01')).toBe(true);
   });
 
   it('returns empty for content without criteria', () => {
@@ -69,7 +74,7 @@ describe('generateTestStubs', () => {
     const criteria = extractCriteria(SAMPLE_PRD);
     const r = generateTestStubs(criteria, { language: 'typescript' });
     expect(r.success).toBe(true);
-    expect((r.test_files ?? 0)).toBeGreaterThan(0);
+    expect(r.test_files ?? 0).toBeGreaterThan(0);
     expect(r.framework).toBe('vitest');
   });
 
@@ -92,7 +97,7 @@ describe('generateTestStubs', () => {
     const criteria = extractCriteria(SAMPLE_PRD);
     const r = generateTestStubs(criteria, { language: 'javascript' });
     // E01-S01 and E01-S02 should produce separate files
-    expect((r.test_files ?? 0)).toBeGreaterThanOrEqual(2);
+    expect(r.test_files ?? 0).toBeGreaterThanOrEqual(2);
   });
 
   it('includes total_criteria count', () => {
@@ -116,8 +121,8 @@ describe('checkCoverage', () => {
     const r = checkCoverage(tmpDir);
     expect(r.success).toBe(true);
     expect(typeof r.coverage).toBe('number');
-    expect((r.coverage ?? 0)).toBeGreaterThanOrEqual(0);
-    expect((r.coverage ?? 0)).toBeLessThanOrEqual(100);
+    expect(r.coverage ?? 0).toBeGreaterThanOrEqual(0);
+    expect(r.coverage ?? 0).toBeLessThanOrEqual(100);
   });
 });
 
@@ -130,10 +135,10 @@ describe('TEST_TYPES', () => {
 
 describe('TEST_FRAMEWORKS', () => {
   it('has typescript framework config', () => {
-    expect(TEST_FRAMEWORKS['typescript']?.framework).toBe('vitest');
+    expect(TEST_FRAMEWORKS.typescript?.framework).toBe('vitest');
   });
 
   it('has python framework config', () => {
-    expect(TEST_FRAMEWORKS['python']?.framework).toBe('pytest');
+    expect(TEST_FRAMEWORKS.python?.framework).toBe('pytest');
   });
 });

--- a/tests/test-tool-guardrails.test.ts
+++ b/tests/test-tool-guardrails.test.ts
@@ -1,0 +1,182 @@
+/**
+ * tests/test-tool-guardrails.test.ts
+ * Vitest tests for src/lib/tool-guardrails.ts (M11 batch 6 port).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  checkOperation,
+  validateFileOperation,
+  RISK_RULES,
+  PROTECTED_PATHS,
+} from '../src/lib/tool-guardrails.js';
+
+// ─── RISK_RULES ───────────────────────────────────────────────────────────────
+
+describe('RISK_RULES', () => {
+  it('contains 8 rules', () => {
+    expect(RISK_RULES).toHaveLength(8);
+  });
+
+  it('has a critical rule for recursive-delete', () => {
+    const rule = RISK_RULES.find(r => r.id === 'recursive-delete');
+    expect(rule).toBeDefined();
+    expect(rule!.risk).toBe('critical');
+  });
+
+  it('has a critical rule for sudo-usage', () => {
+    const rule = RISK_RULES.find(r => r.id === 'sudo-usage');
+    expect(rule).toBeDefined();
+    expect(rule!.risk).toBe('critical');
+  });
+});
+
+// ─── PROTECTED_PATHS ─────────────────────────────────────────────────────────
+
+describe('PROTECTED_PATHS', () => {
+  it('includes .env', () => {
+    expect(PROTECTED_PATHS).toContain('.env');
+  });
+
+  it('includes .jumpstart/state/', () => {
+    expect(PROTECTED_PATHS).toContain('.jumpstart/state/');
+  });
+});
+
+// ─── checkOperation ──────────────────────────────────────────────────────────
+
+describe('checkOperation', () => {
+  it('returns error for empty operation', () => {
+    const result = checkOperation('');
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/required/i);
+  });
+
+  it('returns no violations for safe operation', () => {
+    const result = checkOperation('echo hello');
+    expect(result.success).toBe(true);
+    expect(result.violations).toHaveLength(0);
+    expect(result.risk_level).toBe('none');
+    expect(result.allowed).toBe(true);
+  });
+
+  it('detects rm -rf as critical', () => {
+    const result = checkOperation('rm -rf /tmp/folder');
+    expect(result.success).toBe(true);
+    expect(result.allowed).toBe(false);
+    expect(result.risk_level).toBe('critical');
+    const violationIds = (result.violations ?? []).map(v => v.rule_id);
+    expect(violationIds).toContain('recursive-delete');
+  });
+
+  it('detects sudo as critical', () => {
+    const result = checkOperation('sudo rm file.txt');
+    expect(result.allowed).toBe(false);
+    expect(result.risk_level).toBe('critical');
+  });
+
+  it('detects schema change as high risk', () => {
+    const result = checkOperation('ALTER TABLE users DROP COLUMN email');
+    expect(result.success).toBe(true);
+    expect(result.requires_approval).toBe(true);
+    const violationIds = (result.violations ?? []).map(v => v.rule_id);
+    expect(violationIds).toContain('schema-change');
+  });
+
+  it('detects git force push as high risk', () => {
+    const result = checkOperation('git push --force origin main');
+    expect(result.requires_approval).toBe(true);
+    expect(result.risk_level).toBe('high');
+  });
+
+  it('detects wide glob as medium risk', () => {
+    const result = checkOperation('rm **/*');
+    // recursive-delete not matched here (no -rf), but wide-glob is medium
+    const globs = (result.violations ?? []).filter(v => v.rule_id === 'wide-glob');
+    expect(globs.length).toBeGreaterThan(0);
+  });
+
+  it('detects protected path .env', () => {
+    const result = checkOperation('cat .env');
+    expect(result.success).toBe(true);
+    const ppViolations = (result.violations ?? []).filter(v => v.rule_id === 'protected-path');
+    expect(ppViolations.length).toBeGreaterThan(0);
+  });
+
+  it('detects protected path .jumpstart/state/', () => {
+    const result = checkOperation('rm .jumpstart/state/state.json');
+    const ppViolations = (result.violations ?? []).filter(v => v.rule_id === 'protected-path');
+    expect(ppViolations.length).toBeGreaterThan(0);
+  });
+
+  it('truncates long operations to 200 chars in result', () => {
+    const longOp = 'echo ' + 'a'.repeat(300);
+    const result = checkOperation(longOp);
+    expect((result.operation ?? '').length).toBeLessThanOrEqual(200);
+  });
+
+  it('reports total_violations count', () => {
+    const result = checkOperation('sudo rm -rf .env');
+    expect(typeof result.total_violations).toBe('number');
+    expect((result.total_violations ?? 0)).toBeGreaterThan(0);
+  });
+});
+
+// ─── validateFileOperation ───────────────────────────────────────────────────
+
+describe('validateFileOperation', () => {
+  it('allows safe create', () => {
+    const result = validateFileOperation('create', 'src/lib/foo.ts');
+    expect(result.success).toBe(true);
+    expect(result.allowed).toBe(true);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('warns on delete with high-level warning', () => {
+    const result = validateFileOperation('delete', 'src/lib/foo.ts');
+    expect(result.success).toBe(true);
+    expect(result.allowed).toBe(true);
+    expect(result.warnings.some(w => w.level === 'high')).toBe(true);
+  });
+
+  it('blocks delete of protected path', () => {
+    const result = validateFileOperation('delete', '.env');
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/protected/i);
+  });
+
+  it('blocks delete of .jumpstart/state/ path', () => {
+    const result = validateFileOperation('delete', '.jumpstart/state/state.json');
+    expect(result.allowed).toBe(false);
+  });
+
+  it('warns on edit of .pem file', () => {
+    const result = validateFileOperation('edit', 'certs/server.pem');
+    expect(result.warnings.some(w => w.message.includes('sensitive'))).toBe(true);
+  });
+
+  it('warns on edit of .key file', () => {
+    const result = validateFileOperation('edit', 'private.key');
+    expect(result.warnings.some(w => w.level === 'high')).toBe(true);
+  });
+
+  it('warns on large edit (>100 lines)', () => {
+    const result = validateFileOperation('edit', 'src/foo.ts', { lines_changed: 150 });
+    expect(result.warnings.some(w => w.message.includes('Large edit'))).toBe(true);
+  });
+
+  it('does not warn for small edit', () => {
+    const result = validateFileOperation('edit', 'src/foo.ts', { lines_changed: 10 });
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('sets requires_review true when high warning present', () => {
+    const result = validateFileOperation('delete', 'src/foo.ts');
+    expect(result.requires_review).toBe(true);
+  });
+
+  it('sets requires_review false when no high warnings', () => {
+    const result = validateFileOperation('create', 'src/foo.ts');
+    expect(result.requires_review).toBe(false);
+  });
+});

--- a/tests/test-tool-guardrails.test.ts
+++ b/tests/test-tool-guardrails.test.ts
@@ -3,12 +3,12 @@
  * Vitest tests for src/lib/tool-guardrails.ts (M11 batch 6 port).
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
   checkOperation,
-  validateFileOperation,
-  RISK_RULES,
   PROTECTED_PATHS,
+  RISK_RULES,
+  validateFileOperation,
 } from '../src/lib/tool-guardrails.js';
 
 // ─── RISK_RULES ───────────────────────────────────────────────────────────────
@@ -19,15 +19,15 @@ describe('RISK_RULES', () => {
   });
 
   it('has a critical rule for recursive-delete', () => {
-    const rule = RISK_RULES.find(r => r.id === 'recursive-delete');
+    const rule = RISK_RULES.find((r) => r.id === 'recursive-delete');
     expect(rule).toBeDefined();
-    expect(rule!.risk).toBe('critical');
+    expect(rule?.risk).toBe('critical');
   });
 
   it('has a critical rule for sudo-usage', () => {
-    const rule = RISK_RULES.find(r => r.id === 'sudo-usage');
+    const rule = RISK_RULES.find((r) => r.id === 'sudo-usage');
     expect(rule).toBeDefined();
-    expect(rule!.risk).toBe('critical');
+    expect(rule?.risk).toBe('critical');
   });
 });
 
@@ -65,7 +65,7 @@ describe('checkOperation', () => {
     expect(result.success).toBe(true);
     expect(result.allowed).toBe(false);
     expect(result.risk_level).toBe('critical');
-    const violationIds = (result.violations ?? []).map(v => v.rule_id);
+    const violationIds = (result.violations ?? []).map((v) => v.rule_id);
     expect(violationIds).toContain('recursive-delete');
   });
 
@@ -79,7 +79,7 @@ describe('checkOperation', () => {
     const result = checkOperation('ALTER TABLE users DROP COLUMN email');
     expect(result.success).toBe(true);
     expect(result.requires_approval).toBe(true);
-    const violationIds = (result.violations ?? []).map(v => v.rule_id);
+    const violationIds = (result.violations ?? []).map((v) => v.rule_id);
     expect(violationIds).toContain('schema-change');
   });
 
@@ -92,25 +92,25 @@ describe('checkOperation', () => {
   it('detects wide glob as medium risk', () => {
     const result = checkOperation('rm **/*');
     // recursive-delete not matched here (no -rf), but wide-glob is medium
-    const globs = (result.violations ?? []).filter(v => v.rule_id === 'wide-glob');
+    const globs = (result.violations ?? []).filter((v) => v.rule_id === 'wide-glob');
     expect(globs.length).toBeGreaterThan(0);
   });
 
   it('detects protected path .env', () => {
     const result = checkOperation('cat .env');
     expect(result.success).toBe(true);
-    const ppViolations = (result.violations ?? []).filter(v => v.rule_id === 'protected-path');
+    const ppViolations = (result.violations ?? []).filter((v) => v.rule_id === 'protected-path');
     expect(ppViolations.length).toBeGreaterThan(0);
   });
 
   it('detects protected path .jumpstart/state/', () => {
     const result = checkOperation('rm .jumpstart/state/state.json');
-    const ppViolations = (result.violations ?? []).filter(v => v.rule_id === 'protected-path');
+    const ppViolations = (result.violations ?? []).filter((v) => v.rule_id === 'protected-path');
     expect(ppViolations.length).toBeGreaterThan(0);
   });
 
   it('truncates long operations to 200 chars in result', () => {
-    const longOp = 'echo ' + 'a'.repeat(300);
+    const longOp = `echo ${'a'.repeat(300)}`;
     const result = checkOperation(longOp);
     expect((result.operation ?? '').length).toBeLessThanOrEqual(200);
   });
@@ -118,7 +118,7 @@ describe('checkOperation', () => {
   it('reports total_violations count', () => {
     const result = checkOperation('sudo rm -rf .env');
     expect(typeof result.total_violations).toBe('number');
-    expect((result.total_violations ?? 0)).toBeGreaterThan(0);
+    expect(result.total_violations ?? 0).toBeGreaterThan(0);
   });
 });
 
@@ -136,7 +136,7 @@ describe('validateFileOperation', () => {
     const result = validateFileOperation('delete', 'src/lib/foo.ts');
     expect(result.success).toBe(true);
     expect(result.allowed).toBe(true);
-    expect(result.warnings.some(w => w.level === 'high')).toBe(true);
+    expect(result.warnings.some((w) => w.level === 'high')).toBe(true);
   });
 
   it('blocks delete of protected path', () => {
@@ -152,17 +152,17 @@ describe('validateFileOperation', () => {
 
   it('warns on edit of .pem file', () => {
     const result = validateFileOperation('edit', 'certs/server.pem');
-    expect(result.warnings.some(w => w.message.includes('sensitive'))).toBe(true);
+    expect(result.warnings.some((w) => w.message.includes('sensitive'))).toBe(true);
   });
 
   it('warns on edit of .key file', () => {
     const result = validateFileOperation('edit', 'private.key');
-    expect(result.warnings.some(w => w.level === 'high')).toBe(true);
+    expect(result.warnings.some((w) => w.level === 'high')).toBe(true);
   });
 
   it('warns on large edit (>100 lines)', () => {
     const result = validateFileOperation('edit', 'src/foo.ts', { lines_changed: 150 });
-    expect(result.warnings.some(w => w.message.includes('Large edit'))).toBe(true);
+    expect(result.warnings.some((w) => w.message.includes('Large edit'))).toBe(true);
   });
 
   it('does not warn for small edit', () => {

--- a/tests/test-transcript-ingestion.test.ts
+++ b/tests/test-transcript-ingestion.test.ts
@@ -3,19 +3,19 @@
  * Vitest tests for src/lib/transcript-ingestion.ts (M11 batch 6 port).
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
-import { writeFileSync, mkdirSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
 import {
-  defaultState,
-  loadState,
-  saveState,
-  ingestTranscript,
-  extractFromTranscript,
-  listTranscripts,
   ACTION_PATTERNS,
   DECISION_PATTERNS,
+  defaultState,
+  extractFromTranscript,
+  ingestTranscript,
+  listTranscripts,
+  loadState,
+  saveState,
 } from '../src/lib/transcript-ingestion.js';
 
 let _seq = 0;
@@ -69,7 +69,7 @@ describe('loadState / saveState', () => {
     writeFileSync(
       f,
       '{"__proto__":{"polluted":true},"version":"1.0.0","transcripts":[],"last_updated":null}',
-      'utf8',
+      'utf8'
     );
     // Should fall back to defaultState, not throw to caller
     const state = loadState(f);
@@ -81,7 +81,7 @@ describe('loadState / saveState', () => {
     writeFileSync(
       f,
       '{"constructor":{"polluted":true},"version":"1.0.0","transcripts":[],"last_updated":null}',
-      'utf8',
+      'utf8'
     );
     const state = loadState(f);
     expect(state.transcripts).toEqual([]);
@@ -122,7 +122,10 @@ describe('ingestTranscript', () => {
 
   it('ingests a transcript and returns success', () => {
     const f = tmpStateFile();
-    const result = ingestTranscript('Hello world meeting notes.', { stateFile: f, title: 'Test Meeting' });
+    const result = ingestTranscript('Hello world meeting notes.', {
+      stateFile: f,
+      title: 'Test Meeting',
+    });
     expect(result.success).toBe(true);
     expect(result.transcript?.title).toBe('Test Meeting');
     expect(result.transcript?.id).toMatch(/^TR-/);
@@ -138,18 +141,18 @@ describe('ingestTranscript', () => {
   it('extracts action items from TODO pattern', () => {
     const f = tmpStateFile();
     const result = ingestTranscript('Meeting notes. TODO: fix the build.', { stateFile: f });
-    expect(result.transcript?.actions.some(a => a.text.includes('fix the build'))).toBe(true);
+    expect(result.transcript?.actions.some((a) => a.text.includes('fix the build'))).toBe(true);
   });
 
   it('extracts decisions from "decided" pattern', () => {
     const f = tmpStateFile();
     const result = ingestTranscript('We decided to use TypeScript.', { stateFile: f });
-    expect(result.transcript?.decisions.some(d => d.text.includes('use TypeScript'))).toBe(true);
+    expect(result.transcript?.decisions.some((d) => d.text.includes('use TypeScript'))).toBe(true);
   });
 
   it('extracts key_topics from markdown headings', () => {
     const f = tmpStateFile();
-    const text = '# Sprint Review\n## Action Items\nLet\'s do this.';
+    const text = "# Sprint Review\n## Action Items\nLet's do this.";
     const result = ingestTranscript(text, { stateFile: f });
     expect(result.transcript?.key_topics).toContain('Sprint Review');
     expect(result.transcript?.key_topics).toContain('Action Items');
@@ -175,7 +178,7 @@ describe('extractFromTranscript', () => {
   it('extracts data for existing transcript', () => {
     const f = tmpStateFile();
     const ingested = ingestTranscript('action item: review PR. decided to ship.', { stateFile: f });
-    const id = ingested.transcript!.id;
+    const id = ingested.transcript?.id ?? '';
     const result = extractFromTranscript(id, { stateFile: f });
     expect(result.success).toBe(true);
     expect(result.id).toBe(id);
@@ -201,7 +204,7 @@ describe('listTranscripts', () => {
     ingestTranscript('notes two', { stateFile: f, title: 'Meeting B' });
     const result = listTranscripts({ stateFile: f });
     expect(result.total).toBe(2);
-    expect(result.transcripts.map(t => t.title)).toContain('Meeting A');
-    expect(result.transcripts.map(t => t.title)).toContain('Meeting B');
+    expect(result.transcripts.map((t) => t.title)).toContain('Meeting A');
+    expect(result.transcripts.map((t) => t.title)).toContain('Meeting B');
   });
 });

--- a/tests/test-transcript-ingestion.test.ts
+++ b/tests/test-transcript-ingestion.test.ts
@@ -1,0 +1,207 @@
+/**
+ * tests/test-transcript-ingestion.test.ts
+ * Vitest tests for src/lib/transcript-ingestion.ts (M11 batch 6 port).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  defaultState,
+  loadState,
+  saveState,
+  ingestTranscript,
+  extractFromTranscript,
+  listTranscripts,
+  ACTION_PATTERNS,
+  DECISION_PATTERNS,
+} from '../src/lib/transcript-ingestion.js';
+
+let _seq = 0;
+function tmpStateFile() {
+  const dir = join(tmpdir(), `transcript-test-${Date.now()}-${++_seq}`);
+  mkdirSync(dir, { recursive: true });
+  return join(dir, 'transcripts.json');
+}
+
+// ─── defaultState ─────────────────────────────────────────────────────────────
+
+describe('defaultState', () => {
+  it('returns version 1.0.0', () => {
+    expect(defaultState().version).toBe('1.0.0');
+  });
+
+  it('returns empty transcripts array', () => {
+    expect(defaultState().transcripts).toEqual([]);
+  });
+
+  it('returns null last_updated', () => {
+    expect(defaultState().last_updated).toBeNull();
+  });
+});
+
+// ─── loadState / saveState ───────────────────────────────────────────────────
+
+describe('loadState / saveState', () => {
+  it('returns defaultState when file missing', () => {
+    const state = loadState('/non/existent/path.json');
+    expect(state.transcripts).toEqual([]);
+  });
+
+  it('round-trips state through save/load', () => {
+    const f = tmpStateFile();
+    const state = defaultState();
+    saveState(state, f);
+    const loaded = loadState(f);
+    expect(loaded.version).toBe('1.0.0');
+    expect(loaded.last_updated).not.toBeNull();
+  });
+
+  it('returns defaultState on corrupt JSON', () => {
+    const f = tmpStateFile();
+    writeFileSync(f, 'not-json', 'utf8');
+    expect(loadState(f).transcripts).toEqual([]);
+  });
+
+  it('rejects __proto__ pollution key in state file (M3)', () => {
+    const f = tmpStateFile();
+    writeFileSync(
+      f,
+      '{"__proto__":{"polluted":true},"version":"1.0.0","transcripts":[],"last_updated":null}',
+      'utf8',
+    );
+    // Should fall back to defaultState, not throw to caller
+    const state = loadState(f);
+    expect(state.transcripts).toEqual([]);
+  });
+
+  it('rejects constructor pollution key (M3)', () => {
+    const f = tmpStateFile();
+    writeFileSync(
+      f,
+      '{"constructor":{"polluted":true},"version":"1.0.0","transcripts":[],"last_updated":null}',
+      'utf8',
+    );
+    const state = loadState(f);
+    expect(state.transcripts).toEqual([]);
+  });
+
+  it('creates directory when saving to new path', () => {
+    const dir = join(tmpdir(), `transcript-mkdir-${Date.now()}`, 'nested');
+    const f = join(dir, 'transcripts.json');
+    saveState(defaultState(), f);
+    expect(existsSync(f)).toBe(true);
+  });
+});
+
+// ─── ACTION_PATTERNS / DECISION_PATTERNS ─────────────────────────────────────
+
+describe('ACTION_PATTERNS', () => {
+  it('is an array of RegExp', () => {
+    expect(Array.isArray(ACTION_PATTERNS)).toBe(true);
+    for (const p of ACTION_PATTERNS) expect(p).toBeInstanceOf(RegExp);
+  });
+});
+
+describe('DECISION_PATTERNS', () => {
+  it('is an array of RegExp', () => {
+    expect(Array.isArray(DECISION_PATTERNS)).toBe(true);
+    for (const p of DECISION_PATTERNS) expect(p).toBeInstanceOf(RegExp);
+  });
+});
+
+// ─── ingestTranscript ────────────────────────────────────────────────────────
+
+describe('ingestTranscript', () => {
+  it('returns error for empty text', () => {
+    const result = ingestTranscript('', { stateFile: tmpStateFile() });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/required/i);
+  });
+
+  it('ingests a transcript and returns success', () => {
+    const f = tmpStateFile();
+    const result = ingestTranscript('Hello world meeting notes.', { stateFile: f, title: 'Test Meeting' });
+    expect(result.success).toBe(true);
+    expect(result.transcript?.title).toBe('Test Meeting');
+    expect(result.transcript?.id).toMatch(/^TR-/);
+  });
+
+  it('persists transcript to state file', () => {
+    const f = tmpStateFile();
+    ingestTranscript('Some notes.', { stateFile: f });
+    const state = loadState(f);
+    expect(state.transcripts).toHaveLength(1);
+  });
+
+  it('extracts action items from TODO pattern', () => {
+    const f = tmpStateFile();
+    const result = ingestTranscript('Meeting notes. TODO: fix the build.', { stateFile: f });
+    expect(result.transcript?.actions.some(a => a.text.includes('fix the build'))).toBe(true);
+  });
+
+  it('extracts decisions from "decided" pattern', () => {
+    const f = tmpStateFile();
+    const result = ingestTranscript('We decided to use TypeScript.', { stateFile: f });
+    expect(result.transcript?.decisions.some(d => d.text.includes('use TypeScript'))).toBe(true);
+  });
+
+  it('extracts key_topics from markdown headings', () => {
+    const f = tmpStateFile();
+    const text = '# Sprint Review\n## Action Items\nLet\'s do this.';
+    const result = ingestTranscript(text, { stateFile: f });
+    expect(result.transcript?.key_topics).toContain('Sprint Review');
+    expect(result.transcript?.key_topics).toContain('Action Items');
+  });
+
+  it('uses default title when not provided', () => {
+    const f = tmpStateFile();
+    const result = ingestTranscript('notes', { stateFile: f });
+    expect(result.transcript?.title).toBe('Untitled Meeting');
+  });
+});
+
+// ─── extractFromTranscript ───────────────────────────────────────────────────
+
+describe('extractFromTranscript', () => {
+  it('returns error for unknown id', () => {
+    const f = tmpStateFile();
+    const result = extractFromTranscript('TR-99999999', { stateFile: f });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not found/i);
+  });
+
+  it('extracts data for existing transcript', () => {
+    const f = tmpStateFile();
+    const ingested = ingestTranscript('action item: review PR. decided to ship.', { stateFile: f });
+    const id = ingested.transcript!.id;
+    const result = extractFromTranscript(id, { stateFile: f });
+    expect(result.success).toBe(true);
+    expect(result.id).toBe(id);
+    expect(result.summary?.action_count).toBeGreaterThanOrEqual(0);
+    expect(result.summary?.decision_count).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ─── listTranscripts ─────────────────────────────────────────────────────────
+
+describe('listTranscripts', () => {
+  it('returns empty list when no transcripts', () => {
+    const f = tmpStateFile();
+    const result = listTranscripts({ stateFile: f });
+    expect(result.success).toBe(true);
+    expect(result.total).toBe(0);
+    expect(result.transcripts).toEqual([]);
+  });
+
+  it('lists all ingested transcripts', () => {
+    const f = tmpStateFile();
+    ingestTranscript('notes one', { stateFile: f, title: 'Meeting A' });
+    ingestTranscript('notes two', { stateFile: f, title: 'Meeting B' });
+    const result = listTranscripts({ stateFile: f });
+    expect(result.total).toBe(2);
+    expect(result.transcripts.map(t => t.title)).toContain('Meeting A');
+    expect(result.transcripts.map(t => t.title)).toContain('Meeting B');
+  });
+});

--- a/tests/test-web-dashboard.test.ts
+++ b/tests/test-web-dashboard.test.ts
@@ -3,18 +3,18 @@
  * Vitest tests for src/lib/web-dashboard.ts (M11 batch 6 port).
  */
 
-import { describe, it, expect } from 'vitest';
-import { writeFileSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
 import {
-  generateConfig,
+  DASHBOARD_SECTIONS,
+  DEFAULT_HOST,
+  DEFAULT_PORT,
   gatherDashboardData,
+  generateConfig,
   generateStaticDashboard,
   getServerStatus,
-  DASHBOARD_SECTIONS,
-  DEFAULT_PORT,
-  DEFAULT_HOST,
 } from '../src/lib/web-dashboard.js';
 
 let _seq = 0;
@@ -115,8 +115,12 @@ describe('gatherDashboardData', () => {
     mkdirSync(stateDir, { recursive: true });
     writeFileSync(
       join(stateDir, 'state.json'),
-      JSON.stringify({ current_phase: 3, current_agent: 'developer', last_completed_step: 'build' }),
-      'utf8',
+      JSON.stringify({
+        current_phase: 3,
+        current_agent: 'developer',
+        last_completed_step: 'build',
+      }),
+      'utf8'
     );
     const result = gatherDashboardData(root);
     expect(result.sections.phases.current_phase).toBe(3);
@@ -140,7 +144,7 @@ describe('gatherDashboardData', () => {
     writeFileSync(join(specsDir, 'architecture.md'), '# Arch\n', 'utf8');
     const result = gatherDashboardData(root);
     expect(result.sections.artifacts.total).toBe(2);
-    const names = result.sections.artifacts.files.map(f => f.name);
+    const names = result.sections.artifacts.files.map((f) => f.name);
     expect(names).toContain('prd.md');
     expect(names).toContain('architecture.md');
   });

--- a/tests/test-web-dashboard.test.ts
+++ b/tests/test-web-dashboard.test.ts
@@ -1,0 +1,227 @@
+/**
+ * tests/test-web-dashboard.test.ts
+ * Vitest tests for src/lib/web-dashboard.ts (M11 batch 6 port).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  generateConfig,
+  gatherDashboardData,
+  generateStaticDashboard,
+  getServerStatus,
+  DASHBOARD_SECTIONS,
+  DEFAULT_PORT,
+  DEFAULT_HOST,
+} from '../src/lib/web-dashboard.js';
+
+let _seq = 0;
+function tmpRoot() {
+  const dir = join(tmpdir(), `web-dash-${Date.now()}-${++_seq}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+// ─── constants ────────────────────────────────────────────────────────────────
+
+describe('constants', () => {
+  it('DEFAULT_PORT is 3000', () => {
+    expect(DEFAULT_PORT).toBe(3000);
+  });
+
+  it('DEFAULT_HOST is localhost', () => {
+    expect(DEFAULT_HOST).toBe('localhost');
+  });
+
+  it('DASHBOARD_SECTIONS has 6 sections', () => {
+    expect(DASHBOARD_SECTIONS).toHaveLength(6);
+  });
+
+  it('DASHBOARD_SECTIONS includes phases and artifacts', () => {
+    expect(DASHBOARD_SECTIONS).toContain('phases');
+    expect(DASHBOARD_SECTIONS).toContain('artifacts');
+  });
+});
+
+// ─── generateConfig ───────────────────────────────────────────────────────────
+
+describe('generateConfig', () => {
+  it('returns success with default port and host', () => {
+    const result = generateConfig('/tmp/project');
+    expect(result.success).toBe(true);
+    expect(result.config.port).toBe(DEFAULT_PORT);
+    expect(result.config.host).toBe(DEFAULT_HOST);
+  });
+
+  it('accepts custom port and host', () => {
+    const result = generateConfig('/tmp/project', { port: 8080, host: '0.0.0.0' });
+    expect(result.config.port).toBe(8080);
+    expect(result.config.host).toBe('0.0.0.0');
+  });
+
+  it('resolves root to absolute path', () => {
+    const result = generateConfig('/tmp/project');
+    expect(result.config.root).toMatch(/^\//);
+  });
+
+  it('uses default theme when not specified', () => {
+    const result = generateConfig('/tmp/project');
+    expect(result.config.theme).toBe('default');
+  });
+
+  it('accepts custom sections', () => {
+    const result = generateConfig('/tmp/project', { sections: ['phases', 'artifacts'] });
+    expect(result.config.sections).toEqual(['phases', 'artifacts']);
+  });
+
+  it('defaults refresh_interval to 30', () => {
+    const result = generateConfig('/tmp/project');
+    expect(result.config.refresh_interval).toBe(30);
+  });
+
+  it('includes generated_at timestamp', () => {
+    const result = generateConfig('/tmp/project');
+    expect(result.config.generated_at).toBeTruthy();
+    expect(new Date(result.config.generated_at).getTime()).not.toBeNaN();
+  });
+
+  it('defaults auth to disabled', () => {
+    const result = generateConfig('/tmp/project');
+    expect(result.config.auth.enabled).toBe(false);
+  });
+});
+
+// ─── gatherDashboardData ─────────────────────────────────────────────────────
+
+describe('gatherDashboardData', () => {
+  it('returns success with project_root', () => {
+    const root = tmpRoot();
+    const result = gatherDashboardData(root);
+    expect(result.success).toBe(true);
+    expect(result.project_root).toBe(root);
+  });
+
+  it('defaults to current_phase 0 when no state file', () => {
+    const root = tmpRoot();
+    const result = gatherDashboardData(root);
+    expect(result.sections.phases.current_phase).toBe(0);
+  });
+
+  it('reads current_phase from state.json', () => {
+    const root = tmpRoot();
+    const stateDir = join(root, '.jumpstart', 'state');
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(
+      join(stateDir, 'state.json'),
+      JSON.stringify({ current_phase: 3, current_agent: 'developer', last_completed_step: 'build' }),
+      'utf8',
+    );
+    const result = gatherDashboardData(root);
+    expect(result.sections.phases.current_phase).toBe(3);
+    expect(result.sections.phases.current_agent).toBe('developer');
+  });
+
+  it('falls back to phase 0 on corrupt state.json', () => {
+    const root = tmpRoot();
+    const stateDir = join(root, '.jumpstart', 'state');
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(join(stateDir, 'state.json'), 'not-json', 'utf8');
+    const result = gatherDashboardData(root);
+    expect(result.sections.phases.current_phase).toBe(0);
+  });
+
+  it('lists specs artifacts', () => {
+    const root = tmpRoot();
+    const specsDir = join(root, 'specs');
+    mkdirSync(specsDir);
+    writeFileSync(join(specsDir, 'prd.md'), '# PRD\n', 'utf8');
+    writeFileSync(join(specsDir, 'architecture.md'), '# Arch\n', 'utf8');
+    const result = gatherDashboardData(root);
+    expect(result.sections.artifacts.total).toBe(2);
+    const names = result.sections.artifacts.files.map(f => f.name);
+    expect(names).toContain('prd.md');
+    expect(names).toContain('architecture.md');
+  });
+
+  it('detects config existence', () => {
+    const root = tmpRoot();
+    const cfgDir = join(root, '.jumpstart');
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(join(cfgDir, 'config.yaml'), 'project: {}', 'utf8');
+    const result = gatherDashboardData(root);
+    expect(result.sections.config.exists).toBe(true);
+  });
+
+  it('config.exists is false when no config.yaml', () => {
+    const root = tmpRoot();
+    const result = gatherDashboardData(root);
+    expect(result.sections.config.exists).toBe(false);
+  });
+});
+
+// ─── generateStaticDashboard ─────────────────────────────────────────────────
+
+describe('generateStaticDashboard', () => {
+  it('returns success with html string', () => {
+    const root = tmpRoot();
+    const data = gatherDashboardData(root);
+    const result = generateStaticDashboard(data);
+    expect(result.success).toBe(true);
+    expect(typeof result.html).toBe('string');
+  });
+
+  it('html contains Jump Start Dashboard title', () => {
+    const root = tmpRoot();
+    const data = gatherDashboardData(root);
+    const { html } = generateStaticDashboard(data);
+    expect(html).toContain('Jump Start Dashboard');
+  });
+
+  it('html contains current phase', () => {
+    const root = tmpRoot();
+    const data = gatherDashboardData(root);
+    const { html } = generateStaticDashboard(data);
+    expect(html).toContain('Current Phase:');
+  });
+
+  it('html lists artifact file names', () => {
+    const root = tmpRoot();
+    const specsDir = join(root, 'specs');
+    mkdirSync(specsDir);
+    writeFileSync(join(specsDir, 'prd.md'), '# PRD', 'utf8');
+    const data = gatherDashboardData(root);
+    const { html } = generateStaticDashboard(data);
+    expect(html).toContain('prd.md');
+  });
+});
+
+// ─── getServerStatus ─────────────────────────────────────────────────────────
+
+describe('getServerStatus', () => {
+  it('returns success', () => {
+    const result = getServerStatus();
+    expect(result.success).toBe(true);
+  });
+
+  it('running is false', () => {
+    expect(getServerStatus().running).toBe(false);
+  });
+
+  it('uses default port and host', () => {
+    const result = getServerStatus();
+    expect(result.port).toBe(DEFAULT_PORT);
+    expect(result.host).toBe(DEFAULT_HOST);
+  });
+
+  it('accepts custom port and host', () => {
+    const result = getServerStatus({ port: 9000, host: '127.0.0.1' });
+    expect(result.port).toBe(9000);
+    expect(result.host).toBe('127.0.0.1');
+  });
+
+  it('uptime is null', () => {
+    expect(getServerStatus().uptime).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Ports all 16 remaining legacy modules from `bin/lib/*.js` to `src/lib/*.ts` with full TypeScript strict compliance (`exactOptionalPropertyTypes` + `noUncheckedIndexedAccess`)
- Adds 16 modules: `guided-handoff`, `portfolio-reporting`, `requirements-baseline`, `root-cause-analysis`, `runtime-debugger`, `scanner`, `semantic-diff`, `sla-slo`, `spec-comments`, `spec-maturity`, `sre-integration`, `telemetry-feedback`, `test-generator`, `tool-guardrails`, `transcript-ingestion`, `web-dashboard`
- Wires all 16 into `cleanup.ts` `TS_PORTS` static import map (replaces `legacyRequire` for these modules)
- M3 hardening: `rejectPollutionKeys()` on all JSON `loadState` parse paths
- ADR-006 compliance: no `process.exit()` in library code
- ADR-009 path-safety: user-supplied paths validated via CLI wiring

## Test plan

- [ ] All 16 modules have 15–28 vitest tests each (total 4170 tests passing)
- [ ] Prototype-pollution tests use raw JSON bytes (`__proto__`, `constructor` keys)
- [ ] `npm run verify-baseline` passes 12/12 checks
- [ ] `npx tsc --noEmit` 0 errors
- [ ] `npm run lint` 0 errors, 0 warnings