### PR TITLE
feat(m11-phase5a): add context7-setup citty subcommand

### DIFF
--- a/src/cli/commands/lifecycle.ts
+++ b/src/cli/commands/lifecycle.ts
@@ -37,6 +37,7 @@ import {
   renderApprovalResult,
   renderRejectionResult,
 } from '../../lib/approve.js';
+import { setupContext7 } from '../../lib/context7-setup.js';
 import {
   buildFocusConfig,
   clearFocusFromConfig,
@@ -503,6 +504,47 @@ export const initCommand = defineCommand({
       json: Boolean(args.json),
     });
     if (r.exitCode !== 0) throw new Error(r.message ?? 'init failed');
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// context7-setup
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Replaces the legacy `bin/context7-setup.js` standalone script. Wraps the
+ * existing `setupContext7()` library function with a citty entry point so
+ * users invoke it as `npx @scombey/jumpstart-mode context7-setup` rather
+ * than running the legacy file directly.
+ */
+export const context7SetupCommand = defineCommand({
+  meta: {
+    name: 'context7-setup',
+    description: 'Configure the Context7 MCP integration for your AI assistant',
+  },
+  args: {
+    dryRun: {
+      type: 'boolean',
+      description: 'Show what would be configured without writing files',
+      required: false,
+    },
+    targetDir: {
+      type: 'string',
+      description: 'Target project directory (defaults to cwd)',
+      required: false,
+    },
+  },
+  async run({ args }) {
+    const targetDir = args.targetDir ?? process.cwd();
+    const outcome = await setupContext7({
+      targetDir,
+      dryRun: Boolean(args.dryRun),
+    });
+    if (!outcome.installed && !args.dryRun) {
+      // The setup flow exited early (user opted out, prompts unavailable, etc.).
+      // Not a failure — just nothing was written.
+      return;
+    }
   },
 });
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -147,6 +147,9 @@ const subCommands: Record<string, () => Promise<CommandDef>> = {
   ),
   focus: lazy(() => import('./commands/lifecycle.js').then((m) => m.focusCommand)),
   init: lazy(() => import('./commands/lifecycle.js').then((m) => m.initCommand)),
+  'context7-setup': lazy(() =>
+    import('./commands/lifecycle.js').then((m) => m.context7SetupCommand)
+  ),
   lock: lazy(() => import('./commands/lifecycle.js').then((m) => m.lockCommand)),
   memory: lazy(() => import('./commands/lifecycle.js').then((m) => m.memoryCommand)),
   rewind: lazy(() => import('./commands/lifecycle.js').then((m) => m.rewindCommand)),


### PR DESCRIPTION
## Summary
- Adds the missing 4th citty subcommand (\`context7-setup\`) so the 4-wrapper coverage gap closes (\`headless\`, \`verify\`, \`holodeck\` already had citty entries via \`runners.ts\`)
- 2 files changed, +45 lines
- Wrapper file deletes (\`bin/headless-runner.js\` etc.) deferred to phase 5e — they need arg-shape migration in callers (\`package.json\` scripts, e2e workflow, verify-baseline)

## What changed
- \`src/cli/commands/lifecycle.ts\` — new \`context7SetupCommand\` delegating to the existing \`setupContext7()\` library function
- \`src/cli/main.ts\` — wires \`context7-setup\` into the lazy-import subcommand map

## Test plan
- [x] \`npm run verify-baseline\` → 12/12 gates green
- [x] \`npx tsc --noEmit\` → 0 errors with strict flags ON
- [x] \`npm run lint\` (biome) → 0 errors, 0 warnings
- [x] \`node dist/cli/bin.mjs --help\` shows \`context7-setup\` in COMMANDS
- [ ] CI green on PR

Refs #53