### PR TITLE
feat(m11-batch7): port 17 orphan legacy modules

### DIFF
--- a/src/cli/commands/deferred.ts
+++ b/src/cli/commands/deferred.ts
@@ -57,6 +57,10 @@ import {
   applyConfigPatches as qsApplyConfigPatches,
   generateQuickstartSummary as qsGenerateSummary,
 } from '../../lib/quickstart.js';
+import {
+  analyzeAndPropose as selfEvolveAnalyze,
+  generateProposalArtifact as selfEvolveGenerateArtifact,
+} from '../../lib/self-evolve.js';
 import { type CommandResult, createRealDeps, type Deps } from '../deps.js';
 import { asRest, hasFlag, parseFlag, safeJoin } from './_helpers.js';
 
@@ -68,24 +72,13 @@ export interface SelfEvolveArgs {
   artifact?: boolean | undefined;
 }
 
-interface SelfEvolveLib {
-  // biome-ignore lint/suspicious/noExplicitAny: <legacy ESM lib returns dynamic shape — narrowed at call site>
-  analyzeAndPropose: (projectDir: string) => any;
-  // biome-ignore lint/suspicious/noExplicitAny: <legacy ESM lib returns dynamic shape — narrowed at call site>
-  generateProposalArtifact: (result: any) => string;
-}
-
-export async function selfEvolveImpl(deps: Deps, args: SelfEvolveArgs): Promise<CommandResult> {
-  // bin/lib/self-evolve.mjs is ESM (uses `export`), so it must be loaded via
-  // dynamic import — `legacyRequire` would fail with ERR_REQUIRE_ESM.
-  const mod = (await import(
-    path.join(deps.projectRoot, 'bin', 'lib', 'self-evolve.js')
-  )) as SelfEvolveLib;
-  const result = mod.analyzeAndPropose(deps.projectRoot);
+export function selfEvolveImpl(deps: Deps, args: SelfEvolveArgs): CommandResult {
+  // M11 batch7: self-evolve is now a TS port — use direct imports.
+  const result = selfEvolveAnalyze(deps.projectRoot);
   if (args.artifact) {
-    deps.logger.info(mod.generateProposalArtifact(result));
+    deps.logger.info(selfEvolveGenerateArtifact(result));
   } else {
-    writeResult(result as Record<string, unknown>);
+    writeResult(result as unknown as Record<string, unknown>);
   }
   return { exitCode: 0 };
 }

--- a/src/cli/commands/deferred.ts
+++ b/src/cli/commands/deferred.ts
@@ -52,6 +52,11 @@ import {
   renderMarkdown as renderTimelineMarkdown,
   type TimelineFilters,
 } from '../../lib/timeline.js';
+import {
+  buildQuickstartConfig as qsBuildConfig,
+  applyConfigPatches as qsApplyConfigPatches,
+  generateQuickstartSummary as qsGenerateSummary,
+} from '../../lib/quickstart.js';
 import { type CommandResult, createRealDeps, type Deps } from '../deps.js';
 import { asRest, hasFlag, parseFlag, safeJoin } from './_helpers.js';
 
@@ -361,32 +366,6 @@ export interface QuickstartArgs {
   ceremony?: string | undefined;
 }
 
-interface QuickstartLib {
-  DOMAIN_OPTIONS: { value: string; title: string; description: string }[];
-  CEREMONY_OPTIONS: { value: string; title: string; description: string }[];
-  buildQuickstartConfig: (answers: {
-    projectName?: string | null | undefined;
-    projectType?: string | undefined;
-    domain?: string | undefined;
-    customDomain?: string | null | undefined;
-    ceremony?: string | undefined;
-    targetDir?: string | undefined;
-  }) => {
-    targetDir: string;
-    projectName: string | null;
-    projectType: string;
-    domain: string;
-    ceremony: string;
-    [key: string]: unknown;
-  };
-  generateQuickstartSummary: (config: unknown) => {
-    lines: string[];
-    firstCommand: string;
-    firstMessage: string;
-  };
-  applyConfigPatches: (content: string, config: unknown) => string;
-}
-
 const VALID_QUICKSTART_TYPES = new Set(['greenfield', 'brownfield']);
 const VALID_QUICKSTART_CEREMONIES = new Set(['light', 'standard', 'rigorous']);
 
@@ -430,11 +409,8 @@ export async function quickstartImpl(deps: Deps, args: QuickstartArgs): Promise<
     return { exitCode: 1 };
   }
 
-  const lib = (await import(
-    path.join(deps.projectRoot, 'bin', 'lib', 'quickstart.js')
-  )) as QuickstartLib;
-
-  const qsConfig = lib.buildQuickstartConfig({
+  // M11 batch7: quickstart is now a TS port — use direct imports.
+  const qsConfig = qsBuildConfig({
     projectName: args.name,
     projectType: args.type,
     domain: args.domain,
@@ -447,11 +423,11 @@ export async function quickstartImpl(deps: Deps, args: QuickstartArgs): Promise<
   const configPath = safeJoin(deps, '.jumpstart', 'config.yaml');
   if (existsSync(configPath)) {
     const content = readFileSync(configPath, 'utf8');
-    const patched = lib.applyConfigPatches(content, qsConfig);
+    const patched = qsApplyConfigPatches(content, qsConfig);
     writeFileSync(configPath, patched, 'utf8');
   }
 
-  const summary = lib.generateQuickstartSummary(qsConfig);
+  const summary = qsGenerateSummary(qsConfig);
   deps.logger.success('JumpStart initialized!');
   for (const line of summary.lines) deps.logger.info(`  ${line}`);
   deps.logger.info(`  ▶ Type ${summary.firstCommand} to begin!`);

--- a/src/cli/commands/deferred.ts
+++ b/src/cli/commands/deferred.ts
@@ -39,11 +39,19 @@
  */
 
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
-import * as path from 'node:path';
 import { defineCommand } from 'citty';
 import { generateContextPacket, renderContextMarkdown } from '../../lib/context-summarizer.js';
 import { writeResult } from '../../lib/io.js';
 import * as legacyProactiveValidator from '../../lib/proactive-validator.js';
+import {
+  applyConfigPatches as qsApplyConfigPatches,
+  buildQuickstartConfig as qsBuildConfig,
+  generateQuickstartSummary as qsGenerateSummary,
+} from '../../lib/quickstart.js';
+import {
+  analyzeAndPropose as selfEvolveAnalyze,
+  generateProposalArtifact as selfEvolveGenerateArtifact,
+} from '../../lib/self-evolve.js';
 import {
   clearTimeline,
   generateTimelineReport,
@@ -52,15 +60,6 @@ import {
   renderMarkdown as renderTimelineMarkdown,
   type TimelineFilters,
 } from '../../lib/timeline.js';
-import {
-  buildQuickstartConfig as qsBuildConfig,
-  applyConfigPatches as qsApplyConfigPatches,
-  generateQuickstartSummary as qsGenerateSummary,
-} from '../../lib/quickstart.js';
-import {
-  analyzeAndPropose as selfEvolveAnalyze,
-  generateProposalArtifact as selfEvolveGenerateArtifact,
-} from '../../lib/self-evolve.js';
 import { type CommandResult, createRealDeps, type Deps } from '../deps.js';
 import { asRest, hasFlag, parseFlag, safeJoin } from './_helpers.js';
 

--- a/src/cli/commands/handoff.ts
+++ b/src/cli/commands/handoff.ts
@@ -24,6 +24,7 @@ import { writeResult } from '../../lib/io.js';
 import { generateCoverageReport } from '../../lib/coverage.js';
 import { checkBoundaries } from '../../lib/boundary-check.js';
 import { runLint as lintRunnerRunLint } from '../../lib/lint-runner.js';
+import { loadAllModules as moduleLoaderLoadAllModules } from '../../lib/module-loader.js';
 import { type CommandResult, createRealDeps, type Deps } from '../deps.js';
 import {
   assertUserPath,
@@ -316,12 +317,10 @@ export const diffCommand = defineCommand({
 // ─────────────────────────────────────────────────────────────────────────
 
 export function modulesImpl(deps: Deps): CommandResult {
-  const { loadAllModules } = legacyRequire<{
-    loadAllModules: (dir: string) => Record<string, unknown>;
-  }>('module-loader');
+  // M11 batch7: module-loader is now a TS port — use direct import.
   const modulesDir = safeJoin(deps, '.jumpstart', 'modules');
-  const result = loadAllModules(modulesDir);
-  writeResult(result);
+  const result = moduleLoaderLoadAllModules(modulesDir);
+  writeResult(result as unknown as Record<string, unknown>);
   return { exitCode: 0 };
 }
 

--- a/src/cli/commands/handoff.ts
+++ b/src/cli/commands/handoff.ts
@@ -22,6 +22,7 @@ import { existsSync } from 'node:fs';
 import { defineCommand } from 'citty';
 import { writeResult } from '../../lib/io.js';
 import { generateCoverageReport } from '../../lib/coverage.js';
+import { checkBoundaries } from '../../lib/boundary-check.js';
 import { type CommandResult, createRealDeps, type Deps } from '../deps.js';
 import {
   assertUserPath,
@@ -234,12 +235,9 @@ export const regulatoryCommand = defineCommand({
 // ─────────────────────────────────────────────────────────────────────────
 
 export function boundariesImpl(deps: Deps): CommandResult {
-  const { checkBoundaries } = legacyRequire<{
-    checkBoundaries: (specsDir: string) => Record<string, unknown>;
-  }>('boundary-check');
-  const specsDir = safeJoin(deps, 'specs');
-  const result = checkBoundaries(specsDir);
-  writeResult(result);
+  const root = deps.projectRoot;
+  const result = checkBoundaries({ root });
+  writeResult(result as unknown as Record<string, unknown>);
   return { exitCode: 0 };
 }
 

--- a/src/cli/commands/handoff.ts
+++ b/src/cli/commands/handoff.ts
@@ -23,6 +23,7 @@ import { defineCommand } from 'citty';
 import { writeResult } from '../../lib/io.js';
 import { generateCoverageReport } from '../../lib/coverage.js';
 import { checkBoundaries } from '../../lib/boundary-check.js';
+import { runLint as lintRunnerRunLint } from '../../lib/lint-runner.js';
 import { type CommandResult, createRealDeps, type Deps } from '../deps.js';
 import {
   assertUserPath,
@@ -154,20 +155,18 @@ export interface LintArgs {
   targetDir?: string | undefined;
 }
 
-export async function lintImpl(deps: Deps, args: LintArgs): Promise<CommandResult> {
-  const { runLint } = legacyRequire<{
-    runLint: (dir: string) => Promise<Record<string, unknown> & { ok?: boolean; pass?: boolean }>;
-  }>('lint-runner');
+export function lintImpl(deps: Deps, args: LintArgs): CommandResult {
+  // M11 batch7: lint-runner is now a TS port — use direct import.
   // Pit Crew M8 HIGH (Adversary 5 + Reviewer 2): containment on
   // user-supplied targetDir.
   const safeDir = args.targetDir
     ? assertUserPath(deps, args.targetDir, 'lint:targetDir')
     : deps.projectRoot;
-  const result = await runLint(safeDir);
-  writeResult(result);
+  const result = lintRunnerRunLint(safeDir);
+  writeResult(result as unknown as Record<string, unknown>);
   // Pit Crew M8 MED (Reviewer 5): pre-fix discarded result; lint
   // failures invisible to CI exit code. Post-fix: respect ok/pass.
-  const passed = result.ok !== false && result.pass !== false;
+  const passed = result.pass !== false;
   return { exitCode: passed ? 0 : 1 };
 }
 

--- a/src/cli/commands/handoff.ts
+++ b/src/cli/commands/handoff.ts
@@ -21,6 +21,7 @@
 import { existsSync } from 'node:fs';
 import { defineCommand } from 'citty';
 import { writeResult } from '../../lib/io.js';
+import { generateCoverageReport } from '../../lib/coverage.js';
 import { type CommandResult, createRealDeps, type Deps } from '../deps.js';
 import {
   assertUserPath,
@@ -99,10 +100,7 @@ export function coverageImpl(deps: Deps, args: CoverageArgs): CommandResult {
   // Pit Crew M8 BLOCKER (Adversary 2): containment on both user paths.
   const safePrd = assertUserPath(deps, args.prdPath, 'coverage:prd');
   const safePlan = assertUserPath(deps, args.planPath, 'coverage:plan');
-  const coverageMod = legacyRequire<{
-    generateCoverageReport: (prdPath: string, planPath: string) => string;
-  }>('coverage');
-  deps.logger.info(coverageMod.generateCoverageReport(safePrd, safePlan));
+  deps.logger.info(generateCoverageReport(safePrd, safePlan));
   return { exitCode: 0 };
 }
 

--- a/src/cli/commands/handoff.ts
+++ b/src/cli/commands/handoff.ts
@@ -20,9 +20,10 @@
 
 import { existsSync } from 'node:fs';
 import { defineCommand } from 'citty';
-import { writeResult } from '../../lib/io.js';
-import { generateCoverageReport } from '../../lib/coverage.js';
 import { checkBoundaries } from '../../lib/boundary-check.js';
+import { generateCoverageReport } from '../../lib/coverage.js';
+import { exportHandoffPackage as exportExportHandoffPackage } from '../../lib/export.js';
+import { writeResult } from '../../lib/io.js';
 import { runLint as lintRunnerRunLint } from '../../lib/lint-runner.js';
 import { loadAllModules as moduleLoaderLoadAllModules } from '../../lib/module-loader.js';
 import { type CommandResult, createRealDeps, type Deps } from '../deps.js';
@@ -377,17 +378,10 @@ export interface HandoffArgs {
 }
 
 export function handoffImpl(deps: Deps, args: HandoffArgs): CommandResult {
-  const { exportHandoffPackage } = legacyRequire<{
-    exportHandoffPackage: (opts: { root: string; outputPath?: string | undefined }) => {
-      success: boolean;
-      output_path?: string | undefined;
-      stats?: Record<string, number>;
-      error?: string | undefined;
-    };
-  }>('export');
+  // M11 batch7: export is now a TS port — use direct import.
   const outputPath = parseFlag(args.rest, 'output');
   const jsonMode = hasFlag(args.rest, 'json');
-  const result = exportHandoffPackage({ root: deps.projectRoot, outputPath });
+  const result = exportExportHandoffPackage({ root: deps.projectRoot, output: outputPath });
   if (jsonMode) {
     writeResult(result as unknown as Record<string, unknown>);
     return { exitCode: 0 };
@@ -401,7 +395,7 @@ export function handoffImpl(deps: Deps, args: HandoffArgs): CommandResult {
     }
     return { exitCode: 0 };
   }
-  deps.logger.error(result.error ?? 'handoff failed');
+  deps.logger.error('handoff failed');
   return { exitCode: 1 };
 }
 

--- a/src/cli/commands/lifecycle.ts
+++ b/src/cli/commands/lifecycle.ts
@@ -27,7 +27,6 @@
  */
 
 import { existsSync } from 'node:fs';
-import * as path from 'node:path';
 import { defineCommand } from 'citty';
 import * as legacyAgentCheckpoint from '../../lib/agent-checkpoint.js';
 import {
@@ -46,11 +45,11 @@ import {
   VALID_PRESETS,
   writeFocusToConfig,
 } from '../../lib/focus.js';
+import { generateInitConfig as initGenerateInitConfig } from '../../lib/init.js';
 import { writeResult } from '../../lib/io.js';
 import { acquireLock, listLocks, lockStatus, releaseLock } from '../../lib/locks.js';
 import { determineNextAction } from '../../lib/next-phase.js';
 import * as legacyPlanExecutor from '../../lib/plan-executor.js';
-import { generateInitConfig as initGenerateInitConfig } from '../../lib/init.js';
 import { renderRewindReport, rewindToPhase } from '../../lib/rewind.js';
 import { createCheckpoint, listCheckpoints, restoreCheckpoint } from '../../lib/state-store.js';
 import { type CommandResult, createRealDeps, type Deps } from '../deps.js';

--- a/src/cli/commands/lifecycle.ts
+++ b/src/cli/commands/lifecycle.ts
@@ -50,6 +50,7 @@ import { writeResult } from '../../lib/io.js';
 import { acquireLock, listLocks, lockStatus, releaseLock } from '../../lib/locks.js';
 import { determineNextAction } from '../../lib/next-phase.js';
 import * as legacyPlanExecutor from '../../lib/plan-executor.js';
+import { generateInitConfig as initGenerateInitConfig } from '../../lib/init.js';
 import { renderRewindReport, rewindToPhase } from '../../lib/rewind.js';
 import { createCheckpoint, listCheckpoints, restoreCheckpoint } from '../../lib/state-store.js';
 import { type CommandResult, createRealDeps, type Deps } from '../deps.js';
@@ -455,22 +456,11 @@ export interface InitArgs {
   json?: boolean | undefined;
 }
 
-interface InitLib {
-  generateInitConfig: (input: { skill_level: string; project_type: string }) => {
-    skill_level: string;
-    explanation_depth: string;
-    project_type: string;
-    recommendations: string[];
-  };
-}
-
-export async function initImpl(deps: Deps, args: InitArgs): Promise<CommandResult> {
-  // bin/lib/init.mjs is ESM (uses `export`), so it must be loaded via
-  // dynamic import — `legacyRequire` would fail with ERR_REQUIRE_ESM.
-  const initMod = (await import(path.join(deps.projectRoot, 'bin', 'lib', 'init.js'))) as InitLib;
+export function initImpl(deps: Deps, args: InitArgs): CommandResult {
+  // M11 batch7: init is now a TS port — use direct import.
   const skillLevel = args.skillLevel ?? 'intermediate';
   const projectType = args.type ?? 'greenfield';
-  const result = initMod.generateInitConfig({
+  const result = initGenerateInitConfig({
     skill_level: skillLevel,
     project_type: projectType,
   });

--- a/src/cli/commands/spec-validation.ts
+++ b/src/cli/commands/spec-validation.ts
@@ -31,6 +31,7 @@ import { generateReport as generateInvariantsReport } from '../../lib/invariants
 import { shouldShard, extractEpics, generateShard, generateIndex } from '../../lib/sharder.js';
 import { check as simplicityCheck } from '../../lib/simplicity-gate.js';
 import { checkForChanges as templateCheckForChanges } from '../../lib/template-watcher.js';
+import { runAllChecks as specTesterRunAllChecks, generateReport as specTesterGenerateReport } from '../../lib/spec-tester.js';
 import { type CommandResult, createRealDeps, type Deps } from '../deps.js';
 import { assertUserPath, legacyRequire, safeJoin } from './_helpers.js';
 
@@ -435,21 +436,13 @@ export function checklistImpl(deps: Deps, args: ChecklistArgs): CommandResult {
     deps.logger.error(`File not found: ${args.path}`);
     return { exitCode: 1 };
   }
-  const specTester = legacyRequire<{
-    runAllChecks: (content: string, opts: { specsDir: string }) => { pass?: boolean } | unknown;
-    generateReport: (filePath: string) => string;
-  }>('spec-tester');
   const content = readFileSync(safePath, 'utf8');
   // Pit Crew M8 HIGH (Reviewer 4): pre-fix `void specTester.runAllChecks(...)`
-  // discarded the result — exit code was always 0 even when checks failed.
+  // discarded the result -- exit code was always 0 even when checks failed.
   // Post-fix: capture result, exit non-zero on `pass === false`.
-  const result = specTester.runAllChecks(content, { specsDir: safeJoin(deps, 'specs') });
-  deps.logger.info(specTester.generateReport(safePath));
-  const passed =
-    typeof result === 'object' && result !== null && 'pass' in result
-      ? (result as { pass: boolean }).pass !== false
-      : true;
-  return { exitCode: passed ? 0 : 1 };
+  const result = specTesterRunAllChecks(content, { specsDir: safeJoin(deps, 'specs') });
+  deps.logger.info(specTesterGenerateReport(safePath));
+  return { exitCode: result.pass ? 0 : 1 };
 }
 
 export const checklistCommand = defineCommand({

--- a/src/cli/commands/spec-validation.ts
+++ b/src/cli/commands/spec-validation.ts
@@ -29,6 +29,7 @@ import { writeResult } from '../../lib/io.js';
 import { generateAuditReport } from '../../lib/freshness-gate.js';
 import { generateReport as generateInvariantsReport } from '../../lib/invariants-check.js';
 import { shouldShard, extractEpics, generateShard, generateIndex } from '../../lib/sharder.js';
+import { check as simplicityCheck } from '../../lib/simplicity-gate.js';
 import { type CommandResult, createRealDeps, type Deps } from '../deps.js';
 import { assertUserPath, legacyRequire, safeJoin } from './_helpers.js';
 
@@ -220,15 +221,13 @@ export interface SimplicityArgs {
 }
 
 export function simplicityImpl(deps: Deps, args: SimplicityArgs): CommandResult {
-  const simplicity = legacyRequire<{
-    check: (dir: string) => { pass: boolean; count: number; max: number };
-  }>('simplicity-gate');
-  const result = simplicity.check(args.targetDir ?? 'src');
-  if (result.pass) {
+  const targetDir = args.targetDir ?? 'src';
+  const result = simplicityCheck({ projectDir: targetDir });
+  if (result.passed) {
     deps.logger.success(`Simplicity gate passed (${result.count} top-level dirs).`);
     return { exitCode: 0 };
   }
-  deps.logger.error(`Simplicity gate failed: ${result.count} top-level dirs (max ${result.max}).`);
+  deps.logger.error(result.message);
   deps.logger.warn('  Add a justification section to the Architecture Document.');
   return { exitCode: 1 };
 }

--- a/src/cli/commands/spec-validation.ts
+++ b/src/cli/commands/spec-validation.ts
@@ -26,6 +26,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import * as path from 'node:path';
 import { defineCommand } from 'citty';
 import { writeResult } from '../../lib/io.js';
+import { generateAuditReport } from '../../lib/freshness-gate.js';
 import { type CommandResult, createRealDeps, type Deps } from '../deps.js';
 import { assertUserPath, legacyRequire, safeJoin } from './_helpers.js';
 
@@ -349,11 +350,8 @@ export const templateCheckCommand = defineCommand({
 // ─────────────────────────────────────────────────────────────────────────
 
 export function freshnessAuditImpl(deps: Deps): CommandResult {
-  const freshness = legacyRequire<{
-    generateAuditReport: (specsDir: string) => string;
-  }>('freshness-gate');
   const specsDir = safeJoin(deps, 'specs');
-  const report = freshness.generateAuditReport(specsDir);
+  const report = generateAuditReport(specsDir);
   deps.logger.info(report);
   return { exitCode: 0 };
 }

--- a/src/cli/commands/spec-validation.ts
+++ b/src/cli/commands/spec-validation.ts
@@ -25,13 +25,16 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import * as path from 'node:path';
 import { defineCommand } from 'citty';
-import { writeResult } from '../../lib/io.js';
 import { generateAuditReport } from '../../lib/freshness-gate.js';
 import { generateReport as generateInvariantsReport } from '../../lib/invariants-check.js';
-import { shouldShard, extractEpics, generateShard, generateIndex } from '../../lib/sharder.js';
+import { writeResult } from '../../lib/io.js';
+import { extractEpics, generateIndex, generateShard, shouldShard } from '../../lib/sharder.js';
 import { check as simplicityCheck } from '../../lib/simplicity-gate.js';
+import {
+  generateReport as specTesterGenerateReport,
+  runAllChecks as specTesterRunAllChecks,
+} from '../../lib/spec-tester.js';
 import { checkForChanges as templateCheckForChanges } from '../../lib/template-watcher.js';
-import { runAllChecks as specTesterRunAllChecks, generateReport as specTesterGenerateReport } from '../../lib/spec-tester.js';
 import { type CommandResult, createRealDeps, type Deps } from '../deps.js';
 import { assertUserPath, legacyRequire, safeJoin } from './_helpers.js';
 

--- a/src/cli/commands/spec-validation.ts
+++ b/src/cli/commands/spec-validation.ts
@@ -30,6 +30,7 @@ import { generateAuditReport } from '../../lib/freshness-gate.js';
 import { generateReport as generateInvariantsReport } from '../../lib/invariants-check.js';
 import { shouldShard, extractEpics, generateShard, generateIndex } from '../../lib/sharder.js';
 import { check as simplicityCheck } from '../../lib/simplicity-gate.js';
+import { checkForChanges as templateCheckForChanges } from '../../lib/template-watcher.js';
 import { type CommandResult, createRealDeps, type Deps } from '../deps.js';
 import { assertUserPath, legacyRequire, safeJoin } from './_helpers.js';
 
@@ -314,21 +315,15 @@ export const invariantsCommand = defineCommand({
 // ─────────────────────────────────────────────────────────────────────────
 
 export function templateCheckImpl(deps: Deps): CommandResult {
-  const watcher = legacyRequire<{
-    checkForChanges: (
-      templatesDir: string,
-      snapshotPath: string
-    ) => { template: string; changeType: string }[];
-  }>('template-watcher');
   const templatesDir = safeJoin(deps, '.jumpstart', 'templates');
   const snapshotPath = safeJoin(deps, '.jumpstart', 'state', 'template-snapshot.json');
-  const changes = watcher.checkForChanges(templatesDir, snapshotPath);
-  if (changes.length === 0) {
+  const result = templateCheckForChanges(templatesDir, snapshotPath);
+  if (!result.changed) {
     deps.logger.success('All templates unchanged.');
     return { exitCode: 0 };
   }
-  deps.logger.warn(`${changes.length} template(s) changed:`);
-  for (const c of changes) deps.logger.warn(`  ${c.template}: ${c.changeType}`);
+  deps.logger.warn(`${result.warnings.length} template(s) changed:`);
+  for (const w of result.warnings) deps.logger.warn(`  ${w}`);
   return { exitCode: 0 };
 }
 

--- a/src/cli/commands/spec-validation.ts
+++ b/src/cli/commands/spec-validation.ts
@@ -27,6 +27,7 @@ import * as path from 'node:path';
 import { defineCommand } from 'citty';
 import { writeResult } from '../../lib/io.js';
 import { generateAuditReport } from '../../lib/freshness-gate.js';
+import { generateReport as generateInvariantsReport } from '../../lib/invariants-check.js';
 import { type CommandResult, createRealDeps, type Deps } from '../deps.js';
 import { assertUserPath, legacyRequire, safeJoin } from './_helpers.js';
 
@@ -290,12 +291,9 @@ export const scanWrappersCommand = defineCommand({
 // ─────────────────────────────────────────────────────────────────────────
 
 export function invariantsImpl(deps: Deps): CommandResult {
-  const invariants = legacyRequire<{
-    generateReport: (invariantsPath: string, specsDir: string) => Record<string, unknown>;
-  }>('invariants-check');
   const invariantsPath = safeJoin(deps, '.jumpstart', 'invariants.md');
   const specsDir = safeJoin(deps, 'specs');
-  const report = invariants.generateReport(invariantsPath, specsDir);
+  const report = generateInvariantsReport(invariantsPath, specsDir);
   writeResult(report);
   return { exitCode: 0 };
 }

--- a/src/cli/commands/spec-validation.ts
+++ b/src/cli/commands/spec-validation.ts
@@ -28,6 +28,7 @@ import { defineCommand } from 'citty';
 import { writeResult } from '../../lib/io.js';
 import { generateAuditReport } from '../../lib/freshness-gate.js';
 import { generateReport as generateInvariantsReport } from '../../lib/invariants-check.js';
+import { shouldShard, extractEpics, generateShard, generateIndex } from '../../lib/sharder.js';
 import { type CommandResult, createRealDeps, type Deps } from '../deps.js';
 import { assertUserPath, legacyRequire, safeJoin } from './_helpers.js';
 
@@ -294,7 +295,7 @@ export function invariantsImpl(deps: Deps): CommandResult {
   const invariantsPath = safeJoin(deps, '.jumpstart', 'invariants.md');
   const specsDir = safeJoin(deps, 'specs');
   const report = generateInvariantsReport(invariantsPath, specsDir);
-  writeResult(report);
+  writeResult(report as unknown as Record<string, unknown>);
   return { exitCode: 0 };
 }
 
@@ -374,38 +375,33 @@ export interface ShardArgs {
 }
 
 export function shardImpl(deps: Deps, args: ShardArgs): CommandResult {
-  const sharder = legacyRequire<{
-    shouldShard: (content: string) => boolean;
-    extractEpics: (content: string) => { id: string }[];
-    generateShard: (epic: { id: string }, idx: number) => string;
-    generateIndex: (epics: { id: string }[]) => string;
-  }>('sharder');
   const prdPath = args.prdPath ?? safeJoin(deps, 'specs', 'prd.md');
   if (!existsSync(prdPath)) {
     deps.logger.error(`PRD not found: ${prdPath}`);
     return { exitCode: 1 };
   }
   const content = readFileSync(prdPath, 'utf8');
-  if (!sharder.shouldShard(content)) {
+  const shardDecision = shouldShard(content);
+  if (!shardDecision.shouldShard) {
     deps.logger.success('PRD is within context window limits. No sharding needed.');
     return { exitCode: 0 };
   }
-  const epics = sharder.extractEpics(content);
+  const epics = extractEpics(content);
   deps.logger.info(`Found ${epics.length} epic(s). Generating shards...`);
   const shardDir = safeJoin(deps, 'specs', 'prd');
   if (!existsSync(shardDir)) mkdirSync(shardDir, { recursive: true });
+  const shardDescriptors = [];
   for (let i = 0; i < epics.length; i++) {
     const epic = epics[i];
     if (epic === undefined) continue;
-    const shard = sharder.generateShard(epic, i + 1);
-    const shardPath = path.join(
-      shardDir,
-      `prd-${String(i + 1).padStart(3, '0')}-${epic.id.toLowerCase()}.md`
-    );
+    const shard = generateShard(content, [epic.id], i + 1);
+    const shardFile = `prd-${String(i + 1).padStart(3, '0')}-${epic.id.toLowerCase()}.md`;
+    const shardPath = path.join(shardDir, shardFile);
     writeFileSync(shardPath, shard, 'utf8');
     deps.logger.success(`  ${shardPath}`);
+    shardDescriptors.push({ index: i + 1, epicIds: [epic.id], filePath: `specs/prd/${shardFile}` });
   }
-  const index = sharder.generateIndex(epics);
+  const index = generateIndex(shardDescriptors);
   writeFileSync(path.join(shardDir, 'index.md'), index, 'utf8');
   deps.logger.success('  Index generated.');
   return { exitCode: 0 };

--- a/src/lib/boundary-check.ts
+++ b/src/lib/boundary-check.ts
@@ -1,0 +1,244 @@
+/**
+ * boundary-check.ts -- Boundary Validation (Item 74).
+ *
+ * Validates that the implementation plan does not drift beyond the
+ * "Constraints and Boundaries" defined in the product brief.
+ *
+ * M3 hardening: no JSON state -- pure text processing.
+ * ADR-009: brief/plan paths must be pre-validated by caller.
+ * ADR-006: no process.exit.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface Boundary {
+  type: string;
+  statement: string;
+}
+
+export interface PlanTask {
+  id: string;
+  description: string;
+  scope_terms: string[];
+}
+
+export interface Violation {
+  boundary: string;
+  boundary_type: string;
+  excluded_term: string;
+  found_in: string;
+  severity: string;
+}
+
+export interface Warning {
+  message: string;
+  severity: string;
+}
+
+export interface BoundaryCheckResult {
+  boundaries: Boundary[];
+  violations: Violation[];
+  warnings: Warning[];
+  task_count: number;
+  boundary_count: number;
+  score: number;
+  pass: boolean;
+  error?: string | undefined;
+}
+
+export interface CheckBoundariesInput {
+  brief?: string | undefined;
+  plan?: string | undefined;
+  root?: string | undefined;
+}
+
+const BOUNDARY_HEADERS: RegExp[] = [
+  /^#{2,4}\s+(?:constraints?\s+(?:and\s+)?)?boundar(?:y|ies)/i,
+  /^#{2,4}\s+out\s+of\s+scope/i,
+  /^#{2,4}\s+exclusions?/i,
+  /^#{2,4}\s+constraints?/i,
+  /^#{2,4}\s+(?:what\s+(?:we|this)\s+(?:will\s+)?)?not\s+(?:do|build|include)/i,
+  /^#{2,4}\s+limitations?/i,
+  /^#{2,4}\s+scope\s+(?:boundaries|limits)/i,
+];
+
+/**
+ * Extract boundary statements from the product brief.
+ */
+export function extractBoundaries(content: string): Boundary[] {
+  const boundaries: Boundary[] = [];
+  const lines = content.split('\n');
+  let inBoundarySection = false;
+  let sectionType = '';
+
+  for (const line of lines) {
+    for (const pattern of BOUNDARY_HEADERS) {
+      if (pattern.test(line)) {
+        inBoundarySection = true;
+        sectionType = line.replace(/^#+\s+/, '').trim();
+        break;
+      }
+    }
+
+    if (inBoundarySection && /^#{1,4}\s+/.test(line) && !BOUNDARY_HEADERS.some(p => p.test(line))) {
+      inBoundarySection = false;
+      continue;
+    }
+
+    if (inBoundarySection) {
+      const bulletMatch = line.match(/^\s*[-*+]\s+(.+)/);
+      if (bulletMatch) {
+        boundaries.push({ type: sectionType, statement: (bulletMatch[1] ?? '').trim() });
+      }
+      const numMatch = line.match(/^\s*\d+[.)]\s+(.+)/);
+      if (numMatch) {
+        boundaries.push({ type: sectionType, statement: (numMatch[1] ?? '').trim() });
+      }
+    }
+  }
+
+  return boundaries;
+}
+
+const TECH_REGEX = /\b((?:React|Angular|Vue|Svelte|Next|Nuxt|Express|Fastify|Django|Flask|Rails|Spring|Laravel|Prisma|Sequelize|TypeORM|MongoDB|PostgreSQL|MySQL|Redis|GraphQL|REST|gRPC|Docker|Kubernetes|AWS|Azure|GCP|Firebase|Supabase|Vercel|Netlify|Heroku)(?:\.js)?)\b/gi;
+
+/**
+ * Extract task descriptions and scope indicators from the implementation plan.
+ */
+export function extractPlanScope(content: string): PlanTask[] {
+  const tasks: PlanTask[] = [];
+  const taskSections = content.split(/###\s+/);
+
+  for (const section of taskSections) {
+    const idMatch = section.match(/^(M\d+-T\d+)\s*[:\-—]\s*(.+)/);
+    if (!idMatch) continue;
+
+    const id = idMatch[1] ?? '';
+    const description = (idMatch[2] ?? '').trim();
+
+    const scopeTerms: string[] = [];
+    TECH_REGEX.lastIndex = 0;
+    let tm: RegExpExecArray | null;
+    while ((tm = TECH_REGEX.exec(section)) !== null) {
+      scopeTerms.push(tm[1] ?? '');
+    }
+
+    tasks.push({ id, description, scope_terms: Array.from(new Set(scopeTerms)) });
+  }
+
+  return tasks;
+}
+
+// Stop-words to skip when extracting key terms from exclusion phrases.
+const STOP_WORDS = new Set(['the', 'a', 'an', 'in', 'on', 'at', 'to', 'for', 'of', 'and', 'or', 'but', 'not', 'use', 'using', 'with', 'from', 'any', 'this', 'that', 'it', 'its', 'be', 'is', 'are', 'was', 'been', 'our', 'we', 'will', 'do', 'as', 'no', 'into', 'all', 'within', 'without', 'should', 'must', 'only', 'also', 'when', 'implementation', 'codebase', 'project', 'solution', 'code', 'system', 'service', 'app']);
+
+function extractKeyTerms(phrase: string): string[] {
+  return phrase.split(/\s+/)
+    .map(w => w.replace(/[^a-z0-9_\-]/g, '').toLowerCase())
+    .filter(w => w.length > 3 && !STOP_WORDS.has(w));
+}
+
+/**
+ * Check plan against boundaries.
+ */
+export function checkBoundaries(input: CheckBoundariesInput): BoundaryCheckResult {
+  const {
+    brief = 'specs/product-brief.md',
+    plan = 'specs/implementation-plan.md',
+    root = '.'
+  } = input;
+
+  const briefPath = path.resolve(root, brief);
+  const planPath = path.resolve(root, plan);
+
+  let briefContent = '';
+  let planContent = '';
+
+  try {
+    briefContent = fs.readFileSync(briefPath, 'utf8');
+  } catch {
+    return { error: `Cannot read brief: ${briefPath}`, pass: false, score: 0, boundaries: [], violations: [], warnings: [], task_count: 0, boundary_count: 0 };
+  }
+
+  try {
+    planContent = fs.readFileSync(planPath, 'utf8');
+  } catch {
+    return { error: `Cannot read plan: ${planPath}`, pass: false, score: 0, boundaries: [], violations: [], warnings: [], task_count: 0, boundary_count: 0 };
+  }
+
+  const boundaries = extractBoundaries(briefContent);
+  const tasks = extractPlanScope(planContent);
+  const violations: Violation[] = [];
+  const warnings: Warning[] = [];
+  const planLower = planContent.toLowerCase();
+
+  for (const boundary of boundaries) {
+    const stmt = boundary.statement.toLowerCase();
+
+    const exclusionPatterns = [
+      /\bno\s+(\w+)/g,
+      /\bnot\s+(?:include|build|implement|support|use)\s+(.+)/g,
+      /\bexclude[sd]?\s+(.+)/g,
+      /\bavoid\s+(.+)/g,
+      /\bwithout\s+(.+)/g,
+      /\bwill\s+not\s+(.+)/g,
+      /\bdo\s+not\s+(?:use\s+)?(.+)/g,
+    ];
+
+    for (const pattern of exclusionPatterns) {
+      let em: RegExpExecArray | null;
+      while ((em = pattern.exec(stmt)) !== null) {
+        const captured = (em[1] ?? '').trim().replace(/[.,;]$/, '');
+
+        // For single-word captures (e.g. "no mongodb"), check the word directly.
+        if (!captured.includes(' ') && captured.length > 3) {
+          if (planLower.includes(captured)) {
+            violations.push({
+              boundary: boundary.statement,
+              boundary_type: boundary.type,
+              excluded_term: captured,
+              found_in: 'implementation-plan.md',
+              severity: 'major'
+            });
+          }
+        } else {
+          // For multi-word captures, extract meaningful tech keywords and check each.
+          const keyTerms = extractKeyTerms(captured);
+          for (const term of keyTerms) {
+            if (planLower.includes(term)) {
+              violations.push({
+                boundary: boundary.statement,
+                boundary_type: boundary.type,
+                excluded_term: term,
+                found_in: 'implementation-plan.md',
+                severity: 'major'
+              });
+              break; // one violation per boundary statement per pattern match
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (boundaries.length === 0) {
+    warnings.push({
+      message: 'No boundary statements found in product brief. Consider adding a "Constraints and Boundaries" section.',
+      severity: 'minor'
+    });
+  }
+
+  const totalChecks = Math.max(1, boundaries.length);
+  const score = Math.max(0, Math.round(((totalChecks - violations.length) / totalChecks) * 100));
+
+  return {
+    boundaries,
+    violations,
+    warnings,
+    task_count: tasks.length,
+    boundary_count: boundaries.length,
+    score,
+    pass: violations.filter(v => v.severity === 'major').length === 0
+  };
+}

--- a/src/lib/boundary-check.ts
+++ b/src/lib/boundary-check.ts
@@ -9,8 +9,8 @@
  * ADR-006: no process.exit.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 export interface Boundary {
   type: string;
@@ -81,7 +81,11 @@ export function extractBoundaries(content: string): Boundary[] {
       }
     }
 
-    if (inBoundarySection && /^#{1,4}\s+/.test(line) && !BOUNDARY_HEADERS.some(p => p.test(line))) {
+    if (
+      inBoundarySection &&
+      /^#{1,4}\s+/.test(line) &&
+      !BOUNDARY_HEADERS.some((p) => p.test(line))
+    ) {
       inBoundarySection = false;
       continue;
     }
@@ -101,7 +105,8 @@ export function extractBoundaries(content: string): Boundary[] {
   return boundaries;
 }
 
-const TECH_REGEX = /\b((?:React|Angular|Vue|Svelte|Next|Nuxt|Express|Fastify|Django|Flask|Rails|Spring|Laravel|Prisma|Sequelize|TypeORM|MongoDB|PostgreSQL|MySQL|Redis|GraphQL|REST|gRPC|Docker|Kubernetes|AWS|Azure|GCP|Firebase|Supabase|Vercel|Netlify|Heroku)(?:\.js)?)\b/gi;
+const TECH_REGEX =
+  /\b((?:React|Angular|Vue|Svelte|Next|Nuxt|Express|Fastify|Django|Flask|Rails|Spring|Laravel|Prisma|Sequelize|TypeORM|MongoDB|PostgreSQL|MySQL|Redis|GraphQL|REST|gRPC|Docker|Kubernetes|AWS|Azure|GCP|Firebase|Supabase|Vercel|Netlify|Heroku)(?:\.js)?)\b/gi;
 
 /**
  * Extract task descriptions and scope indicators from the implementation plan.
@@ -119,8 +124,9 @@ export function extractPlanScope(content: string): PlanTask[] {
 
     const scopeTerms: string[] = [];
     TECH_REGEX.lastIndex = 0;
-    let tm: RegExpExecArray | null;
-    while ((tm = TECH_REGEX.exec(section)) !== null) {
+    for (;;) {
+      const tm = TECH_REGEX.exec(section);
+      if (tm === null) break;
       scopeTerms.push(tm[1] ?? '');
     }
 
@@ -131,12 +137,64 @@ export function extractPlanScope(content: string): PlanTask[] {
 }
 
 // Stop-words to skip when extracting key terms from exclusion phrases.
-const STOP_WORDS = new Set(['the', 'a', 'an', 'in', 'on', 'at', 'to', 'for', 'of', 'and', 'or', 'but', 'not', 'use', 'using', 'with', 'from', 'any', 'this', 'that', 'it', 'its', 'be', 'is', 'are', 'was', 'been', 'our', 'we', 'will', 'do', 'as', 'no', 'into', 'all', 'within', 'without', 'should', 'must', 'only', 'also', 'when', 'implementation', 'codebase', 'project', 'solution', 'code', 'system', 'service', 'app']);
+const STOP_WORDS = new Set([
+  'the',
+  'a',
+  'an',
+  'in',
+  'on',
+  'at',
+  'to',
+  'for',
+  'of',
+  'and',
+  'or',
+  'but',
+  'not',
+  'use',
+  'using',
+  'with',
+  'from',
+  'any',
+  'this',
+  'that',
+  'it',
+  'its',
+  'be',
+  'is',
+  'are',
+  'was',
+  'been',
+  'our',
+  'we',
+  'will',
+  'do',
+  'as',
+  'no',
+  'into',
+  'all',
+  'within',
+  'without',
+  'should',
+  'must',
+  'only',
+  'also',
+  'when',
+  'implementation',
+  'codebase',
+  'project',
+  'solution',
+  'code',
+  'system',
+  'service',
+  'app',
+]);
 
 function extractKeyTerms(phrase: string): string[] {
-  return phrase.split(/\s+/)
-    .map(w => w.replace(/[^a-z0-9_\-]/g, '').toLowerCase())
-    .filter(w => w.length > 3 && !STOP_WORDS.has(w));
+  return phrase
+    .split(/\s+/)
+    .map((w) => w.replace(/[^a-z0-9_-]/g, '').toLowerCase())
+    .filter((w) => w.length > 3 && !STOP_WORDS.has(w));
 }
 
 /**
@@ -146,7 +204,7 @@ export function checkBoundaries(input: CheckBoundariesInput): BoundaryCheckResul
   const {
     brief = 'specs/product-brief.md',
     plan = 'specs/implementation-plan.md',
-    root = '.'
+    root = '.',
   } = input;
 
   const briefPath = path.resolve(root, brief);
@@ -158,13 +216,31 @@ export function checkBoundaries(input: CheckBoundariesInput): BoundaryCheckResul
   try {
     briefContent = fs.readFileSync(briefPath, 'utf8');
   } catch {
-    return { error: `Cannot read brief: ${briefPath}`, pass: false, score: 0, boundaries: [], violations: [], warnings: [], task_count: 0, boundary_count: 0 };
+    return {
+      error: `Cannot read brief: ${briefPath}`,
+      pass: false,
+      score: 0,
+      boundaries: [],
+      violations: [],
+      warnings: [],
+      task_count: 0,
+      boundary_count: 0,
+    };
   }
 
   try {
     planContent = fs.readFileSync(planPath, 'utf8');
   } catch {
-    return { error: `Cannot read plan: ${planPath}`, pass: false, score: 0, boundaries: [], violations: [], warnings: [], task_count: 0, boundary_count: 0 };
+    return {
+      error: `Cannot read plan: ${planPath}`,
+      pass: false,
+      score: 0,
+      boundaries: [],
+      violations: [],
+      warnings: [],
+      task_count: 0,
+      boundary_count: 0,
+    };
   }
 
   const boundaries = extractBoundaries(briefContent);
@@ -187,8 +263,9 @@ export function checkBoundaries(input: CheckBoundariesInput): BoundaryCheckResul
     ];
 
     for (const pattern of exclusionPatterns) {
-      let em: RegExpExecArray | null;
-      while ((em = pattern.exec(stmt)) !== null) {
+      for (;;) {
+        const em = pattern.exec(stmt);
+        if (em === null) break;
         const captured = (em[1] ?? '').trim().replace(/[.,;]$/, '');
 
         // For single-word captures (e.g. "no mongodb"), check the word directly.
@@ -199,7 +276,7 @@ export function checkBoundaries(input: CheckBoundariesInput): BoundaryCheckResul
               boundary_type: boundary.type,
               excluded_term: captured,
               found_in: 'implementation-plan.md',
-              severity: 'major'
+              severity: 'major',
             });
           }
         } else {
@@ -212,7 +289,7 @@ export function checkBoundaries(input: CheckBoundariesInput): BoundaryCheckResul
                 boundary_type: boundary.type,
                 excluded_term: term,
                 found_in: 'implementation-plan.md',
-                severity: 'major'
+                severity: 'major',
               });
               break; // one violation per boundary statement per pattern match
             }
@@ -224,8 +301,9 @@ export function checkBoundaries(input: CheckBoundariesInput): BoundaryCheckResul
 
   if (boundaries.length === 0) {
     warnings.push({
-      message: 'No boundary statements found in product brief. Consider adding a "Constraints and Boundaries" section.',
-      severity: 'minor'
+      message:
+        'No boundary statements found in product brief. Consider adding a "Constraints and Boundaries" section.',
+      severity: 'minor',
     });
   }
 
@@ -239,6 +317,6 @@ export function checkBoundaries(input: CheckBoundariesInput): BoundaryCheckResul
     task_count: tasks.length,
     boundary_count: boundaries.length,
     score,
-    pass: violations.filter(v => v.severity === 'major').length === 0
+    pass: violations.filter((v) => v.severity === 'major').length === 0,
   };
 }

--- a/src/lib/coverage.ts
+++ b/src/lib/coverage.ts
@@ -9,7 +9,7 @@
  * ADR-006: no process.exit — throws Error on unreadable files.
  */
 
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 
 /**
  * Extract all story IDs from a PRD document.
@@ -81,8 +81,8 @@ export function computeCoverage(prdPath: string, planPath: string): CoverageResu
   const planStoryRefsArr = planContent.match(/\bE\d+-S\d+\b/g) ?? [];
   const planStoryRefs = new Set<string>(planStoryRefsArr);
 
-  const covered = storyIds.filter(id => coveredStories.has(id) || planStoryRefs.has(id));
-  const uncovered = storyIds.filter(id => !coveredStories.has(id) && !planStoryRefs.has(id));
+  const covered = storyIds.filter((id) => coveredStories.has(id) || planStoryRefs.has(id));
+  const uncovered = storyIds.filter((id) => !coveredStories.has(id) && !planStoryRefs.has(id));
 
   const totalStories = storyIds.length;
   const coveragePct = totalStories > 0 ? Math.round((covered.length / totalStories) * 100) : 100;
@@ -92,7 +92,7 @@ export function computeCoverage(prdPath: string, planPath: string): CoverageResu
     uncovered,
     total_stories: totalStories,
     total_tasks: taskMappings.size,
-    coverage_pct: coveragePct
+    coverage_pct: coveragePct,
   };
 }
 

--- a/src/lib/coverage.ts
+++ b/src/lib/coverage.ts
@@ -1,0 +1,124 @@
+/**
+ * coverage.ts — Story-to-Task Coverage Validation (Item 67).
+ *
+ * Ensures 100% of PRD stories are mapped to at least one implementation task.
+ * Reports coverage gaps.
+ *
+ * M3 hardening: no JSON state — pure text processing, no persist paths.
+ * ADR-009: no user-supplied paths gated here (callers use assertInsideRoot before calling).
+ * ADR-006: no process.exit — throws Error on unreadable files.
+ */
+
+import * as fs from 'fs';
+
+/**
+ * Extract all story IDs from a PRD document.
+ * Matches patterns like E01-S01, E02-S03, etc.
+ */
+export function extractStoryIds(prdContent: string): string[] {
+  const matches = prdContent.match(/\bE\d+-S\d+\b/g) ?? [];
+  return Array.from(new Set(matches));
+}
+
+/**
+ * Extract task-to-story mappings from an implementation plan.
+ * Returns a map of task IDs to the story IDs they reference.
+ */
+export function extractTaskMappings(planContent: string): Map<string, string[]> {
+  const mappings = new Map<string, string[]>();
+
+  const taskPattern = /\b(M\d+-T\d+)\b/g;
+  const tasks = Array.from(new Set(planContent.match(taskPattern) ?? []));
+
+  for (const taskId of tasks) {
+    const escaped = taskId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const taskRegex = new RegExp(`${escaped}[\\s\\S]*?(?=M\\d+-T\\d+|$)`, 'g');
+    const section = taskRegex.exec(planContent);
+    if (section) {
+      const storyRefs = section[0].match(/\bE\d+-S\d+\b/g) ?? [];
+      mappings.set(taskId, Array.from(new Set(storyRefs)));
+    } else {
+      mappings.set(taskId, []);
+    }
+  }
+
+  return mappings;
+}
+
+export interface CoverageResult {
+  covered: string[];
+  uncovered: string[];
+  total_stories: number;
+  total_tasks: number;
+  coverage_pct: number;
+}
+
+/**
+ * Compute coverage of PRD stories by implementation tasks.
+ * Paths must be pre-validated by the caller (assertInsideRoot / assertUserPath).
+ */
+export function computeCoverage(prdPath: string, planPath: string): CoverageResult {
+  if (!fs.existsSync(prdPath)) {
+    throw new Error(`PRD not found: ${prdPath}`);
+  }
+  if (!fs.existsSync(planPath)) {
+    throw new Error(`Implementation plan not found: ${planPath}`);
+  }
+
+  const prdContent = fs.readFileSync(prdPath, 'utf8');
+  const planContent = fs.readFileSync(planPath, 'utf8');
+
+  const storyIds = extractStoryIds(prdContent);
+  const taskMappings = extractTaskMappings(planContent);
+
+  const coveredStories = new Set<string>();
+  taskMappings.forEach((stories) => {
+    for (const storyId of stories) {
+      coveredStories.add(storyId);
+    }
+  });
+
+  const planStoryRefsArr = planContent.match(/\bE\d+-S\d+\b/g) ?? [];
+  const planStoryRefs = new Set<string>(planStoryRefsArr);
+
+  const covered = storyIds.filter(id => coveredStories.has(id) || planStoryRefs.has(id));
+  const uncovered = storyIds.filter(id => !coveredStories.has(id) && !planStoryRefs.has(id));
+
+  const totalStories = storyIds.length;
+  const coveragePct = totalStories > 0 ? Math.round((covered.length / totalStories) * 100) : 100;
+
+  return {
+    covered,
+    uncovered,
+    total_stories: totalStories,
+    total_tasks: taskMappings.size,
+    coverage_pct: coveragePct
+  };
+}
+
+/**
+ * Generate a coverage report in markdown format.
+ */
+export function generateCoverageReport(prdPath: string, planPath: string): string {
+  const result = computeCoverage(prdPath, planPath);
+
+  let report = `# Coverage Report: PRD Stories -> Implementation Tasks\n\n`;
+  report += `**Coverage:** ${result.coverage_pct}% (${result.covered.length}/${result.total_stories} stories)\n`;
+  report += `**Total Tasks:** ${result.total_tasks}\n\n`;
+
+  if (result.coverage_pct === 100) {
+    report += 'All PRD stories are covered by implementation tasks.\n';
+  } else {
+    report += '## Uncovered Stories\n\n';
+    report += 'The following PRD stories have no corresponding implementation tasks:\n\n';
+    for (const id of result.uncovered) {
+      report += `- ${id}\n`;
+    }
+    report += '\n## Covered Stories\n\n';
+    for (const id of result.covered) {
+      report += `- ${id}\n`;
+    }
+  }
+
+  return report;
+}

--- a/src/lib/dashboard.ts
+++ b/src/lib/dashboard.ts
@@ -40,6 +40,8 @@ import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { join, resolve } from 'node:path';
 import { buildFromSpecs, getCoverage } from './graph.js';
+import { runAllChecks as specTesterRunAllChecks } from './spec-tester.js';
+import { computeCoverage as coverageComputeCoverage } from './coverage.js';
 import { loadState } from './state-store.js';
 import { getTimelineSummary } from './timeline.js';
 import { summarizeUsage } from './usage.js';
@@ -211,11 +213,8 @@ async function loadNextPhaseSibling(): Promise<NextPhaseModule | null> {
 }
 
 function loadSpecTesterSibling(): SpecTesterModule | null {
-  try {
-    return require('../../bin/lib/spec-tester.js') as SpecTesterModule;
-  } catch {
-    return null;
-  }
+  // M11 batch7: spec-tester is now a TS port -- return a thin wrapper.
+  return { runAllChecks: (content) => specTesterRunAllChecks(content) };
 }
 
 interface CoverageModule {
@@ -231,11 +230,8 @@ interface CoverageModule {
 }
 
 function loadCoverageSibling(): CoverageModule | null {
-  try {
-    return require('../../bin/lib/coverage.js') as CoverageModule;
-  } catch {
-    return null;
-  }
+  // M11 batch7: coverage is now a TS port -- return a thin wrapper.
+  return { computeCoverage: coverageComputeCoverage };
 }
 
 // Data Gathering

--- a/src/lib/dashboard.ts
+++ b/src/lib/dashboard.ts
@@ -42,6 +42,7 @@ import { join, resolve } from 'node:path';
 import { buildFromSpecs, getCoverage } from './graph.js';
 import { runAllChecks as specTesterRunAllChecks } from './spec-tester.js';
 import { computeCoverage as coverageComputeCoverage } from './coverage.js';
+import { isArtifactApproved as handoffIsArtifactApproved } from './handoff.js';
 import { loadState } from './state-store.js';
 import { getTimelineSummary } from './timeline.js';
 import { summarizeUsage } from './usage.js';
@@ -191,14 +192,8 @@ interface SpecTesterModule {
 // the catch now rebinds via a debug-only logger so a regression surfaces
 // when DEBUG=1.
 async function loadHandoffSibling(): Promise<HandoffModule | null> {
-  try {
-    // @ts-expect-error legacy ESM module without .d.mts companion (M11 cleanup)
-    const mod = (await import('../../bin/lib/handoff.mjs')) as HandoffModule;
-    return mod;
-  } catch (err) {
-    if (process.env.DEBUG) console.error('[dashboard] handoff sibling unavailable:', err);
-    return null;
-  }
+  // M11 batch7: handoff is now a TS port -- return a thin wrapper.
+  return { isArtifactApproved: (content) => handoffIsArtifactApproved(content) };
 }
 
 async function loadNextPhaseSibling(): Promise<NextPhaseModule | null> {

--- a/src/lib/dashboard.ts
+++ b/src/lib/dashboard.ts
@@ -39,10 +39,10 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { join, resolve } from 'node:path';
-import { buildFromSpecs, getCoverage } from './graph.js';
-import { runAllChecks as specTesterRunAllChecks } from './spec-tester.js';
 import { computeCoverage as coverageComputeCoverage } from './coverage.js';
+import { buildFromSpecs, getCoverage } from './graph.js';
 import { isArtifactApproved as handoffIsArtifactApproved } from './handoff.js';
+import { runAllChecks as specTesterRunAllChecks } from './spec-tester.js';
 import { loadState } from './state-store.js';
 import { getTimelineSummary } from './timeline.js';
 import { summarizeUsage } from './usage.js';

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -1,0 +1,531 @@
+/**
+ * export.ts -- Portable Handoff Package (UX Feature 14).
+ *
+ * Generates a self-contained handoff package with all approved specs,
+ * key decisions, implementation status, and coverage data.
+ *
+ * ADR-006: no process.exit.
+ * ADR-009: root/output paths validated by caller.
+ * M3 hardening: state.json parse failure → defaultState fallback.
+ *               assertNoPollution() applied before using parsed state.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { summarizeArtifact } from './context-summarizer.js';
+import { computeCoverage } from './coverage.js';
+
+// ─── M3 Hardening ─────────────────────────────────────────────────────────────
+
+const POLLUTION_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function assertNoPollution(obj: unknown, depth = 0): void {
+  if (depth > 10 || typeof obj !== 'object' || obj === null) return;
+  for (const key of Object.keys(obj as Record<string, unknown>)) {
+    if (POLLUTION_KEYS.has(key)) throw new Error(`Prototype pollution key: "${key}"`);
+    assertNoPollution((obj as Record<string, unknown>)[key], depth + 1);
+  }
+}
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface PhaseEntry {
+  phase: number;
+  name: string;
+  artifact: string | null;
+}
+
+export interface PhaseStatus {
+  phase: number;
+  name: string;
+  status: string;
+  artifact: string | null;
+}
+
+export interface ArtifactSummaryEntry {
+  file: string;
+  phase: number;
+  phase_name: string;
+  approved: boolean;
+  frontmatter?: Record<string, unknown>;
+  sections?: unknown[];
+  structured_data?: Record<string, unknown>;
+  error?: string | undefined;
+}
+
+export interface DecisionEntry {
+  file: string;
+  title: string;
+  status: string;
+}
+
+export interface CoverageData {
+  covered?: string[] | undefined;
+  uncovered?: string[] | undefined;
+  total_stories?: number | undefined;
+  coverage_pct?: number | null | undefined;
+}
+
+export interface OpenItem {
+  file: string;
+  tag: string;
+}
+
+export interface ImplementationStatus {
+  current_phase: unknown;
+  current_agent?: unknown;
+  phase_history: unknown[];
+  resume_context: unknown;
+}
+
+export interface HandoffData {
+  project_name: string;
+  exported_at: string;
+  phases: PhaseStatus[];
+  approved_artifacts: string[];
+  summaries: ArtifactSummaryEntry[];
+  decisions: DecisionEntry[];
+  coverage: CoverageData | null;
+  open_items: OpenItem[];
+  implementation_status: ImplementationStatus;
+}
+
+export interface ExportHandoffOptions {
+  root?: string | undefined;
+  output?: string | undefined;
+  json?: boolean | undefined;
+  specsDir?: string | undefined;
+}
+
+export interface ExportHandoffResult {
+  success: boolean;
+  output_path: string;
+  stats: {
+    phases: number;
+    approved: number;
+    summaries: number;
+    decisions: number;
+    open_items: number;
+    has_coverage: boolean;
+  };
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+export const PHASES: PhaseEntry[] = [
+  { phase: -1, name: 'Scout', artifact: 'specs/codebase-context.md' },
+  { phase: 0, name: 'Challenger', artifact: 'specs/challenger-brief.md' },
+  { phase: 1, name: 'Analyst', artifact: 'specs/product-brief.md' },
+  { phase: 2, name: 'PM', artifact: 'specs/prd.md' },
+  { phase: 3, name: 'Architect', artifact: 'specs/architecture.md' },
+  { phase: 4, name: 'Developer', artifact: null },
+];
+
+export const SECONDARY_ARTIFACTS: string[] = ['specs/implementation-plan.md'];
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Check if a file contains an approved Phase Gate section.
+ */
+export function isApproved(content: string): boolean {
+  if (!content) return false;
+  if (!/## Phase Gate Approval/i.test(content)) return false;
+  const match = content.match(/\*\*Approved by:\*\*\s*(.+)/i);
+  if (!match || (match[1] ?? '').trim().toLowerCase() === 'pending') return false;
+  const gateSection = content.split(/## Phase Gate Approval/i)[1] ?? '';
+  const unchecked = gateSection.match(/- \[ \]/g);
+  return !unchecked || unchecked.length === 0;
+}
+
+function walkFiles(dir: string): string[] {
+  const results: string[] = [];
+  if (!fs.existsSync(dir)) return results;
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...walkFiles(full));
+    } else {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+interface StateShape {
+  current_phase: unknown;
+  current_agent?: unknown;
+  approved_artifacts: string[];
+  phase_history: unknown[];
+  resume_context: unknown;
+}
+
+function defaultState(): StateShape {
+  return { current_phase: null, approved_artifacts: [], phase_history: [], resume_context: null };
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Gather all data needed for the handoff package.
+ */
+export function gatherHandoffData(options: ExportHandoffOptions = {}): HandoffData {
+  const root = options.root ?? process.cwd();
+  const specsDir = options.specsDir ?? path.join(root, 'specs');
+
+  // Load state with M3 hardening
+  let state: StateShape = defaultState();
+  try {
+    const statePath = path.join(root, '.jumpstart', 'state', 'state.json');
+    if (fs.existsSync(statePath)) {
+      const raw = JSON.parse(fs.readFileSync(statePath, 'utf8')) as unknown;
+      assertNoPollution(raw);
+      state = raw as StateShape;
+    }
+  } catch {
+    state = defaultState();
+  }
+
+  // Load project name from config.yaml
+  let projectName = path.basename(root);
+  try {
+    const configPath = path.join(root, '.jumpstart', 'config.yaml');
+    if (fs.existsSync(configPath)) {
+      const configContent = fs.readFileSync(configPath, 'utf8');
+      const nameMatch = configContent.match(/name:\s*['"]?([^'"\n]+)/);
+      if (nameMatch) projectName = (nameMatch[1] ?? '').trim();
+    }
+  } catch {
+    /* use default */
+  }
+
+  // Gather phase status and summaries
+  const phases: PhaseStatus[] = [];
+  const summaries: ArtifactSummaryEntry[] = [];
+  const approvedArtifacts: string[] = [];
+
+  for (const p of PHASES) {
+    if (!p.artifact) {
+      phases.push({ phase: p.phase, name: p.name, status: 'n/a', artifact: null });
+      continue;
+    }
+
+    const artifactPath = path.join(root, p.artifact);
+    let status = 'not-started';
+    let approved = false;
+
+    if (fs.existsSync(artifactPath)) {
+      const content = fs.readFileSync(artifactPath, 'utf8');
+      approved = isApproved(content);
+      status = approved ? 'approved' : 'draft';
+
+      if (approved) approvedArtifacts.push(p.artifact);
+
+      try {
+        const summary = summarizeArtifact(artifactPath, p.artifact);
+        if (summary) {
+          summaries.push({
+            file: p.artifact,
+            phase: p.phase,
+            phase_name: p.name,
+            approved,
+            frontmatter: (summary.frontmatter ?? {}) as Record<string, unknown>,
+            sections: summary.sections ?? [],
+            structured_data: (summary.structured_data ?? {}) as Record<string, unknown>,
+          });
+        }
+      } catch {
+        summaries.push({
+          file: p.artifact,
+          phase: p.phase,
+          phase_name: p.name,
+          approved,
+          error: 'Could not summarize',
+        });
+      }
+    }
+
+    phases.push({ phase: p.phase, name: p.name, status, artifact: p.artifact });
+  }
+
+  // Check secondary artifacts (implementation-plan.md)
+  for (const sa of SECONDARY_ARTIFACTS) {
+    const saPath = path.join(root, sa);
+    if (fs.existsSync(saPath)) {
+      const content = fs.readFileSync(saPath, 'utf8');
+      const approved = isApproved(content);
+      if (approved) approvedArtifacts.push(sa);
+      try {
+        const summary = summarizeArtifact(saPath, sa);
+        if (summary) {
+          summaries.push({
+            file: sa,
+            phase: 3,
+            phase_name: 'Architect',
+            approved,
+            frontmatter: (summary.frontmatter ?? {}) as Record<string, unknown>,
+            sections: summary.sections ?? [],
+            structured_data: (summary.structured_data ?? {}) as Record<string, unknown>,
+          });
+        }
+      } catch {
+        /* skip */
+      }
+    }
+  }
+
+  // Gather ADRs from specs/decisions/
+  const decisions: DecisionEntry[] = [];
+  const decisionsDir = path.join(specsDir, 'decisions');
+  if (fs.existsSync(decisionsDir)) {
+    try {
+      const files = fs.readdirSync(decisionsDir).filter((f) => f.endsWith('.md'));
+      for (const f of files) {
+        const content = fs.readFileSync(path.join(decisionsDir, f), 'utf8');
+        const titleMatch = content.match(/^#\s+(.+)/m);
+        const statusMatch = content.match(/\*\*Status:\*\*\s*(.+)/i);
+        decisions.push({
+          file: `specs/decisions/${f}`,
+          title: titleMatch ? (titleMatch[1] ?? f) : f,
+          status: statusMatch ? (statusMatch[1] ?? 'Unknown').trim() : 'Unknown',
+        });
+      }
+    } catch {
+      /* skip */
+    }
+  }
+
+  // Coverage data
+  let coverage: CoverageData | null = null;
+  const prdPath = path.join(root, 'specs/prd.md');
+  const planPath = path.join(root, 'specs/implementation-plan.md');
+  if (fs.existsSync(prdPath) && fs.existsSync(planPath)) {
+    try {
+      coverage = computeCoverage(prdPath, planPath);
+    } catch {
+      /* skip */
+    }
+  }
+
+  // Open clarifications
+  const openItems: OpenItem[] = [];
+  for (const s of summaries) {
+    const sd = s.structured_data ?? {};
+    const clarifications = sd.clarifications;
+    if (Array.isArray(clarifications)) {
+      for (const c of clarifications) {
+        openItems.push({ file: s.file, tag: String(c) });
+      }
+    }
+  }
+
+  // Scan for [NEEDS CLARIFICATION] in all spec files
+  if (fs.existsSync(specsDir)) {
+    try {
+      const specFiles = walkFiles(specsDir).filter((f) => f.endsWith('.md'));
+      for (const sf of specFiles) {
+        const content = fs.readFileSync(sf, 'utf8');
+        const matches = content.match(/\[NEEDS CLARIFICATION[^\]]*\]/g);
+        if (matches) {
+          const relPath = path.relative(root, sf).replace(/\\/g, '/');
+          for (const m of matches) {
+            if (!openItems.find((o) => o.file === relPath && o.tag === m)) {
+              openItems.push({ file: relPath, tag: m });
+            }
+          }
+        }
+      }
+    } catch {
+      /* skip */
+    }
+  }
+
+  return {
+    project_name: projectName,
+    exported_at: new Date().toISOString(),
+    phases,
+    approved_artifacts: approvedArtifacts,
+    summaries,
+    decisions,
+    coverage,
+    open_items: openItems,
+    implementation_status: {
+      current_phase: state.current_phase,
+      current_agent: state.current_agent,
+      phase_history: state.phase_history ?? [],
+      resume_context: state.resume_context,
+    },
+  };
+}
+
+/**
+ * Render handoff data as a self-contained Markdown document.
+ */
+export function renderHandoffMarkdown(data: HandoffData): string {
+  const lines: string[] = [];
+
+  lines.push(`# Handoff Package — ${data.project_name}`);
+  lines.push('');
+  lines.push(`> Exported: ${data.exported_at}`);
+  lines.push('');
+
+  // Phase Status Table
+  lines.push('## Phase Status');
+  lines.push('');
+  lines.push('| Phase | Name | Status | Artifact |');
+  lines.push('|-------|------|--------|----------|');
+  for (const p of data.phases) {
+    const statusIcon =
+      p.status === 'approved'
+        ? '✅'
+        : p.status === 'draft'
+          ? '📝'
+          : p.status === 'n/a'
+            ? '—'
+            : '⬜';
+    lines.push(`| ${p.phase} | ${p.name} | ${statusIcon} ${p.status} | ${p.artifact ?? '—'} |`);
+  }
+  lines.push('');
+
+  // Approved Artifacts
+  if (data.approved_artifacts.length > 0) {
+    lines.push('## Approved Artifacts');
+    lines.push('');
+    for (const a of data.approved_artifacts) {
+      lines.push(`- ✅ ${a}`);
+    }
+    lines.push('');
+  }
+
+  // Summaries
+  if (data.summaries.length > 0) {
+    lines.push('## Artifact Summaries');
+    lines.push('');
+    for (const s of data.summaries) {
+      lines.push(`### ${s.phase_name} — ${s.file}`);
+      lines.push('');
+      if (s.error) {
+        lines.push(`_${s.error}_`);
+      } else {
+        const sections = s.sections ?? [];
+        if (Array.isArray(sections) && sections.length > 0) {
+          for (const sec of sections) {
+            const secRecord = sec as Record<string, unknown>;
+            lines.push(`**${String(secRecord.heading ?? '')}**`);
+            if (secRecord.summary) lines.push(String(secRecord.summary));
+            lines.push('');
+          }
+        }
+        const sd = s.structured_data ?? {};
+        if (Array.isArray(sd.user_stories) && (sd.user_stories as unknown[]).length > 0) {
+          lines.push(`**User Stories:** ${(sd.user_stories as unknown[]).length} stories`);
+        }
+        if (Array.isArray(sd.nfrs) && (sd.nfrs as unknown[]).length > 0) {
+          lines.push(`**NFRs:** ${(sd.nfrs as unknown[]).length} requirements`);
+        }
+        if (Array.isArray(sd.components) && (sd.components as unknown[]).length > 0) {
+          lines.push(`**Components:** ${(sd.components as unknown[]).join(', ')}`);
+        }
+        if (Array.isArray(sd.tech_stack) && (sd.tech_stack as unknown[]).length > 0) {
+          lines.push(`**Tech Stack:** ${(sd.tech_stack as unknown[]).join(', ')}`);
+        }
+      }
+      lines.push('');
+    }
+  }
+
+  // Decisions
+  if (data.decisions.length > 0) {
+    lines.push('## Architecture Decisions');
+    lines.push('');
+    for (const d of data.decisions) {
+      lines.push(`- **${d.title}** — _${d.status}_ (${d.file})`);
+    }
+    lines.push('');
+  }
+
+  // Coverage
+  if (data.coverage) {
+    const cov = data.coverage;
+    lines.push('## Coverage');
+    lines.push('');
+    lines.push(
+      `- **Stories covered:** ${Array.isArray(cov.covered) ? cov.covered.length : 0} / ${cov.total_stories ?? 0}`
+    );
+    lines.push(
+      `- **Coverage:** ${cov.coverage_pct != null ? `${String(cov.coverage_pct)}%` : 'N/A'}`
+    );
+    if (Array.isArray(cov.uncovered) && cov.uncovered.length > 0) {
+      lines.push(`- **Uncovered:** ${cov.uncovered.join(', ')}`);
+    }
+    lines.push('');
+  }
+
+  // Open Items
+  if (data.open_items.length > 0) {
+    lines.push('## Open Clarifications');
+    lines.push('');
+    for (const item of data.open_items) {
+      lines.push(`- ${item.file}: ${item.tag}`);
+    }
+    lines.push('');
+  }
+
+  // Implementation Status
+  lines.push('## Implementation Status');
+  lines.push('');
+  const is = data.implementation_status;
+  lines.push(
+    `- **Current Phase:** ${is.current_phase !== null ? String(is.current_phase) : 'Not started'}`
+  );
+  lines.push(`- **Current Agent:** ${String(is.current_agent ?? 'None')}`);
+  if (Array.isArray(is.phase_history) && is.phase_history.length > 0) {
+    lines.push(`- **Completed Phases:** ${is.phase_history.length}`);
+  }
+  lines.push('');
+
+  lines.push('---');
+  lines.push('');
+  lines.push('_Generated by JumpStart `/jumpstart.handoff`_');
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+/**
+ * Export a complete handoff package to a file.
+ */
+export function exportHandoffPackage(options: ExportHandoffOptions = {}): ExportHandoffResult {
+  const root = options.root ?? process.cwd();
+  const data = gatherHandoffData({ root, specsDir: path.join(root, 'specs') });
+
+  const outputPath = options.output ?? path.join(root, 'specs', 'handoff-package.md');
+  const outputDir = path.dirname(outputPath);
+
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+
+  let content: string;
+  if (options.json) {
+    content = `${JSON.stringify(data, null, 2)}\n`;
+  } else {
+    content = renderHandoffMarkdown(data);
+  }
+
+  fs.writeFileSync(outputPath, content, 'utf8');
+
+  return {
+    success: true,
+    output_path: outputPath,
+    stats: {
+      phases: data.phases.length,
+      approved: data.approved_artifacts.length,
+      summaries: data.summaries.length,
+      decisions: data.decisions.length,
+      open_items: data.open_items.length,
+      has_coverage: data.coverage !== null,
+    },
+  };
+}

--- a/src/lib/freshness-gate.ts
+++ b/src/lib/freshness-gate.ts
@@ -10,8 +10,8 @@
  * ADR-006: no process.exit.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 /**
  * Context7 citation pattern: [Context7: library@version] or <!-- c7:library -->
@@ -26,20 +26,71 @@ export const CITATION_PATTERNS: RegExp[] = [
  * Technology keywords that SHOULD trigger a Context7 lookup.
  */
 export const TECH_KEYWORDS: string[] = [
-  'react', 'next.js', 'nextjs', 'vue', 'angular', 'svelte',
-  'express', 'fastify', 'koa', 'hono', 'nest.js', 'nestjs',
-  'prisma', 'drizzle', 'typeorm', 'sequelize', 'mongoose',
-  'tailwind', 'bootstrap', 'material-ui', 'chakra',
-  'jest', 'vitest', 'playwright', 'cypress', 'mocha',
-  'webpack', 'vite', 'esbuild', 'rollup', 'turbopack',
-  'docker', 'kubernetes', 'terraform', 'pulumi',
-  'aws', 'azure', 'gcp', 'vercel', 'netlify', 'cloudflare',
-  'postgresql', 'mysql', 'mongodb', 'redis', 'sqlite',
-  'graphql', 'trpc', 'grpc', 'openapi',
-  'typescript', 'python', 'rust', 'go', 'java',
-  'supabase', 'firebase', 'clerk', 'auth0',
-  'stripe', 'twilio', 'sendgrid',
-  'langchain', 'openai', 'anthropic',
+  'react',
+  'next.js',
+  'nextjs',
+  'vue',
+  'angular',
+  'svelte',
+  'express',
+  'fastify',
+  'koa',
+  'hono',
+  'nest.js',
+  'nestjs',
+  'prisma',
+  'drizzle',
+  'typeorm',
+  'sequelize',
+  'mongoose',
+  'tailwind',
+  'bootstrap',
+  'material-ui',
+  'chakra',
+  'jest',
+  'vitest',
+  'playwright',
+  'cypress',
+  'mocha',
+  'webpack',
+  'vite',
+  'esbuild',
+  'rollup',
+  'turbopack',
+  'docker',
+  'kubernetes',
+  'terraform',
+  'pulumi',
+  'aws',
+  'azure',
+  'gcp',
+  'vercel',
+  'netlify',
+  'cloudflare',
+  'postgresql',
+  'mysql',
+  'mongodb',
+  'redis',
+  'sqlite',
+  'graphql',
+  'trpc',
+  'grpc',
+  'openapi',
+  'typescript',
+  'python',
+  'rust',
+  'go',
+  'java',
+  'supabase',
+  'firebase',
+  'clerk',
+  'auth0',
+  'stripe',
+  'twilio',
+  'sendgrid',
+  'langchain',
+  'openai',
+  'anthropic',
 ];
 
 export interface DocumentAuditResult {
@@ -65,7 +116,7 @@ export interface SpecsAuditResult {
 export function auditDocument(content: string): DocumentAuditResult {
   const contentLower = content.toLowerCase();
 
-  const techs = TECH_KEYWORDS.filter(kw => contentLower.includes(kw.toLowerCase()));
+  const techs = TECH_KEYWORDS.filter((kw) => contentLower.includes(kw.toLowerCase()));
 
   const citations: string[] = [];
   for (const pattern of CITATION_PATTERNS) {
@@ -77,14 +128,13 @@ export function auditDocument(content: string): DocumentAuditResult {
     }
   }
 
-  const citedTechsLower = citations.map(c => c.toLowerCase());
-  const uncited = techs.filter(tech => {
-    return !citedTechsLower.some(c => c.includes(tech.toLowerCase()));
+  const citedTechsLower = citations.map((c) => c.toLowerCase());
+  const uncited = techs.filter((tech) => {
+    return !citedTechsLower.some((c) => c.includes(tech.toLowerCase()));
   });
 
-  const score = techs.length === 0
-    ? 100
-    : Math.round(((techs.length - uncited.length) / techs.length) * 100);
+  const score =
+    techs.length === 0 ? 100 : Math.round(((techs.length - uncited.length) / techs.length) * 100);
 
   return { techs, citations, uncited, score };
 }
@@ -101,7 +151,7 @@ export function auditSpecs(specsDir: string): SpecsAuditResult {
     return { files, overallScore: 100, warnings: ['Specs directory not found.'] };
   }
 
-  const specFiles = walkDir(specsDir).filter(f => f.endsWith('.md'));
+  const specFiles = walkDir(specsDir).filter((f) => f.endsWith('.md'));
 
   for (const filePath of specFiles) {
     const content = fs.readFileSync(filePath, 'utf8');
@@ -113,16 +163,15 @@ export function auditSpecs(specsDir: string): SpecsAuditResult {
     if (result.uncited.length > 0) {
       warnings.push(
         `${relativePath}: Uncited technologies: ${result.uncited.join(', ')}. ` +
-        `Use Context7 MCP to fetch live docs.`
+          `Use Context7 MCP to fetch live docs.`
       );
     }
   }
 
   const totalTechs = files.reduce((sum, f) => sum + f.techs.length, 0);
   const totalUncited = files.reduce((sum, f) => sum + f.uncited.length, 0);
-  const overallScore = totalTechs === 0
-    ? 100
-    : Math.round(((totalTechs - totalUncited) / totalTechs) * 100);
+  const overallScore =
+    totalTechs === 0 ? 100 : Math.round(((totalTechs - totalUncited) / totalTechs) * 100);
 
   return { files, overallScore, warnings };
 }

--- a/src/lib/freshness-gate.ts
+++ b/src/lib/freshness-gate.ts
@@ -1,0 +1,184 @@
+/**
+ * freshness-gate.ts — Context7 Documentation Freshness Gate (Item 101).
+ *
+ * Enforces that agents use Context7 MCP for live documentation lookups
+ * instead of relying on stale training data. Audits specs for proper
+ * Context7 citation markers.
+ *
+ * M3 hardening: no JSON persist — pure text audit, no mutable state paths.
+ * ADR-009: specsDir passed in by callers who must validate paths first.
+ * ADR-006: no process.exit.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Context7 citation pattern: [Context7: library@version] or <!-- c7:library -->
+ */
+export const CITATION_PATTERNS: RegExp[] = [
+  /\[Context7:\s*[^\]]+\]/gi,
+  /<!--\s*c7:[^\s]+\s*-->/gi,
+  /\bContext7\b/gi,
+];
+
+/**
+ * Technology keywords that SHOULD trigger a Context7 lookup.
+ */
+export const TECH_KEYWORDS: string[] = [
+  'react', 'next.js', 'nextjs', 'vue', 'angular', 'svelte',
+  'express', 'fastify', 'koa', 'hono', 'nest.js', 'nestjs',
+  'prisma', 'drizzle', 'typeorm', 'sequelize', 'mongoose',
+  'tailwind', 'bootstrap', 'material-ui', 'chakra',
+  'jest', 'vitest', 'playwright', 'cypress', 'mocha',
+  'webpack', 'vite', 'esbuild', 'rollup', 'turbopack',
+  'docker', 'kubernetes', 'terraform', 'pulumi',
+  'aws', 'azure', 'gcp', 'vercel', 'netlify', 'cloudflare',
+  'postgresql', 'mysql', 'mongodb', 'redis', 'sqlite',
+  'graphql', 'trpc', 'grpc', 'openapi',
+  'typescript', 'python', 'rust', 'go', 'java',
+  'supabase', 'firebase', 'clerk', 'auth0',
+  'stripe', 'twilio', 'sendgrid',
+  'langchain', 'openai', 'anthropic',
+];
+
+export interface DocumentAuditResult {
+  techs: string[];
+  citations: string[];
+  uncited: string[];
+  score: number;
+}
+
+export interface FileAuditEntry extends DocumentAuditResult {
+  path: string;
+}
+
+export interface SpecsAuditResult {
+  files: FileAuditEntry[];
+  overallScore: number;
+  warnings: string[];
+}
+
+/**
+ * Scan a document for technology references that lack Context7 citations.
+ */
+export function auditDocument(content: string): DocumentAuditResult {
+  const contentLower = content.toLowerCase();
+
+  const techs = TECH_KEYWORDS.filter(kw => contentLower.includes(kw.toLowerCase()));
+
+  const citations: string[] = [];
+  for (const pattern of CITATION_PATTERNS) {
+    // Reset lastIndex since flags include 'g'
+    pattern.lastIndex = 0;
+    const matches = content.match(pattern);
+    if (matches) {
+      citations.push(...matches);
+    }
+  }
+
+  const citedTechsLower = citations.map(c => c.toLowerCase());
+  const uncited = techs.filter(tech => {
+    return !citedTechsLower.some(c => c.includes(tech.toLowerCase()));
+  });
+
+  const score = techs.length === 0
+    ? 100
+    : Math.round(((techs.length - uncited.length) / techs.length) * 100);
+
+  return { techs, citations, uncited, score };
+}
+
+/**
+ * Run a freshness audit across all spec files.
+ * specsDir should be pre-validated by the caller.
+ */
+export function auditSpecs(specsDir: string): SpecsAuditResult {
+  const files: FileAuditEntry[] = [];
+  const warnings: string[] = [];
+
+  if (!fs.existsSync(specsDir)) {
+    return { files, overallScore: 100, warnings: ['Specs directory not found.'] };
+  }
+
+  const specFiles = walkDir(specsDir).filter(f => f.endsWith('.md'));
+
+  for (const filePath of specFiles) {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const result = auditDocument(content);
+    const relativePath = path.relative(specsDir, filePath);
+
+    files.push({ path: relativePath, ...result });
+
+    if (result.uncited.length > 0) {
+      warnings.push(
+        `${relativePath}: Uncited technologies: ${result.uncited.join(', ')}. ` +
+        `Use Context7 MCP to fetch live docs.`
+      );
+    }
+  }
+
+  const totalTechs = files.reduce((sum, f) => sum + f.techs.length, 0);
+  const totalUncited = files.reduce((sum, f) => sum + f.uncited.length, 0);
+  const overallScore = totalTechs === 0
+    ? 100
+    : Math.round(((totalTechs - totalUncited) / totalTechs) * 100);
+
+  return { files, overallScore, warnings };
+}
+
+/**
+ * Generate a documentation audit report in markdown.
+ */
+export function generateAuditReport(specsDir: string): string {
+  const audit = auditSpecs(specsDir);
+
+  let report = `# Documentation Freshness Audit\n\n`;
+  report += `**Generated:** ${new Date().toISOString()}\n`;
+  report += `**Overall Score:** ${audit.overallScore}/100\n\n`;
+
+  if (audit.files.length === 0) {
+    report += `No spec files found.\n`;
+    return report;
+  }
+
+  report += `## File-Level Results\n\n`;
+  report += `| File | Technologies | Citations | Uncited | Score |\n`;
+  report += `|------|-------------|-----------|---------|-------|\n`;
+
+  for (const file of audit.files) {
+    report += `| ${file.path} | ${file.techs.length} | ${file.citations.length} | ${file.uncited.length} | ${file.score}/100 |\n`;
+  }
+
+  if (audit.warnings.length > 0) {
+    report += `\n## Warnings\n\n`;
+    for (const warning of audit.warnings) {
+      report += `- ${warning}\n`;
+    }
+
+    report += `\n## Remediation\n\n`;
+    report += `For each uncited technology, use Context7 MCP:\n\n`;
+    report += `1. Resolve the library ID: \`resolve-library-id\`\n`;
+    report += `2. Fetch current docs: \`get-library-docs\`\n`;
+    report += `3. Add citation marker: \`[Context7: library@version]\`\n`;
+  }
+
+  return report;
+}
+
+/**
+ * Walk a directory recursively.
+ */
+function walkDir(dir: string): string[] {
+  const results: string[] = [];
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...walkDir(fullPath));
+    } else {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}

--- a/src/lib/handoff.ts
+++ b/src/lib/handoff.ts
@@ -69,7 +69,7 @@ export const PHASE_MAP: Record<string, PhaseTransition> = {
     next_phase: 0,
     next_agent: 'challenger',
     next_artifacts: ['specs/challenger-brief.md', 'specs/insights/challenger-brief-insights.md'],
-    next_context: ['.jumpstart/config.yaml', '.jumpstart/roadmap.md', 'specs/codebase-context.md']
+    next_context: ['.jumpstart/config.yaml', '.jumpstart/roadmap.md', 'specs/codebase-context.md'],
   },
   '0': {
     name: 'Challenger',
@@ -77,7 +77,7 @@ export const PHASE_MAP: Record<string, PhaseTransition> = {
     next_phase: 1,
     next_agent: 'analyst',
     next_artifacts: ['specs/product-brief.md', 'specs/insights/product-brief-insights.md'],
-    next_context: ['.jumpstart/config.yaml', '.jumpstart/roadmap.md', 'specs/challenger-brief.md']
+    next_context: ['.jumpstart/config.yaml', '.jumpstart/roadmap.md', 'specs/challenger-brief.md'],
   },
   '1': {
     name: 'Analyst',
@@ -85,15 +85,30 @@ export const PHASE_MAP: Record<string, PhaseTransition> = {
     next_phase: 2,
     next_agent: 'pm',
     next_artifacts: ['specs/prd.md', 'specs/insights/prd-insights.md'],
-    next_context: ['.jumpstart/config.yaml', '.jumpstart/roadmap.md', 'specs/challenger-brief.md', 'specs/product-brief.md']
+    next_context: [
+      '.jumpstart/config.yaml',
+      '.jumpstart/roadmap.md',
+      'specs/challenger-brief.md',
+      'specs/product-brief.md',
+    ],
   },
   '2': {
     name: 'PM',
     artifact: 'specs/prd.md',
     next_phase: 3,
     next_agent: 'architect',
-    next_artifacts: ['specs/architecture.md', 'specs/implementation-plan.md', 'specs/insights/architecture-insights.md'],
-    next_context: ['.jumpstart/config.yaml', '.jumpstart/roadmap.md', 'specs/challenger-brief.md', 'specs/product-brief.md', 'specs/prd.md']
+    next_artifacts: [
+      'specs/architecture.md',
+      'specs/implementation-plan.md',
+      'specs/insights/architecture-insights.md',
+    ],
+    next_context: [
+      '.jumpstart/config.yaml',
+      '.jumpstart/roadmap.md',
+      'specs/challenger-brief.md',
+      'specs/product-brief.md',
+      'specs/prd.md',
+    ],
   },
   '3': {
     name: 'Architect',
@@ -101,7 +116,13 @@ export const PHASE_MAP: Record<string, PhaseTransition> = {
     next_phase: 4,
     next_agent: 'developer',
     next_artifacts: ['specs/insights/implementation-insights.md'],
-    next_context: ['.jumpstart/config.yaml', '.jumpstart/roadmap.md', 'specs/prd.md', 'specs/architecture.md', 'specs/implementation-plan.md']
+    next_context: [
+      '.jumpstart/config.yaml',
+      '.jumpstart/roadmap.md',
+      'specs/prd.md',
+      'specs/architecture.md',
+      'specs/implementation-plan.md',
+    ],
   },
   '4': {
     name: 'Developer',
@@ -109,8 +130,8 @@ export const PHASE_MAP: Record<string, PhaseTransition> = {
     next_phase: null,
     next_agent: null,
     next_artifacts: [],
-    next_context: []
-  }
+    next_context: [],
+  },
 };
 
 // ─── Public API ───────────────────────────────────────────────────────────────
@@ -125,7 +146,8 @@ export function isArtifactApproved(content: string): boolean {
 
   // Check that "Approved by" is not "Pending"
   const approvedByMatch = content.match(/\*\*Approved by:\*\*\s*(.+)/i);
-  if (!approvedByMatch || (approvedByMatch[1] ?? '').trim().toLowerCase() === 'pending') return false;
+  if (!approvedByMatch || (approvedByMatch[1] ?? '').trim().toLowerCase() === 'pending')
+    return false;
 
   // Check all checkboxes are checked
   const gateSection = content.split(/## Phase Gate Approval/i)[1] ?? '';
@@ -150,7 +172,7 @@ export function getHandoff(currentPhase: number): HandoffResult | HandoffErrorRe
       next_phase: null,
       next_agent: null,
       message: 'Phase 4 is the final phase. No further handoff needed.',
-      ready: false
+      ready: false,
     };
   }
 
@@ -161,7 +183,7 @@ export function getHandoff(currentPhase: number): HandoffResult | HandoffErrorRe
     next_agent: transition.next_agent,
     artifacts_to_create: transition.next_artifacts,
     context_files: transition.next_context,
-    ready: true
+    ready: true,
   };
 }
 
@@ -181,8 +203,8 @@ export function executeHandoff(currentPhase: number): HandoffResult | HandoffErr
         source_phase: currentPhase,
         target_phase: r.next_phase,
         next_agent: r.next_agent,
-        context_files: r.context_files
-      }
+        context_files: r.context_files,
+      },
     });
   }
 

--- a/src/lib/handoff.ts
+++ b/src/lib/handoff.ts
@@ -1,0 +1,190 @@
+/**
+ * handoff.ts -- Auto-Handoff Logic (Item 37).
+ *
+ * After a phase artifact is approved, determines the next phase's
+ * artifacts and agent context automatically.
+ *
+ * M3 hardening: no JSON state -- pure in-memory data.
+ * ADR-006: no process.exit.
+ */
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface PhaseTransition {
+  name: string;
+  artifact: string | null;
+  next_phase: number | null;
+  next_agent: string | null;
+  next_artifacts: string[];
+  next_context: string[];
+}
+
+export interface HandoffResult {
+  current_phase: number;
+  current_name?: string | undefined;
+  next_phase: number | null;
+  next_agent: string | null;
+  artifacts_to_create?: string[] | undefined;
+  context_files?: string[] | undefined;
+  message?: string | undefined;
+  error?: string | undefined;
+  ready: boolean;
+}
+
+export interface HandoffErrorResult {
+  error: string;
+  ready: false;
+}
+
+// ─── Timeline Hook ────────────────────────────────────────────────────────────
+
+interface TimelineHook {
+  recordEvent(event: {
+    event_type: string;
+    phase: number;
+    action: string;
+    metadata: Record<string, unknown>;
+  }): void;
+}
+
+let _timelineHook: TimelineHook | null = null;
+
+/**
+ * Set the timeline instance for recording handoff events.
+ */
+export function setHandoffTimelineHook(timeline: TimelineHook | null): void {
+  _timelineHook = timeline;
+}
+
+// ─── Phase Map ────────────────────────────────────────────────────────────────
+
+/**
+ * Phase transition map.
+ * Each phase defines what artifacts and context the next phase needs.
+ */
+export const PHASE_MAP: Record<string, PhaseTransition> = {
+  '-1': {
+    name: 'Scout',
+    artifact: 'specs/codebase-context.md',
+    next_phase: 0,
+    next_agent: 'challenger',
+    next_artifacts: ['specs/challenger-brief.md', 'specs/insights/challenger-brief-insights.md'],
+    next_context: ['.jumpstart/config.yaml', '.jumpstart/roadmap.md', 'specs/codebase-context.md']
+  },
+  '0': {
+    name: 'Challenger',
+    artifact: 'specs/challenger-brief.md',
+    next_phase: 1,
+    next_agent: 'analyst',
+    next_artifacts: ['specs/product-brief.md', 'specs/insights/product-brief-insights.md'],
+    next_context: ['.jumpstart/config.yaml', '.jumpstart/roadmap.md', 'specs/challenger-brief.md']
+  },
+  '1': {
+    name: 'Analyst',
+    artifact: 'specs/product-brief.md',
+    next_phase: 2,
+    next_agent: 'pm',
+    next_artifacts: ['specs/prd.md', 'specs/insights/prd-insights.md'],
+    next_context: ['.jumpstart/config.yaml', '.jumpstart/roadmap.md', 'specs/challenger-brief.md', 'specs/product-brief.md']
+  },
+  '2': {
+    name: 'PM',
+    artifact: 'specs/prd.md',
+    next_phase: 3,
+    next_agent: 'architect',
+    next_artifacts: ['specs/architecture.md', 'specs/implementation-plan.md', 'specs/insights/architecture-insights.md'],
+    next_context: ['.jumpstart/config.yaml', '.jumpstart/roadmap.md', 'specs/challenger-brief.md', 'specs/product-brief.md', 'specs/prd.md']
+  },
+  '3': {
+    name: 'Architect',
+    artifact: 'specs/architecture.md',
+    next_phase: 4,
+    next_agent: 'developer',
+    next_artifacts: ['specs/insights/implementation-insights.md'],
+    next_context: ['.jumpstart/config.yaml', '.jumpstart/roadmap.md', 'specs/prd.md', 'specs/architecture.md', 'specs/implementation-plan.md']
+  },
+  '4': {
+    name: 'Developer',
+    artifact: null,
+    next_phase: null,
+    next_agent: null,
+    next_artifacts: [],
+    next_context: []
+  }
+};
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Check if an artifact is approved by scanning for Phase Gate approval markers.
+ */
+export function isArtifactApproved(content: string): boolean {
+  if (!content) return false;
+  const hasGateSection = /## Phase Gate Approval/i.test(content);
+  if (!hasGateSection) return false;
+
+  // Check that "Approved by" is not "Pending"
+  const approvedByMatch = content.match(/\*\*Approved by:\*\*\s*(.+)/i);
+  if (!approvedByMatch || (approvedByMatch[1] ?? '').trim().toLowerCase() === 'pending') return false;
+
+  // Check all checkboxes are checked
+  const gateSection = content.split(/## Phase Gate Approval/i)[1] ?? '';
+  const unchecked = gateSection.match(/- \[ \]/g);
+  return !unchecked || unchecked.length === 0;
+}
+
+/**
+ * Determine the next phase handoff from a given phase.
+ */
+export function getHandoff(currentPhase: number): HandoffResult | HandoffErrorResult {
+  const key = String(currentPhase);
+  const transition = PHASE_MAP[key];
+
+  if (!transition) {
+    return { error: `Unknown phase: ${currentPhase}`, ready: false };
+  }
+
+  if (transition.next_phase === null) {
+    return {
+      current_phase: currentPhase,
+      next_phase: null,
+      next_agent: null,
+      message: 'Phase 4 is the final phase. No further handoff needed.',
+      ready: false
+    };
+  }
+
+  return {
+    current_phase: currentPhase,
+    current_name: transition.name,
+    next_phase: transition.next_phase,
+    next_agent: transition.next_agent,
+    artifacts_to_create: transition.next_artifacts,
+    context_files: transition.next_context,
+    ready: true
+  };
+}
+
+/**
+ * Execute a handoff and record it in the timeline.
+ */
+export function executeHandoff(currentPhase: number): HandoffResult | HandoffErrorResult {
+  const result = getHandoff(currentPhase);
+
+  if ('ready' in result && result.ready && _timelineHook) {
+    const r = result as HandoffResult;
+    _timelineHook.recordEvent({
+      event_type: 'handoff',
+      phase: currentPhase,
+      action: `Handoff: Phase ${currentPhase} (${r.current_name}) → Phase ${r.next_phase} (${r.next_agent})`,
+      metadata: {
+        source_phase: currentPhase,
+        target_phase: r.next_phase,
+        next_agent: r.next_agent,
+        context_files: r.context_files
+      }
+    });
+  }
+
+  return result;
+}

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -46,15 +46,15 @@ export const SKILL_PRESETS: Record<SkillLevel, SkillPreset> = {
     config_overrides: {
       'workflow.explanation_level': 'detailed',
       'workflow.show_hints': true,
-      'workflow.verbose_gates': true
+      'workflow.verbose_gates': true,
     },
     recommendations: [
       'Read the AGENTS.md file for an overview of the workflow',
       'Start with /jumpstart.challenge to define your problem',
       'Follow each phase sequentially — do not skip ahead',
       'Use /jumpstart.help at any time for phase-specific guidance',
-      'Review the Gherkin guide for writing acceptance criteria'
-    ]
+      'Review the Gherkin guide for writing acceptance criteria',
+    ],
   },
   intermediate: {
     explanation_depth: 'standard',
@@ -64,13 +64,13 @@ export const SKILL_PRESETS: Record<SkillLevel, SkillPreset> = {
     config_overrides: {
       'workflow.explanation_level': 'standard',
       'workflow.show_hints': false,
-      'workflow.verbose_gates': true
+      'workflow.verbose_gates': true,
     },
     recommendations: [
       'Run /jumpstart.status to see project progress at any time',
       'Use /jumpstart.pitcrew for multi-agent advisory discussions',
-      'Review specs/ artifacts before advancing phases'
-    ]
+      'Review specs/ artifacts before advancing phases',
+    ],
   },
   expert: {
     explanation_depth: 'minimal',
@@ -80,14 +80,14 @@ export const SKILL_PRESETS: Record<SkillLevel, SkillPreset> = {
     config_overrides: {
       'workflow.explanation_level': 'minimal',
       'workflow.show_hints': false,
-      'workflow.verbose_gates': false
+      'workflow.verbose_gates': false,
     },
     recommendations: [
       'Use /jumpstart.quick for small changes that skip full flow',
       'Run /jumpstart.crossref to validate spec linkage',
-      'Consider /jumpstart.scan for brownfield projects'
-    ]
-  }
+      'Consider /jumpstart.scan for brownfield projects',
+    ],
+  },
 };
 
 // ─── Public API ───────────────────────────────────────────────────────────────
@@ -123,6 +123,6 @@ export function generateInitConfig(input: GenerateInitConfigInput): InitConfig {
     verbose_gates: preset.verbose_gates,
     auto_hints: preset.auto_hints,
     config_overrides: preset.config_overrides,
-    recommendations
+    recommendations,
   };
 }

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -1,0 +1,128 @@
+/**
+ * init.ts -- Interactive Init (Item 76).
+ *
+ * Adjusts explanation detail based on user's chosen skill level.
+ * Pure in-memory computation — no file I/O, no process.exit (ADR-006).
+ */
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type SkillLevel = 'beginner' | 'intermediate' | 'expert';
+export type ProjectType = 'greenfield' | 'brownfield';
+
+export interface SkillPreset {
+  explanation_depth: string;
+  show_examples: boolean;
+  verbose_gates: boolean;
+  auto_hints: boolean;
+  config_overrides: Record<string, boolean | string>;
+  recommendations: string[];
+}
+
+export interface InitConfig {
+  skill_level: string;
+  project_type: string;
+  explanation_depth: string;
+  show_examples: boolean;
+  verbose_gates: boolean;
+  auto_hints: boolean;
+  config_overrides: Record<string, boolean | string>;
+  recommendations: string[];
+}
+
+export interface GenerateInitConfigInput {
+  skill_level?: string | undefined;
+  project_type?: string | undefined;
+}
+
+// ─── Skill-level presets ──────────────────────────────────────────────────────
+
+export const SKILL_PRESETS: Record<SkillLevel, SkillPreset> = {
+  beginner: {
+    explanation_depth: 'detailed',
+    show_examples: true,
+    verbose_gates: true,
+    auto_hints: true,
+    config_overrides: {
+      'workflow.explanation_level': 'detailed',
+      'workflow.show_hints': true,
+      'workflow.verbose_gates': true
+    },
+    recommendations: [
+      'Read the AGENTS.md file for an overview of the workflow',
+      'Start with /jumpstart.challenge to define your problem',
+      'Follow each phase sequentially — do not skip ahead',
+      'Use /jumpstart.help at any time for phase-specific guidance',
+      'Review the Gherkin guide for writing acceptance criteria'
+    ]
+  },
+  intermediate: {
+    explanation_depth: 'standard',
+    show_examples: false,
+    verbose_gates: true,
+    auto_hints: false,
+    config_overrides: {
+      'workflow.explanation_level': 'standard',
+      'workflow.show_hints': false,
+      'workflow.verbose_gates': true
+    },
+    recommendations: [
+      'Run /jumpstart.status to see project progress at any time',
+      'Use /jumpstart.pitcrew for multi-agent advisory discussions',
+      'Review specs/ artifacts before advancing phases'
+    ]
+  },
+  expert: {
+    explanation_depth: 'minimal',
+    show_examples: false,
+    verbose_gates: false,
+    auto_hints: false,
+    config_overrides: {
+      'workflow.explanation_level': 'minimal',
+      'workflow.show_hints': false,
+      'workflow.verbose_gates': false
+    },
+    recommendations: [
+      'Use /jumpstart.quick for small changes that skip full flow',
+      'Run /jumpstart.crossref to validate spec linkage',
+      'Consider /jumpstart.scan for brownfield projects'
+    ]
+  }
+};
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Generate initialization configuration based on skill level.
+ */
+export function generateInitConfig(input: GenerateInitConfigInput): InitConfig {
+  const { skill_level = 'intermediate', project_type = 'greenfield' } = input;
+  const normalizedLevel = skill_level.toLowerCase();
+
+  // Use Object.prototype.hasOwnProperty to safely check the preset exists
+  // (prevents __proto__/constructor/prototype keys from causing pollution).
+  const validLevels: SkillLevel[] = ['beginner', 'intermediate', 'expert'];
+  const safeLevel: SkillLevel = validLevels.includes(normalizedLevel as SkillLevel)
+    ? (normalizedLevel as SkillLevel)
+    : 'intermediate';
+
+  const preset: SkillPreset = SKILL_PRESETS[safeLevel];
+
+  // Add project-type-specific recommendations
+  const recommendations = [...preset.recommendations];
+  if (project_type === 'brownfield') {
+    recommendations.unshift('Run /jumpstart.scout first to analyze your existing codebase');
+    recommendations.push('The Scout output will inform all subsequent phases');
+  }
+
+  return {
+    skill_level: normalizedLevel,
+    project_type,
+    explanation_depth: preset.explanation_depth,
+    show_examples: preset.show_examples,
+    verbose_gates: preset.verbose_gates,
+    auto_hints: preset.auto_hints,
+    config_overrides: preset.config_overrides,
+    recommendations
+  };
+}

--- a/src/lib/invariants-check.ts
+++ b/src/lib/invariants-check.ts
@@ -9,8 +9,8 @@
  * ADR-006: no process.exit.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 export interface Invariant {
   id: string;
@@ -52,10 +52,13 @@ export function loadInvariants(invariantsPath: string): Invariant[] {
   const tableMatch = content.match(/\|[^|]*\|[^|]*\|[^|]*\|[^|]*\|[^|]*\|/gm);
   if (!tableMatch) return invariants;
 
-  const rows = tableMatch.filter(row => !row.includes('---') && !row.includes('Category'));
+  const rows = tableMatch.filter((row) => !row.includes('---') && !row.includes('Category'));
 
   for (const row of rows) {
-    const cells = row.split('|').map(c => c.trim()).filter(c => c);
+    const cells = row
+      .split('|')
+      .map((c) => c.trim())
+      .filter((c) => c);
     if (cells.length >= 4) {
       const id = cells[0] ?? '';
       const name = cells[1] ?? '';
@@ -72,7 +75,10 @@ export function loadInvariants(invariantsPath: string): Invariant[] {
 /**
  * Check architecture document against invariants.
  */
-export function checkAgainstArchitecture(archContent: string, invariants: Invariant[]): ArchCoverage {
+export function checkAgainstArchitecture(
+  archContent: string,
+  invariants: Invariant[]
+): ArchCoverage {
   const passed: Array<Invariant & { coverage: number }> = [];
   const failed: Array<Invariant & { coverage: number }> = [];
   const warnings: string[] = [];
@@ -83,9 +89,9 @@ export function checkAgainstArchitecture(archContent: string, invariants: Invari
     const keywords = inv.requirement
       .toLowerCase()
       .split(/[\s,;.]+/)
-      .filter(w => w.length > 4);
+      .filter((w) => w.length > 4);
 
-    const keywordHits = keywords.filter(kw => contentLower.includes(kw));
+    const keywordHits = keywords.filter((kw) => contentLower.includes(kw));
     const coverage = keywords.length > 0 ? keywordHits.length / keywords.length : 0;
 
     if (coverage >= 0.3) {
@@ -94,7 +100,7 @@ export function checkAgainstArchitecture(archContent: string, invariants: Invari
       failed.push({ ...inv, coverage: Math.round(coverage * 100) });
       warnings.push(
         `Invariant "${inv.name}" (${inv.id}) — ${inv.category}: ` +
-        `Architecture document may not address: "${inv.requirement}"`
+          `Architecture document may not address: "${inv.requirement}"`
       );
     }
   }
@@ -112,7 +118,7 @@ export function checkAgainstPlan(planContent: string, invariants: Invariant[]): 
 
   for (const inv of invariants) {
     const nameWords = inv.name.toLowerCase().split(/\s+/);
-    const found = nameWords.some(w => w.length > 3 && contentLower.includes(w));
+    const found = nameWords.some((w) => w.length > 3 && contentLower.includes(w));
 
     if (found) {
       addressed.push(inv.id);
@@ -135,7 +141,7 @@ export function generateReport(invariantsPath: string, specsDir: string): Invari
       invariantCount: 0,
       archCoverage: null,
       planCoverage: null,
-      summary: 'No invariants defined.'
+      summary: 'No invariants defined.',
     };
   }
 
@@ -154,9 +160,10 @@ export function generateReport(invariantsPath: string, specsDir: string): Invari
   }
 
   const failedCount = archCoverage ? archCoverage.failed.length : invariants.length;
-  const summary = failedCount === 0
-    ? `All ${invariants.length} invariant(s) addressed in architecture.`
-    : `${failedCount}/${invariants.length} invariant(s) may not be addressed in architecture.`;
+  const summary =
+    failedCount === 0
+      ? `All ${invariants.length} invariant(s) addressed in architecture.`
+      : `${failedCount}/${invariants.length} invariant(s) may not be addressed in architecture.`;
 
   return { invariantCount: invariants.length, archCoverage, planCoverage, summary };
 }

--- a/src/lib/invariants-check.ts
+++ b/src/lib/invariants-check.ts
@@ -1,0 +1,162 @@
+/**
+ * invariants-check.ts — Environment Invariants ("Roadmapal Invariants") (Item 15).
+ *
+ * Non-negotiable rules (encryption-at-rest, audit logging, etc.)
+ * enforced pre-implementation.
+ *
+ * M3 hardening: no JSON state — reads .md files only, no persist paths.
+ * ADR-009: paths must be pre-validated by caller (assertInsideRoot / safeJoin).
+ * ADR-006: no process.exit.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface Invariant {
+  id: string;
+  name: string;
+  category: string;
+  requirement: string;
+  verification: string;
+}
+
+export interface ArchCoverage {
+  passed: Array<Invariant & { coverage: number }>;
+  failed: Array<Invariant & { coverage: number }>;
+  warnings: string[];
+}
+
+export interface PlanCoverage {
+  addressed: string[];
+  unaddressed: string[];
+}
+
+export interface InvariantsReport {
+  invariantCount: number;
+  archCoverage: ArchCoverage | null;
+  planCoverage: PlanCoverage | null;
+  summary: string;
+}
+
+/**
+ * Load invariants from the invariants file.
+ */
+export function loadInvariants(invariantsPath: string): Invariant[] {
+  if (!fs.existsSync(invariantsPath)) {
+    return [];
+  }
+
+  const content = fs.readFileSync(invariantsPath, 'utf8');
+  const invariants: Invariant[] = [];
+
+  const tableMatch = content.match(/\|[^|]*\|[^|]*\|[^|]*\|[^|]*\|[^|]*\|/gm);
+  if (!tableMatch) return invariants;
+
+  const rows = tableMatch.filter(row => !row.includes('---') && !row.includes('Category'));
+
+  for (const row of rows) {
+    const cells = row.split('|').map(c => c.trim()).filter(c => c);
+    if (cells.length >= 4) {
+      const id = cells[0] ?? '';
+      const name = cells[1] ?? '';
+      const category = cells[2] ?? '';
+      const requirement = cells[3] ?? '';
+      const verification = cells[4] ?? 'Manual review';
+      invariants.push({ id, name, category, requirement, verification });
+    }
+  }
+
+  return invariants;
+}
+
+/**
+ * Check architecture document against invariants.
+ */
+export function checkAgainstArchitecture(archContent: string, invariants: Invariant[]): ArchCoverage {
+  const passed: Array<Invariant & { coverage: number }> = [];
+  const failed: Array<Invariant & { coverage: number }> = [];
+  const warnings: string[] = [];
+
+  const contentLower = archContent.toLowerCase();
+
+  for (const inv of invariants) {
+    const keywords = inv.requirement
+      .toLowerCase()
+      .split(/[\s,;.]+/)
+      .filter(w => w.length > 4);
+
+    const keywordHits = keywords.filter(kw => contentLower.includes(kw));
+    const coverage = keywords.length > 0 ? keywordHits.length / keywords.length : 0;
+
+    if (coverage >= 0.3) {
+      passed.push({ ...inv, coverage: Math.round(coverage * 100) });
+    } else {
+      failed.push({ ...inv, coverage: Math.round(coverage * 100) });
+      warnings.push(
+        `Invariant "${inv.name}" (${inv.id}) — ${inv.category}: ` +
+        `Architecture document may not address: "${inv.requirement}"`
+      );
+    }
+  }
+
+  return { passed, failed, warnings };
+}
+
+/**
+ * Check implementation plan against invariants.
+ */
+export function checkAgainstPlan(planContent: string, invariants: Invariant[]): PlanCoverage {
+  const addressed: string[] = [];
+  const unaddressed: string[] = [];
+  const contentLower = planContent.toLowerCase();
+
+  for (const inv of invariants) {
+    const nameWords = inv.name.toLowerCase().split(/\s+/);
+    const found = nameWords.some(w => w.length > 3 && contentLower.includes(w));
+
+    if (found) {
+      addressed.push(inv.id);
+    } else {
+      unaddressed.push(inv.id);
+    }
+  }
+
+  return { addressed, unaddressed };
+}
+
+/**
+ * Generate a compliance report for all invariants.
+ */
+export function generateReport(invariantsPath: string, specsDir: string): InvariantsReport {
+  const invariants = loadInvariants(invariantsPath);
+
+  if (invariants.length === 0) {
+    return {
+      invariantCount: 0,
+      archCoverage: null,
+      planCoverage: null,
+      summary: 'No invariants defined.'
+    };
+  }
+
+  let archCoverage: ArchCoverage | null = null;
+  const archPath = path.join(specsDir, 'architecture.md');
+  if (fs.existsSync(archPath)) {
+    const archContent = fs.readFileSync(archPath, 'utf8');
+    archCoverage = checkAgainstArchitecture(archContent, invariants);
+  }
+
+  let planCoverage: PlanCoverage | null = null;
+  const planPath = path.join(specsDir, 'implementation-plan.md');
+  if (fs.existsSync(planPath)) {
+    const planContent = fs.readFileSync(planPath, 'utf8');
+    planCoverage = checkAgainstPlan(planContent, invariants);
+  }
+
+  const failedCount = archCoverage ? archCoverage.failed.length : invariants.length;
+  const summary = failedCount === 0
+    ? `All ${invariants.length} invariant(s) addressed in architecture.`
+    : `${failedCount}/${invariants.length} invariant(s) may not be addressed in architecture.`;
+
+  return { invariantCount: invariants.length, archCoverage, planCoverage, summary };
+}

--- a/src/lib/knowledge-graph.ts
+++ b/src/lib/knowledge-graph.ts
@@ -12,16 +12,23 @@
  * defaultState fallback: loadState returns defaultState() on parse failure.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 const DEFAULT_STATE_FILE = path.join('.jumpstart', 'state', 'knowledge-graph.json');
 
-export const NODE_TYPES = ['pattern', 'decision', 'control', 'component', 'skill', 'module'] as const;
+export const NODE_TYPES = [
+  'pattern',
+  'decision',
+  'control',
+  'component',
+  'skill',
+  'module',
+] as const;
 export const EDGE_TYPES = ['uses', 'implements', 'depends-on', 'related-to', 'supersedes'] as const;
 
-export type NodeType = typeof NODE_TYPES[number];
-export type EdgeType = typeof EDGE_TYPES[number];
+export type NodeType = (typeof NODE_TYPES)[number];
+export type EdgeType = (typeof EDGE_TYPES)[number];
 
 export interface KGNode {
   id: string;
@@ -84,7 +91,7 @@ export function saveState(state: KGState, stateFile?: string | null | undefined)
   const dir = path.dirname(fp);
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
   state.last_updated = new Date().toISOString();
-  fs.writeFileSync(fp, JSON.stringify(state, null, 2) + '\n', 'utf8');
+  fs.writeFileSync(fp, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
 }
 
 export interface AddNodeOptions {
@@ -114,7 +121,7 @@ export function addNode(name: string, type: string, options: AddNodeOptions = {}
     type: type as NodeType,
     tags: options.tags ?? [],
     metadata: options.metadata ?? {},
-    created_at: new Date().toISOString()
+    created_at: new Date().toISOString(),
   };
 
   state.nodes.push(node);
@@ -133,16 +140,30 @@ export interface AddEdgeResult {
   error?: string | undefined;
 }
 
-export function addEdge(fromId: string, toId: string, edgeType: string, options: AddEdgeOptions = {}): AddEdgeResult {
-  if (!fromId || !toId || !edgeType) return { success: false, error: 'fromId, toId, and edgeType are required' };
+export function addEdge(
+  fromId: string,
+  toId: string,
+  edgeType: string,
+  options: AddEdgeOptions = {}
+): AddEdgeResult {
+  if (!fromId || !toId || !edgeType)
+    return { success: false, error: 'fromId, toId, and edgeType are required' };
   if (!(EDGE_TYPES as readonly string[]).includes(edgeType)) {
-    return { success: false, error: `Unknown edge type: ${edgeType}. Valid: ${EDGE_TYPES.join(', ')}` };
+    return {
+      success: false,
+      error: `Unknown edge type: ${edgeType}. Valid: ${EDGE_TYPES.join(', ')}`,
+    };
   }
 
   const stateFile = options.stateFile;
   const state = loadState(stateFile);
 
-  const edge: KGEdge = { from: fromId, to: toId, type: edgeType as EdgeType, created_at: new Date().toISOString() };
+  const edge: KGEdge = {
+    from: fromId,
+    to: toId,
+    type: edgeType as EdgeType,
+    created_at: new Date().toISOString(),
+  };
   state.edges.push(edge);
   saveState(state, stateFile);
 
@@ -168,20 +189,20 @@ export function queryGraph(options: QueryOptions = {}): QueryResult {
   const state = loadState(options.stateFile);
 
   let nodes = state.nodes;
-  if (options.type) nodes = nodes.filter(n => n.type === options.type);
-  if (options.tag) nodes = nodes.filter(n => n.tags.includes(options.tag as string));
+  if (options.type) nodes = nodes.filter((n) => n.type === options.type);
+  if (options.tag) nodes = nodes.filter((n) => n.tags.includes(options.tag as string));
   if (options.search) {
     const q = options.search.toLowerCase();
-    nodes = nodes.filter(n => n.name.toLowerCase().includes(q));
+    nodes = nodes.filter((n) => n.name.toLowerCase().includes(q));
   }
 
-  const nodeIds = new Set(nodes.map(n => n.id));
+  const nodeIds = new Set(nodes.map((n) => n.id));
   return {
     success: true,
     nodes: nodes.length,
     edges: state.edges.length,
     results: nodes,
-    related_edges: state.edges.filter(e => nodeIds.has(e.from) || nodeIds.has(e.to))
+    related_edges: state.edges.filter((e) => nodeIds.has(e.from) || nodeIds.has(e.to)),
   };
 }
 
@@ -208,6 +229,6 @@ export function generateReport(options: ReportOptions = {}): ReportResult {
     success: true,
     total_nodes: state.nodes.length,
     total_edges: state.edges.length,
-    by_type: byType
+    by_type: byType,
   };
 }

--- a/src/lib/knowledge-graph.ts
+++ b/src/lib/knowledge-graph.ts
@@ -1,0 +1,213 @@
+/**
+ * knowledge-graph.ts — Knowledge Graph Across Initiatives (Item 81).
+ *
+ * Reuse patterns, controls, decisions, skills, and modules across the enterprise.
+ *
+ * State file: .jumpstart/state/knowledge-graph.json
+ *
+ * M3 hardening: validates JSON keys rejecting __proto__/constructor/prototype
+ *   before merging into state.
+ * ADR-009: stateFile paths must be pre-validated by caller or use default.
+ * ADR-006: no process.exit — returns error objects on failure.
+ * defaultState fallback: loadState returns defaultState() on parse failure.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const DEFAULT_STATE_FILE = path.join('.jumpstart', 'state', 'knowledge-graph.json');
+
+export const NODE_TYPES = ['pattern', 'decision', 'control', 'component', 'skill', 'module'] as const;
+export const EDGE_TYPES = ['uses', 'implements', 'depends-on', 'related-to', 'supersedes'] as const;
+
+export type NodeType = typeof NODE_TYPES[number];
+export type EdgeType = typeof EDGE_TYPES[number];
+
+export interface KGNode {
+  id: string;
+  name: string;
+  type: NodeType;
+  tags: string[];
+  metadata: Record<string, unknown>;
+  created_at: string;
+}
+
+export interface KGEdge {
+  from: string;
+  to: string;
+  type: EdgeType;
+  created_at: string;
+}
+
+export interface KGState {
+  version: string;
+  nodes: KGNode[];
+  edges: KGEdge[];
+  last_updated: string | null;
+}
+
+/** Dangerous keys that must never appear in parsed JSON objects */
+const BLOCKED_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/**
+ * Recursively check an object for prototype-pollution keys.
+ * Throws if any blocked key is found.
+ */
+function assertNoPollution(obj: unknown, path_ = ''): void {
+  if (obj === null || typeof obj !== 'object') return;
+  for (const key of Object.keys(obj as object)) {
+    if (BLOCKED_KEYS.has(key)) {
+      throw new Error(`Prototype pollution key detected at ${path_}.${key}`);
+    }
+    assertNoPollution((obj as Record<string, unknown>)[key], `${path_}.${key}`);
+  }
+}
+
+export function defaultState(): KGState {
+  return { version: '1.0.0', nodes: [], edges: [], last_updated: null };
+}
+
+export function loadState(stateFile?: string | null | undefined): KGState {
+  const fp = stateFile ?? DEFAULT_STATE_FILE;
+  if (!fs.existsSync(fp)) return defaultState();
+  try {
+    const raw = JSON.parse(fs.readFileSync(fp, 'utf8'));
+    assertNoPollution(raw);
+    return raw as KGState;
+  } catch {
+    return defaultState();
+  }
+}
+
+export function saveState(state: KGState, stateFile?: string | null | undefined): void {
+  const fp = stateFile ?? DEFAULT_STATE_FILE;
+  const dir = path.dirname(fp);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  state.last_updated = new Date().toISOString();
+  fs.writeFileSync(fp, JSON.stringify(state, null, 2) + '\n', 'utf8');
+}
+
+export interface AddNodeOptions {
+  stateFile?: string | null | undefined;
+  tags?: string[] | undefined;
+  metadata?: Record<string, unknown> | undefined;
+}
+
+export interface AddNodeResult {
+  success: boolean;
+  node?: KGNode | undefined;
+  error?: string | undefined;
+}
+
+export function addNode(name: string, type: string, options: AddNodeOptions = {}): AddNodeResult {
+  if (!name || !type) return { success: false, error: 'name and type are required' };
+  if (!(NODE_TYPES as readonly string[]).includes(type)) {
+    return { success: false, error: `Unknown type: ${type}. Valid: ${NODE_TYPES.join(', ')}` };
+  }
+
+  const stateFile = options.stateFile;
+  const state = loadState(stateFile);
+
+  const node: KGNode = {
+    id: `KG-${Date.now()}`,
+    name,
+    type: type as NodeType,
+    tags: options.tags ?? [],
+    metadata: options.metadata ?? {},
+    created_at: new Date().toISOString()
+  };
+
+  state.nodes.push(node);
+  saveState(state, stateFile);
+
+  return { success: true, node };
+}
+
+export interface AddEdgeOptions {
+  stateFile?: string | null | undefined;
+}
+
+export interface AddEdgeResult {
+  success: boolean;
+  edge?: KGEdge | undefined;
+  error?: string | undefined;
+}
+
+export function addEdge(fromId: string, toId: string, edgeType: string, options: AddEdgeOptions = {}): AddEdgeResult {
+  if (!fromId || !toId || !edgeType) return { success: false, error: 'fromId, toId, and edgeType are required' };
+  if (!(EDGE_TYPES as readonly string[]).includes(edgeType)) {
+    return { success: false, error: `Unknown edge type: ${edgeType}. Valid: ${EDGE_TYPES.join(', ')}` };
+  }
+
+  const stateFile = options.stateFile;
+  const state = loadState(stateFile);
+
+  const edge: KGEdge = { from: fromId, to: toId, type: edgeType as EdgeType, created_at: new Date().toISOString() };
+  state.edges.push(edge);
+  saveState(state, stateFile);
+
+  return { success: true, edge };
+}
+
+export interface QueryOptions {
+  stateFile?: string | null | undefined;
+  type?: string | undefined;
+  tag?: string | undefined;
+  search?: string | undefined;
+}
+
+export interface QueryResult {
+  success: boolean;
+  nodes: number;
+  edges: number;
+  results: KGNode[];
+  related_edges: KGEdge[];
+}
+
+export function queryGraph(options: QueryOptions = {}): QueryResult {
+  const state = loadState(options.stateFile);
+
+  let nodes = state.nodes;
+  if (options.type) nodes = nodes.filter(n => n.type === options.type);
+  if (options.tag) nodes = nodes.filter(n => n.tags.includes(options.tag as string));
+  if (options.search) {
+    const q = options.search.toLowerCase();
+    nodes = nodes.filter(n => n.name.toLowerCase().includes(q));
+  }
+
+  const nodeIds = new Set(nodes.map(n => n.id));
+  return {
+    success: true,
+    nodes: nodes.length,
+    edges: state.edges.length,
+    results: nodes,
+    related_edges: state.edges.filter(e => nodeIds.has(e.from) || nodeIds.has(e.to))
+  };
+}
+
+export interface ReportOptions {
+  stateFile?: string | null | undefined;
+}
+
+export interface ReportResult {
+  success: boolean;
+  total_nodes: number;
+  total_edges: number;
+  by_type: Record<string, number>;
+}
+
+export function generateReport(options: ReportOptions = {}): ReportResult {
+  const state = loadState(options.stateFile);
+
+  const byType: Record<string, number> = {};
+  for (const n of state.nodes) {
+    byType[n.type] = (byType[n.type] ?? 0) + 1;
+  }
+
+  return {
+    success: true,
+    total_nodes: state.nodes.length,
+    total_edges: state.edges.length,
+    by_type: byType
+  };
+}

--- a/src/lib/lint-runner.ts
+++ b/src/lib/lint-runner.ts
@@ -12,9 +12,9 @@
  * to prevent shell injection (same pattern as smoke-tester.ts).
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
-import { spawnSync } from 'child_process';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -83,8 +83,8 @@ export function detectLinter(root: string): LinterInfo | null {
   if (fs.existsSync(pkgPath)) {
     try {
       const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as Record<string, unknown>;
-      const scripts = pkg['scripts'] as Record<string, unknown> | undefined;
-      if (scripts && typeof scripts['lint'] === 'string') {
+      const scripts = pkg.scripts as Record<string, unknown> | undefined;
+      if (scripts && typeof scripts.lint === 'string') {
         return { command: 'npm run lint --', name: 'npm lint script' };
       }
     } catch {
@@ -119,7 +119,7 @@ export function parseFindings(output: string): LintFinding[] {
         file: eslintMatch[1] ?? '',
         line: parseInt(eslintMatch[2] ?? '0', 10),
         severity: eslintMatch[3] ?? 'error',
-        message: (eslintMatch[4] ?? '').trim()
+        message: (eslintMatch[4] ?? '').trim(),
       });
       continue;
     }
@@ -131,7 +131,7 @@ export function parseFindings(output: string): LintFinding[] {
         file: genericMatch[1] ?? '',
         line: parseInt(genericMatch[2] ?? '0', 10),
         severity: 'error',
-        message: (genericMatch[3] ?? '').trim()
+        message: (genericMatch[3] ?? '').trim(),
       });
     }
   }
@@ -150,7 +150,10 @@ function runCommand(
   extraArgs: string[],
   cwd: string
 ): { output: string; exitCode: number } {
-  const parts = command.trim().split(/\s+/).filter(p => p.length > 0);
+  const parts = command
+    .trim()
+    .split(/\s+/)
+    .filter((p) => p.length > 0);
   const head = parts[0];
   if (!head) return { output: 'Empty command', exitCode: 1 };
   const tail = [...parts.slice(1), ...extraArgs];
@@ -176,8 +179,7 @@ function runCommand(
  */
 export function runLint(input: RunLintInput | string): LintResult {
   // Accept a plain string root path for backward compat with CLI callers.
-  const normalised: RunLintInput =
-    typeof input === 'string' ? { root: input } : input;
+  const normalised: RunLintInput = typeof input === 'string' ? { root: input } : input;
 
   const { files = [], root = '.', config = {} } = normalised;
   const resolvedRoot = path.resolve(root);
@@ -199,17 +201,15 @@ export function runLint(input: RunLintInput | string): LintResult {
       pass: true,
       fix_tasks: [],
       linter: null,
-      message: 'No linter detected. Consider adding ESLint, Pylint, or a similar tool.'
+      message: 'No linter detected. Consider adding ESLint, Pylint, or a similar tool.',
     };
   }
 
   // Append --fix flag if requested
-  const baseCommand = config.fix
-    ? `${linterInfo.command} --fix`
-    : linterInfo.command;
+  const baseCommand = config.fix ? `${linterInfo.command} --fix` : linterInfo.command;
 
   // Filter to existing files
-  const existingFiles = files.filter(f => {
+  const existingFiles = files.filter((f) => {
     const fp = path.isAbsolute(f) ? f : path.join(resolvedRoot, f);
     return fs.existsSync(fp);
   });
@@ -224,7 +224,7 @@ export function runLint(input: RunLintInput | string): LintResult {
       pass: true,
       fix_tasks: [],
       linter: linterInfo.name,
-      message: 'No existing files to lint.'
+      message: 'No existing files to lint.',
     };
   }
 
@@ -232,8 +232,8 @@ export function runLint(input: RunLintInput | string): LintResult {
   const { output, exitCode } = runCommand(baseCommand, existingFiles, resolvedRoot);
 
   const findings = parseFindings(output);
-  const errors = findings.filter(f => f.severity === 'error').length;
-  const warnings = findings.filter(f => f.severity === 'warning').length;
+  const errors = findings.filter((f) => f.severity === 'error').length;
+  const warnings = findings.filter((f) => f.severity === 'warning').length;
 
   // Generate fix tasks for errors grouped by file
   const fixTasks: FixTask[] = [];
@@ -254,7 +254,7 @@ export function runLint(input: RunLintInput | string): LintResult {
       file,
       error_count: errs.length,
       description: `Fix ${errs.length} lint error(s) in ${file}`,
-      errors: errs.map(e => ({ line: e.line, message: e.message }))
+      errors: errs.map((e) => ({ line: e.line, message: e.message })),
     });
   });
 
@@ -266,6 +266,6 @@ export function runLint(input: RunLintInput | string): LintResult {
     pass: errors === 0,
     fix_tasks: fixTasks,
     linter: linterInfo.name,
-    exit_code: exitCode
+    exit_code: exitCode,
   };
 }

--- a/src/lib/lint-runner.ts
+++ b/src/lib/lint-runner.ts
@@ -1,0 +1,271 @@
+/**
+ * lint-runner.ts -- Lint-on-Save for Agents (Item 66).
+ *
+ * Runs configured linters after agent writes to src/.
+ * Failures create a fix task artifact.
+ *
+ * M3 hardening: no JSON state — pure command execution.
+ * ADR-006: no process.exit.
+ * ADR-009: root paths validated by caller before passing in.
+ *
+ * Security: commands are tokenized and run via spawnSync(shell:false)
+ * to prevent shell injection (same pattern as smoke-tester.ts).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface LinterInfo {
+  command: string;
+  name: string;
+}
+
+export interface LintFinding {
+  file: string;
+  line: number | null;
+  severity: string;
+  message: string;
+}
+
+export interface FixTask {
+  file: string;
+  error_count: number;
+  description: string;
+  errors: Array<{ line: number | null; message: string }>;
+}
+
+export interface LintResult {
+  files_checked: number;
+  errors: number;
+  warnings: number;
+  findings: LintFinding[];
+  pass: boolean;
+  fix_tasks: FixTask[];
+  linter: string | null;
+  message?: string | undefined;
+  exit_code?: number | undefined;
+}
+
+export interface LintConfig {
+  lint_command?: string | undefined;
+  fix?: boolean | undefined;
+}
+
+export interface RunLintInput {
+  files?: string[] | undefined;
+  root?: string | undefined;
+  config?: LintConfig | undefined;
+}
+
+// ─── Linter detection ────────────────────────────────────────────────────────
+
+const LINTER_CHECKS: Array<{ file: string; command: string; name: string }> = [
+  { file: '.eslintrc.json', command: 'npx eslint', name: 'ESLint' },
+  { file: '.eslintrc.js', command: 'npx eslint', name: 'ESLint' },
+  { file: '.eslintrc.yml', command: 'npx eslint', name: 'ESLint' },
+  { file: 'eslint.config.js', command: 'npx eslint', name: 'ESLint (flat)' },
+  { file: 'eslint.config.mjs', command: 'npx eslint', name: 'ESLint (flat)' },
+  { file: '.pylintrc', command: 'python -m pylint', name: 'Pylint' },
+  { file: 'setup.cfg', command: 'python -m flake8', name: 'Flake8' },
+  { file: 'pyproject.toml', command: 'python -m ruff check', name: 'Ruff' },
+  { file: 'biome.json', command: 'npx @biomejs/biome lint', name: 'Biome' },
+];
+
+/**
+ * Detect the project's linter from configuration files.
+ */
+export function detectLinter(root: string): LinterInfo | null {
+  // Also check package.json for lint script
+  const pkgPath = path.join(root, 'package.json');
+  if (fs.existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as Record<string, unknown>;
+      const scripts = pkg['scripts'] as Record<string, unknown> | undefined;
+      if (scripts && typeof scripts['lint'] === 'string') {
+        return { command: 'npm run lint --', name: 'npm lint script' };
+      }
+    } catch {
+      // ignore parse errors
+    }
+  }
+
+  for (const check of LINTER_CHECKS) {
+    if (fs.existsSync(path.join(root, check.file))) {
+      return { command: check.command, name: check.name };
+    }
+  }
+
+  return null;
+}
+
+// ─── Output parsing ───────────────────────────────────────────────────────────
+
+/**
+ * Parse linter output into structured findings.
+ * Handles common output formats (ESLint, Pylint, etc.).
+ */
+export function parseFindings(output: string): LintFinding[] {
+  const findings: LintFinding[] = [];
+  const lines = output.split('\n');
+
+  for (const line of lines) {
+    // ESLint format: /path/file.js:10:5: error message (rule-name)
+    const eslintMatch = line.match(/^(.+?):(\d+):\d+:\s+(error|warning)\s+(.+)/);
+    if (eslintMatch) {
+      findings.push({
+        file: eslintMatch[1] ?? '',
+        line: parseInt(eslintMatch[2] ?? '0', 10),
+        severity: eslintMatch[3] ?? 'error',
+        message: (eslintMatch[4] ?? '').trim()
+      });
+      continue;
+    }
+
+    // Generic pattern: file:line: message
+    const genericMatch = line.match(/^(.+?):(\d+):\s+(.+)/);
+    if (genericMatch && !line.startsWith(' ')) {
+      findings.push({
+        file: genericMatch[1] ?? '',
+        line: parseInt(genericMatch[2] ?? '0', 10),
+        severity: 'error',
+        message: (genericMatch[3] ?? '').trim()
+      });
+    }
+  }
+
+  return findings;
+}
+
+// ─── Command execution ────────────────────────────────────────────────────────
+
+/**
+ * Tokenize a command string and run via spawnSync with shell:false
+ * (same pattern as smoke-tester.ts — prevents shell injection).
+ */
+function runCommand(
+  command: string,
+  extraArgs: string[],
+  cwd: string
+): { output: string; exitCode: number } {
+  const parts = command.trim().split(/\s+/).filter(p => p.length > 0);
+  const head = parts[0];
+  if (!head) return { output: 'Empty command', exitCode: 1 };
+  const tail = [...parts.slice(1), ...extraArgs];
+
+  const result = spawnSync(head, tail, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: 60000,
+    shell: false,
+  });
+
+  const output = (result.stdout ?? '') + (result.stderr ?? '');
+  const exitCode = result.status ?? 1;
+  return { output, exitCode };
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Run linter on specified files.
+ * When called with a string, treats it as the root directory (backward compat).
+ */
+export function runLint(input: RunLintInput | string): LintResult {
+  // Accept a plain string root path for backward compat with CLI callers.
+  const normalised: RunLintInput =
+    typeof input === 'string' ? { root: input } : input;
+
+  const { files = [], root = '.', config = {} } = normalised;
+  const resolvedRoot = path.resolve(root);
+
+  // Determine linter
+  let linterInfo: LinterInfo | null;
+  if (config.lint_command) {
+    linterInfo = { command: config.lint_command, name: 'custom' };
+  } else {
+    linterInfo = detectLinter(resolvedRoot);
+  }
+
+  if (!linterInfo) {
+    return {
+      files_checked: files.length,
+      errors: 0,
+      warnings: 0,
+      findings: [],
+      pass: true,
+      fix_tasks: [],
+      linter: null,
+      message: 'No linter detected. Consider adding ESLint, Pylint, or a similar tool.'
+    };
+  }
+
+  // Append --fix flag if requested
+  const baseCommand = config.fix
+    ? `${linterInfo.command} --fix`
+    : linterInfo.command;
+
+  // Filter to existing files
+  const existingFiles = files.filter(f => {
+    const fp = path.isAbsolute(f) ? f : path.join(resolvedRoot, f);
+    return fs.existsSync(fp);
+  });
+
+  // If files were specified but none exist, return early
+  if (files.length > 0 && existingFiles.length === 0) {
+    return {
+      files_checked: 0,
+      errors: 0,
+      warnings: 0,
+      findings: [],
+      pass: true,
+      fix_tasks: [],
+      linter: linterInfo.name,
+      message: 'No existing files to lint.'
+    };
+  }
+
+  // Run the linter: pass file args separately so spawnSync can handle them safely
+  const { output, exitCode } = runCommand(baseCommand, existingFiles, resolvedRoot);
+
+  const findings = parseFindings(output);
+  const errors = findings.filter(f => f.severity === 'error').length;
+  const warnings = findings.filter(f => f.severity === 'warning').length;
+
+  // Generate fix tasks for errors grouped by file
+  const fixTasks: FixTask[] = [];
+  const fileErrors = new Map<string, LintFinding[]>();
+  for (const finding of findings) {
+    if (finding.severity === 'error') {
+      const existing = fileErrors.get(finding.file);
+      if (existing) {
+        existing.push(finding);
+      } else {
+        fileErrors.set(finding.file, [finding]);
+      }
+    }
+  }
+
+  fileErrors.forEach((errs, file) => {
+    fixTasks.push({
+      file,
+      error_count: errs.length,
+      description: `Fix ${errs.length} lint error(s) in ${file}`,
+      errors: errs.map(e => ({ line: e.line, message: e.message }))
+    });
+  });
+
+  return {
+    files_checked: existingFiles.length > 0 ? existingFiles.length : files.length,
+    errors,
+    warnings,
+    findings,
+    pass: errors === 0,
+    fix_tasks: fixTasks,
+    linter: linterInfo.name,
+    exit_code: exitCode
+  };
+}

--- a/src/lib/module-loader.ts
+++ b/src/lib/module-loader.ts
@@ -10,8 +10,8 @@
  * ADR-009: modulesDir validated by caller.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -103,7 +103,7 @@ export function discoverModules(modulesDir: string): DiscoveredModule[] {
       modules.push({
         name: (manifest.name as string | undefined) || entry.name,
         path: modDir,
-        manifest
+        manifest,
       });
     } catch {
       // Skip modules with invalid or dangerous manifests
@@ -174,13 +174,13 @@ export function loadModule(modulesDir: string, moduleName: string): LoadModuleRe
       return {
         loaded: false,
         module: null,
-        error: `Invalid manifest: ${validation.errors.join('; ')}`
+        error: `Invalid manifest: ${validation.errors.join('; ')}`,
       };
     }
 
     // Resolve resource paths — only include files that actually exist
     const resolve = (arr: string[] | undefined): string[] =>
-      (arr ?? []).map(f => path.join(modDir, f)).filter(f => fs.existsSync(f));
+      (arr ?? []).map((f) => path.join(modDir, f)).filter((f) => fs.existsSync(f));
 
     return {
       loaded: true,
@@ -194,9 +194,9 @@ export function loadModule(modulesDir: string, moduleName: string): LoadModuleRe
         commands: resolve(manifest.commands),
         checks: resolve(manifest.checks),
         skills: resolve(manifest.skills),
-        manifest
+        manifest,
       },
-      error: null
+      error: null,
     };
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -216,9 +216,7 @@ export function loadAllModules(
   const errors: string[] = [];
   const modules: LoadedModule[] = [];
 
-  const toLoad = enabledList
-    ? discovered.filter(m => enabledList.includes(m.name))
-    : discovered;
+  const toLoad = enabledList ? discovered.filter((m) => enabledList.includes(m.name)) : discovered;
 
   for (const mod of toLoad) {
     const result = loadModule(modulesDir, mod.name);

--- a/src/lib/module-loader.ts
+++ b/src/lib/module-loader.ts
@@ -1,0 +1,233 @@
+/**
+ * module-loader.ts -- Pluggable Module System for Jump Start (Item 91).
+ *
+ * Loads add-on modules from `.jumpstart/modules/`. Each module can provide
+ * additional agents, templates, commands, and quality checks.
+ *
+ * M3 hardening: assertNoPollution() applied to all parsed module.json before
+ * use — rejects __proto__/constructor/prototype keys.
+ * ADR-006: no process.exit.
+ * ADR-009: modulesDir validated by caller.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface ModuleManifest {
+  name: string;
+  version: string;
+  description: string;
+  agents?: string[] | undefined;
+  templates?: string[] | undefined;
+  commands?: string[] | undefined;
+  checks?: string[] | undefined;
+  skills?: string[] | undefined;
+  [key: string]: unknown;
+}
+
+export interface DiscoveredModule {
+  name: string;
+  path: string;
+  manifest: ModuleManifest;
+}
+
+export interface LoadedModule {
+  name: string;
+  version: string;
+  description: string;
+  path: string;
+  agents: string[];
+  templates: string[];
+  commands: string[];
+  checks: string[];
+  skills: string[];
+  manifest: ModuleManifest;
+}
+
+export interface LoadModuleResult {
+  loaded: boolean;
+  module: LoadedModule | null;
+  error: string | null;
+}
+
+export interface LoadAllModulesResult {
+  modules: LoadedModule[];
+  errors: string[];
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+// ─── M3 Hardening ─────────────────────────────────────────────────────────────
+
+const POLLUTION_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function assertNoPollution(obj: unknown, depth = 0): void {
+  if (depth > 10 || typeof obj !== 'object' || obj === null) return;
+  for (const key of Object.keys(obj as Record<string, unknown>)) {
+    if (POLLUTION_KEYS.has(key)) {
+      throw new Error(`Prototype pollution key detected: "${key}"`);
+    }
+    assertNoPollution((obj as Record<string, unknown>)[key], depth + 1);
+  }
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Discover all modules in the modules directory.
+ */
+export function discoverModules(modulesDir: string): DiscoveredModule[] {
+  if (!fs.existsSync(modulesDir)) return [];
+
+  const entries = fs.readdirSync(modulesDir, { withFileTypes: true });
+  const modules: DiscoveredModule[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name === 'README.md') continue;
+
+    const modDir = path.join(modulesDir, entry.name);
+    const manifestPath = path.join(modDir, 'module.json');
+
+    if (!fs.existsSync(manifestPath)) continue;
+
+    try {
+      const raw = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as unknown;
+      assertNoPollution(raw);
+      const manifest = raw as ModuleManifest;
+      modules.push({
+        name: (manifest.name as string | undefined) || entry.name,
+        path: modDir,
+        manifest
+      });
+    } catch {
+      // Skip modules with invalid or dangerous manifests
+    }
+  }
+
+  return modules;
+}
+
+/**
+ * Validate a module manifest against the schema.
+ */
+export function validateManifest(manifest: ModuleManifest): ValidationResult {
+  const errors: string[] = [];
+
+  if (!manifest.name || typeof manifest.name !== 'string') {
+    errors.push('Missing or invalid "name" field');
+  } else if (!/^[a-z][a-z0-9-]*$/.test(manifest.name)) {
+    errors.push('"name" must be lowercase kebab-case');
+  }
+
+  if (!manifest.version || typeof manifest.version !== 'string') {
+    errors.push('Missing or invalid "version" field');
+  } else if (!/^\d+\.\d+\.\d+/.test(manifest.version)) {
+    errors.push('"version" must follow semver (e.g., 1.0.0)');
+  }
+
+  if (!manifest.description || typeof manifest.description !== 'string') {
+    errors.push('Missing or invalid "description" field');
+  } else if (manifest.description.length < 10) {
+    errors.push('"description" must be at least 10 characters');
+  }
+
+  // Validate resource arrays
+  const resourceKeys: string[] = ['agents', 'templates', 'commands', 'checks', 'skills'];
+  for (const key of resourceKeys) {
+    const val = manifest[key];
+    if (val !== undefined && !Array.isArray(val)) {
+      errors.push(`"${key}" must be an array`);
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Load a specific module by name.
+ */
+export function loadModule(modulesDir: string, moduleName: string): LoadModuleResult {
+  const modDir = path.join(modulesDir, moduleName);
+
+  if (!fs.existsSync(modDir)) {
+    return { loaded: false, module: null, error: `Module directory not found: ${moduleName}` };
+  }
+
+  const manifestPath = path.join(modDir, 'module.json');
+  if (!fs.existsSync(manifestPath)) {
+    return { loaded: false, module: null, error: `No module.json found in ${moduleName}` };
+  }
+
+  try {
+    const raw = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as unknown;
+    assertNoPollution(raw);
+    const manifest = raw as ModuleManifest;
+    const validation = validateManifest(manifest);
+
+    if (!validation.valid) {
+      return {
+        loaded: false,
+        module: null,
+        error: `Invalid manifest: ${validation.errors.join('; ')}`
+      };
+    }
+
+    // Resolve resource paths — only include files that actually exist
+    const resolve = (arr: string[] | undefined): string[] =>
+      (arr ?? []).map(f => path.join(modDir, f)).filter(f => fs.existsSync(f));
+
+    return {
+      loaded: true,
+      module: {
+        name: manifest.name,
+        version: manifest.version,
+        description: manifest.description,
+        path: modDir,
+        agents: resolve(manifest.agents),
+        templates: resolve(manifest.templates),
+        commands: resolve(manifest.commands),
+        checks: resolve(manifest.checks),
+        skills: resolve(manifest.skills),
+        manifest
+      },
+      error: null
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { loaded: false, module: null, error: `Failed to load ${moduleName}: ${msg}` };
+  }
+}
+
+/**
+ * Load all enabled modules.
+ * If enabledList is null/undefined, loads all discovered modules.
+ */
+export function loadAllModules(
+  modulesDir: string,
+  enabledList?: string[] | null
+): LoadAllModulesResult {
+  const discovered = discoverModules(modulesDir);
+  const errors: string[] = [];
+  const modules: LoadedModule[] = [];
+
+  const toLoad = enabledList
+    ? discovered.filter(m => enabledList.includes(m.name))
+    : discovered;
+
+  for (const mod of toLoad) {
+    const result = loadModule(modulesDir, mod.name);
+    if (result.loaded && result.module) {
+      modules.push(result.module);
+    } else if (result.error) {
+      errors.push(result.error);
+    }
+  }
+
+  return { modules, errors };
+}

--- a/src/lib/proactive-validator.ts
+++ b/src/lib/proactive-validator.ts
@@ -45,20 +45,20 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join, basename as pathBasename } from 'node:path';
-import { validateCrossRefs } from './crossref.js';
-import {
-  runAllChecks as specTesterRunAllChecks,
-  checkGWTFormat as specTesterCheckGWT,
-  checkMetricCoverage as specTesterCheckMetrics,
-  checkGuessingLanguage as specTesterCheckGuessing,
-} from './spec-tester.js';
 import { computeCoverage as coverageComputeCoverage } from './coverage.js';
+import { validateCrossRefs } from './crossref.js';
 import { detectSmells } from './smell-detector.js';
 import { checkSpecDrift } from './spec-drift.js';
+import {
+  checkGuessingLanguage as specTesterCheckGuessing,
+  checkGWTFormat as specTesterCheckGWT,
+  checkMetricCoverage as specTesterCheckMetrics,
+  runAllChecks as specTesterRunAllChecks,
+} from './spec-tester.js';
 import { buildNFRMap } from './traceability.js';
 import { checkApproval, validateArtifact } from './validator.js';
 
-const require = createRequire(import.meta.url);
+const _require = createRequire(import.meta.url);
 
 // ─── Sibling-loader for legacy CJS modules without TS ports ──────────────────
 
@@ -109,17 +109,24 @@ function loadSpecTester(): SpecTesterModule {
     checkPassiveVoice: (content) => specTesterRunAllChecks(content).passive_voice,
     checkGWTFormat: (content) => {
       const r = specTesterCheckGWT(content);
-      return { issues: r.issues.map(i => ({ line: i.line, criterion: i.context })), count: r.issues.length };
+      return {
+        issues: r.issues.map((i) => ({ line: i.line, criterion: i.context })),
+        count: r.issues.length,
+      };
     },
     checkMetricCoverage: (content) => {
       const r = specTesterCheckMetrics(content);
-      return { gaps: r.gaps.map(g => ({ requirement: g })), coverage: r.coverage_pct };
+      return { gaps: r.gaps.map((g) => ({ requirement: g })), coverage: r.coverage_pct };
     },
     checkGuessingLanguage: (content) => {
       const r = specTesterCheckGuessing(content);
       return { issues: r.issues, count: r.count };
     },
-    runAllChecks: (content, options) => specTesterRunAllChecks(content, options) as unknown as { score: number; [key: string]: unknown },
+    runAllChecks: (content, options) =>
+      specTesterRunAllChecks(content, options) as unknown as {
+        score: number;
+        [key: string]: unknown;
+      },
   };
 }
 

--- a/src/lib/proactive-validator.ts
+++ b/src/lib/proactive-validator.ts
@@ -46,6 +46,13 @@ import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join, basename as pathBasename } from 'node:path';
 import { validateCrossRefs } from './crossref.js';
+import {
+  runAllChecks as specTesterRunAllChecks,
+  checkGWTFormat as specTesterCheckGWT,
+  checkMetricCoverage as specTesterCheckMetrics,
+  checkGuessingLanguage as specTesterCheckGuessing,
+} from './spec-tester.js';
+import { computeCoverage as coverageComputeCoverage } from './coverage.js';
 import { detectSmells } from './smell-detector.js';
 import { checkSpecDrift } from './spec-drift.js';
 import { buildNFRMap } from './traceability.js';
@@ -95,19 +102,29 @@ interface CoverageModule {
   };
 }
 
-let _specTester: SpecTesterModule | null = null;
+// M11 batch7: spec-tester and coverage are now TS ports -- wire directly.
 function loadSpecTester(): SpecTesterModule {
-  if (_specTester) return _specTester;
-  // The legacy CJS module has no TS port; we load via createRequire.
-  _specTester = require('../../bin/lib/spec-tester.js') as SpecTesterModule;
-  return _specTester;
+  return {
+    checkAmbiguity: (content) => specTesterRunAllChecks(content).ambiguity,
+    checkPassiveVoice: (content) => specTesterRunAllChecks(content).passive_voice,
+    checkGWTFormat: (content) => {
+      const r = specTesterCheckGWT(content);
+      return { issues: r.issues.map(i => ({ line: i.line, criterion: i.context })), count: r.issues.length };
+    },
+    checkMetricCoverage: (content) => {
+      const r = specTesterCheckMetrics(content);
+      return { gaps: r.gaps.map(g => ({ requirement: g })), coverage: r.coverage_pct };
+    },
+    checkGuessingLanguage: (content) => {
+      const r = specTesterCheckGuessing(content);
+      return { issues: r.issues, count: r.count };
+    },
+    runAllChecks: (content, options) => specTesterRunAllChecks(content, options) as unknown as { score: number; [key: string]: unknown },
+  };
 }
 
-let _coverage: CoverageModule | null = null;
 function loadCoverage(): CoverageModule {
-  if (_coverage) return _coverage;
-  _coverage = require('../../bin/lib/coverage.js') as CoverageModule;
-  return _coverage;
+  return { computeCoverage: coverageComputeCoverage };
 }
 
 // ─── Diagnostic codes ────────────────────────────────────────────────────────

--- a/src/lib/quickstart.ts
+++ b/src/lib/quickstart.ts
@@ -1,0 +1,205 @@
+/**
+ * quickstart.ts -- 5-Minute Quickstart Wizard (UX Feature 15).
+ *
+ * Streamlined interactive setup that asks 3–4 questions (project name,
+ * type, domain, ceremony level) and drops the user into Phase 0.
+ *
+ * This module exports the data helpers only. Interactive prompt flow
+ * is driven from the CLI command (which owns the prompts dependency).
+ *
+ * ADR-006: no process.exit.
+ * M3 hardening: no JSON state — pure data transformation.
+ */
+
+import * as path from 'path';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface DomainOption {
+  value: string;
+  title: string;
+  description: string;
+}
+
+export interface CeremonyOption {
+  value: string;
+  title: string;
+  description: string;
+}
+
+export interface QuickstartAnswers {
+  projectName?: string | null | undefined;
+  projectType?: string | undefined;
+  domain?: string | undefined;
+  customDomain?: string | null | undefined;
+  ceremony?: string | undefined;
+  targetDir?: string | undefined;
+  approverName?: string | null | undefined;
+}
+
+export interface QuickstartConfig {
+  targetDir: string;
+  projectName: string | null;
+  approverName: string | null;
+  projectType: string;
+  copilot: boolean;
+  force: boolean;
+  dryRun: boolean;
+  interactive: boolean;
+  domain: string;
+  ceremony: string;
+}
+
+export interface QuickstartSummary {
+  lines: string[];
+  firstCommand: string;
+  firstMessage: string;
+}
+
+export interface ConfigPatch {
+  section: string;
+  key: string;
+  value: string;
+  pattern: RegExp;
+  replacement: string;
+}
+
+export interface ConfigPatchResult {
+  patches: ConfigPatch[];
+}
+
+// ─── Domain Options ───────────────────────────────────────────────────────────
+
+export const DOMAIN_OPTIONS: DomainOption[] = [
+  { value: 'web-app',       title: 'Web Application',       description: 'Browser-based UI with backend services' },
+  { value: 'mobile-app',    title: 'Mobile Application',    description: 'iOS, Android, or cross-platform mobile app' },
+  { value: 'api-service',   title: 'API / Microservice',    description: 'REST or GraphQL backend service' },
+  { value: 'cli-tool',      title: 'CLI Tool',              description: 'Command-line utility or developer tool' },
+  { value: 'library',       title: 'Library / SDK',         description: 'Reusable package consumed by other projects' },
+  { value: 'data-pipeline', title: 'Data Pipeline',         description: 'ETL, streaming, or analytics pipeline' },
+  { value: 'ecommerce',     title: 'E-Commerce',            description: 'Online store, payments, inventory' },
+  { value: 'saas',          title: 'SaaS Platform',         description: 'Multi-tenant software-as-a-service product' },
+  { value: 'other',         title: 'Other',                 description: 'Custom domain — enter your own' },
+];
+
+// ─── Ceremony Options ─────────────────────────────────────────────────────────
+
+export const CEREMONY_OPTIONS: CeremonyOption[] = [
+  {
+    value: 'light',
+    title: 'Light — Fast prototyping',
+    description: 'Minimal docs, skip optional gates, fast iteration. Best for proofs of concept and experiments.'
+  },
+  {
+    value: 'standard',
+    title: 'Standard — Balanced (recommended)',
+    description: 'Full spec workflow with all quality gates. Good default for most projects.'
+  },
+  {
+    value: 'rigorous',
+    title: 'Rigorous — Enterprise grade',
+    description: 'Maximum ceremony: adversarial review, peer review, strict TDD, security audits. For regulated or high-risk projects.'
+  },
+];
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Build a complete install configuration from wizard answers.
+ */
+export function buildQuickstartConfig(answers: QuickstartAnswers = {}): QuickstartConfig {
+  const domain =
+    answers.domain === 'other'
+      ? (answers.customDomain ?? 'general')
+      : (answers.domain ?? 'general');
+
+  return {
+    targetDir: answers.targetDir ?? '.',
+    projectName: answers.projectName ?? null,
+    approverName: answers.approverName ?? null,
+    projectType: answers.projectType ?? 'greenfield',
+    copilot: true, // Enable Copilot integration by default in quickstart
+    force: false,
+    dryRun: false,
+    interactive: false,
+    domain,
+    ceremony: answers.ceremony ?? 'standard',
+  };
+}
+
+/**
+ * Determine the first command the user should run after setup.
+ */
+export function getFirstCommand(config: QuickstartConfig): { command: string; message: string } {
+  if (config.projectType === 'brownfield') {
+    return {
+      command: '/jumpstart.scout',
+      message: 'Brownfield project detected. The Scout will analyze your existing codebase first.'
+    };
+  }
+  return {
+    command: '/jumpstart.challenge',
+    message: 'Ready to begin! The Challenger will interrogate your problem space and sharpen the project vision.'
+  };
+}
+
+/**
+ * Generate a formatted summary of the quickstart configuration.
+ */
+export function generateQuickstartSummary(config: QuickstartConfig): QuickstartSummary {
+  const next = getFirstCommand(config);
+  const lines = [
+    `Project:  ${config.projectName ?? path.basename(path.resolve(config.targetDir))}`,
+    `Type:     ${config.projectType}`,
+    `Domain:   ${config.domain}`,
+    `Ceremony: ${config.ceremony}`,
+    `Copilot:  ${config.copilot ? 'enabled' : 'disabled'}`,
+  ];
+
+  return {
+    lines,
+    firstCommand: next.command,
+    firstMessage: next.message,
+  };
+}
+
+/**
+ * Build the YAML patch descriptors for adding domain and ceremony to config.yaml.
+ */
+export function getConfigPatches(config: QuickstartConfig): ConfigPatchResult {
+  const patches: ConfigPatch[] = [];
+
+  if (config.domain && config.domain !== 'general') {
+    patches.push({
+      section: 'project',
+      key: 'domain',
+      value: config.domain,
+      pattern: /^(\s*type:\s*\S+)$/m,
+      replacement: `$1\n  domain: ${config.domain}`
+    });
+  }
+
+  if (config.ceremony && config.ceremony !== 'standard') {
+    patches.push({
+      section: 'ceremony',
+      key: 'profile',
+      value: config.ceremony,
+      pattern: /^(\s*profile:\s*)\S+/m,
+      replacement: `$1${config.ceremony}`
+    });
+  }
+
+  return { patches };
+}
+
+/**
+ * Apply config.yaml patches to a content string.
+ */
+export function applyConfigPatches(content: string, config: QuickstartConfig): string {
+  let result = content;
+  const { patches } = getConfigPatches(config);
+  for (const patch of patches) {
+    result = result.replace(patch.pattern, patch.replacement);
+  }
+  return result;
+}

--- a/src/lib/quickstart.ts
+++ b/src/lib/quickstart.ts
@@ -11,7 +11,7 @@
  * M3 hardening: no JSON state — pure data transformation.
  */
 
-import * as path from 'path';
+import * as path from 'node:path';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -71,15 +71,39 @@ export interface ConfigPatchResult {
 // ─── Domain Options ───────────────────────────────────────────────────────────
 
 export const DOMAIN_OPTIONS: DomainOption[] = [
-  { value: 'web-app',       title: 'Web Application',       description: 'Browser-based UI with backend services' },
-  { value: 'mobile-app',    title: 'Mobile Application',    description: 'iOS, Android, or cross-platform mobile app' },
-  { value: 'api-service',   title: 'API / Microservice',    description: 'REST or GraphQL backend service' },
-  { value: 'cli-tool',      title: 'CLI Tool',              description: 'Command-line utility or developer tool' },
-  { value: 'library',       title: 'Library / SDK',         description: 'Reusable package consumed by other projects' },
-  { value: 'data-pipeline', title: 'Data Pipeline',         description: 'ETL, streaming, or analytics pipeline' },
-  { value: 'ecommerce',     title: 'E-Commerce',            description: 'Online store, payments, inventory' },
-  { value: 'saas',          title: 'SaaS Platform',         description: 'Multi-tenant software-as-a-service product' },
-  { value: 'other',         title: 'Other',                 description: 'Custom domain — enter your own' },
+  {
+    value: 'web-app',
+    title: 'Web Application',
+    description: 'Browser-based UI with backend services',
+  },
+  {
+    value: 'mobile-app',
+    title: 'Mobile Application',
+    description: 'iOS, Android, or cross-platform mobile app',
+  },
+  {
+    value: 'api-service',
+    title: 'API / Microservice',
+    description: 'REST or GraphQL backend service',
+  },
+  { value: 'cli-tool', title: 'CLI Tool', description: 'Command-line utility or developer tool' },
+  {
+    value: 'library',
+    title: 'Library / SDK',
+    description: 'Reusable package consumed by other projects',
+  },
+  {
+    value: 'data-pipeline',
+    title: 'Data Pipeline',
+    description: 'ETL, streaming, or analytics pipeline',
+  },
+  { value: 'ecommerce', title: 'E-Commerce', description: 'Online store, payments, inventory' },
+  {
+    value: 'saas',
+    title: 'SaaS Platform',
+    description: 'Multi-tenant software-as-a-service product',
+  },
+  { value: 'other', title: 'Other', description: 'Custom domain — enter your own' },
 ];
 
 // ─── Ceremony Options ─────────────────────────────────────────────────────────
@@ -88,17 +112,19 @@ export const CEREMONY_OPTIONS: CeremonyOption[] = [
   {
     value: 'light',
     title: 'Light — Fast prototyping',
-    description: 'Minimal docs, skip optional gates, fast iteration. Best for proofs of concept and experiments.'
+    description:
+      'Minimal docs, skip optional gates, fast iteration. Best for proofs of concept and experiments.',
   },
   {
     value: 'standard',
     title: 'Standard — Balanced (recommended)',
-    description: 'Full spec workflow with all quality gates. Good default for most projects.'
+    description: 'Full spec workflow with all quality gates. Good default for most projects.',
   },
   {
     value: 'rigorous',
     title: 'Rigorous — Enterprise grade',
-    description: 'Maximum ceremony: adversarial review, peer review, strict TDD, security audits. For regulated or high-risk projects.'
+    description:
+      'Maximum ceremony: adversarial review, peer review, strict TDD, security audits. For regulated or high-risk projects.',
   },
 ];
 
@@ -134,12 +160,13 @@ export function getFirstCommand(config: QuickstartConfig): { command: string; me
   if (config.projectType === 'brownfield') {
     return {
       command: '/jumpstart.scout',
-      message: 'Brownfield project detected. The Scout will analyze your existing codebase first.'
+      message: 'Brownfield project detected. The Scout will analyze your existing codebase first.',
     };
   }
   return {
     command: '/jumpstart.challenge',
-    message: 'Ready to begin! The Challenger will interrogate your problem space and sharpen the project vision.'
+    message:
+      'Ready to begin! The Challenger will interrogate your problem space and sharpen the project vision.',
   };
 }
 
@@ -175,7 +202,7 @@ export function getConfigPatches(config: QuickstartConfig): ConfigPatchResult {
       key: 'domain',
       value: config.domain,
       pattern: /^(\s*type:\s*\S+)$/m,
-      replacement: `$1\n  domain: ${config.domain}`
+      replacement: `$1\n  domain: ${config.domain}`,
     });
   }
 
@@ -185,7 +212,7 @@ export function getConfigPatches(config: QuickstartConfig): ConfigPatchResult {
       key: 'profile',
       value: config.ceremony,
       pattern: /^(\s*profile:\s*)\S+/m,
-      replacement: `$1${config.ceremony}`
+      replacement: `$1${config.ceremony}`,
     });
   }
 

--- a/src/lib/self-evolve.ts
+++ b/src/lib/self-evolve.ts
@@ -1,0 +1,183 @@
+/**
+ * self-evolve.ts -- Framework Self-Improvement Hook (Item 100).
+ *
+ * Analyzes project usage patterns and generates config change proposals.
+ * All proposals require explicit human approval before applying.
+ *
+ * ADR-006: no process.exit.
+ * ADR-009: projectDir validated by caller.
+ * M3 hardening: no JSON state parsed — reads .md and .yaml files only.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface ConfigProposal {
+  setting: string;
+  current: unknown;
+  proposed: unknown;
+  rationale: string;
+}
+
+export interface ProjectAnalysis {
+  specs_found: number;
+  adrs_found: number;
+  has_usage_log: boolean;
+  has_correction_log: boolean;
+  quality_score: null;
+  modules_loaded: number;
+}
+
+export interface AnalyzeResult {
+  proposals: ConfigProposal[];
+  analysis: ProjectAnalysis;
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Analyze the project state and generate config improvement proposals.
+ */
+export function analyzeAndPropose(projectDir: string): AnalyzeResult {
+  const proposals: ConfigProposal[] = [];
+  const analysis: ProjectAnalysis = {
+    specs_found: 0,
+    adrs_found: 0,
+    has_usage_log: false,
+    has_correction_log: false,
+    quality_score: null,
+    modules_loaded: 0
+  };
+
+  const configPath = path.join(projectDir, '.jumpstart', 'config.yaml');
+  if (!fs.existsSync(configPath)) {
+    return { proposals: [], analysis };
+  }
+
+  const configContent = fs.readFileSync(configPath, 'utf8');
+
+  // Count specs
+  const specsDir = path.join(projectDir, 'specs');
+  if (fs.existsSync(specsDir)) {
+    const specFiles = fs.readdirSync(specsDir).filter(f => f.endsWith('.md'));
+    analysis.specs_found = specFiles.length;
+  }
+
+  // Count ADRs
+  const adrsDir = path.join(projectDir, 'specs', 'decisions');
+  if (fs.existsSync(adrsDir)) {
+    analysis.adrs_found = fs.readdirSync(adrsDir).filter(f => f.endsWith('.md')).length;
+  }
+
+  // Check usage log
+  const usageLog = path.join(projectDir, '.jumpstart', 'usage-log.json');
+  analysis.has_usage_log = fs.existsSync(usageLog);
+
+  // Check correction log
+  const correctionLog = path.join(projectDir, '.jumpstart', 'correction-log.md');
+  analysis.has_correction_log = fs.existsSync(correctionLog);
+
+  // ── Heuristic-based proposals ─────────────────────────────────────────────
+
+  // If many ADRs exist but diagram verification is off
+  if (analysis.adrs_found > 5 && configContent.includes('auto_verify_at_gate: false')) {
+    proposals.push({
+      setting: 'diagram_verification.auto_verify_at_gate',
+      current: false,
+      proposed: true,
+      rationale: `Project has ${analysis.adrs_found} ADRs, suggesting complexity. Auto-verifying diagrams at gates would catch inconsistencies earlier.`
+    });
+  }
+
+  // If no usage log exists and project is mature
+  if (!analysis.has_usage_log && analysis.specs_found > 3) {
+    proposals.push({
+      setting: 'usage_tracking',
+      current: 'disabled',
+      proposed: 'enabled',
+      rationale: 'Project has multiple spec artifacts. Enabling usage tracking would provide visibility into agent session costs and help optimize workflow.'
+    });
+  }
+
+  // If skill level is not set
+  if (configContent.includes('skill_level: null')) {
+    proposals.push({
+      setting: 'user.skill_level',
+      current: null,
+      proposed: 'intermediate',
+      rationale: 'Skill level is unset. Setting it to "intermediate" would enable adaptive explanations and hints tailored to experience level.'
+    });
+  }
+
+  // If many corrections logged, suggest stricter quality gates
+  if (analysis.has_correction_log) {
+    try {
+      const corrections = fs.readFileSync(correctionLog, 'utf8');
+      const entryCount = (corrections.match(/^## /gm) ?? []).length;
+      if (entryCount > 5 && configContent.includes('overall_score_min: 70')) {
+        proposals.push({
+          setting: 'testing.spec_quality.overall_score_min',
+          current: 70,
+          proposed: 80,
+          rationale: `Correction log has ${entryCount} entries. Raising the minimum quality score from 70 to 80 would catch more issues before they require correction.`
+        });
+      }
+    } catch {
+      // Skip if can't read
+    }
+  }
+
+  // If peer review is disabled and project has grown
+  if (analysis.specs_found > 4 && configContent.includes('peer_review_required: false')) {
+    proposals.push({
+      setting: 'testing.peer_review_required',
+      current: false,
+      proposed: true,
+      rationale: `Project has ${analysis.specs_found} spec artifacts. Enabling peer review would add an additional quality layer as complexity grows.`
+    });
+  }
+
+  return { proposals, analysis };
+}
+
+/**
+ * Generate a config proposal markdown artifact from analysis results.
+ */
+export function generateProposalArtifact(result: AnalyzeResult): string {
+  if (result.proposals.length === 0) {
+    return '# Configuration Change Proposal\n\nNo changes proposed. Current configuration is well-suited to the project state.\n';
+  }
+
+  let md = '# Configuration Change Proposal\n\n';
+  md += `> **Generated:** ${new Date().toISOString()}\n`;
+  md += `> **Triggered by:** Self-evolve analysis\n\n`;
+  md += '---\n\n';
+
+  md += '## Proposed Changes\n\n';
+  md += '| Setting | Current Value | Proposed Value | Rationale |\n';
+  md += '|---------|--------------|----------------|----------|\n';
+  for (const p of result.proposals) {
+    md += `| \`${p.setting}\` | ${String(p.current)} | ${String(p.proposed)} | ${String(p.rationale).substring(0, 80)}... |\n`;
+  }
+
+  md += '\n---\n\n';
+  md += '## Project Analysis\n\n';
+  md += `| Metric | Value |\n|--------|-------|\n`;
+  const analysisRecord = result.analysis as unknown as Record<string, unknown>;
+  for (const key of Object.keys(analysisRecord)) {
+    md += `| ${key} | ${String(analysisRecord[key])} |\n`;
+  }
+
+  md += '\n---\n\n';
+  md += '## Approval\n\n';
+  md += 'This proposal requires explicit human approval before applying changes.\n\n';
+  md += '- [ ] Changes reviewed and understood\n';
+  md += '- [ ] Impact analysis acceptable\n\n';
+  md += '**Approved by:** Pending\n';
+  md += '**Approval date:** Pending\n';
+  md += '**Action:** [Apply / Reject / Defer]\n';
+
+  return md;
+}

--- a/src/lib/self-evolve.ts
+++ b/src/lib/self-evolve.ts
@@ -9,8 +9,8 @@
  * M3 hardening: no JSON state parsed — reads .md and .yaml files only.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -48,7 +48,7 @@ export function analyzeAndPropose(projectDir: string): AnalyzeResult {
     has_usage_log: false,
     has_correction_log: false,
     quality_score: null,
-    modules_loaded: 0
+    modules_loaded: 0,
   };
 
   const configPath = path.join(projectDir, '.jumpstart', 'config.yaml');
@@ -61,14 +61,14 @@ export function analyzeAndPropose(projectDir: string): AnalyzeResult {
   // Count specs
   const specsDir = path.join(projectDir, 'specs');
   if (fs.existsSync(specsDir)) {
-    const specFiles = fs.readdirSync(specsDir).filter(f => f.endsWith('.md'));
+    const specFiles = fs.readdirSync(specsDir).filter((f) => f.endsWith('.md'));
     analysis.specs_found = specFiles.length;
   }
 
   // Count ADRs
   const adrsDir = path.join(projectDir, 'specs', 'decisions');
   if (fs.existsSync(adrsDir)) {
-    analysis.adrs_found = fs.readdirSync(adrsDir).filter(f => f.endsWith('.md')).length;
+    analysis.adrs_found = fs.readdirSync(adrsDir).filter((f) => f.endsWith('.md')).length;
   }
 
   // Check usage log
@@ -87,7 +87,7 @@ export function analyzeAndPropose(projectDir: string): AnalyzeResult {
       setting: 'diagram_verification.auto_verify_at_gate',
       current: false,
       proposed: true,
-      rationale: `Project has ${analysis.adrs_found} ADRs, suggesting complexity. Auto-verifying diagrams at gates would catch inconsistencies earlier.`
+      rationale: `Project has ${analysis.adrs_found} ADRs, suggesting complexity. Auto-verifying diagrams at gates would catch inconsistencies earlier.`,
     });
   }
 
@@ -97,7 +97,8 @@ export function analyzeAndPropose(projectDir: string): AnalyzeResult {
       setting: 'usage_tracking',
       current: 'disabled',
       proposed: 'enabled',
-      rationale: 'Project has multiple spec artifacts. Enabling usage tracking would provide visibility into agent session costs and help optimize workflow.'
+      rationale:
+        'Project has multiple spec artifacts. Enabling usage tracking would provide visibility into agent session costs and help optimize workflow.',
     });
   }
 
@@ -107,7 +108,8 @@ export function analyzeAndPropose(projectDir: string): AnalyzeResult {
       setting: 'user.skill_level',
       current: null,
       proposed: 'intermediate',
-      rationale: 'Skill level is unset. Setting it to "intermediate" would enable adaptive explanations and hints tailored to experience level.'
+      rationale:
+        'Skill level is unset. Setting it to "intermediate" would enable adaptive explanations and hints tailored to experience level.',
     });
   }
 
@@ -121,7 +123,7 @@ export function analyzeAndPropose(projectDir: string): AnalyzeResult {
           setting: 'testing.spec_quality.overall_score_min',
           current: 70,
           proposed: 80,
-          rationale: `Correction log has ${entryCount} entries. Raising the minimum quality score from 70 to 80 would catch more issues before they require correction.`
+          rationale: `Correction log has ${entryCount} entries. Raising the minimum quality score from 70 to 80 would catch more issues before they require correction.`,
         });
       }
     } catch {
@@ -135,7 +137,7 @@ export function analyzeAndPropose(projectDir: string): AnalyzeResult {
       setting: 'testing.peer_review_required',
       current: false,
       proposed: true,
-      rationale: `Project has ${analysis.specs_found} spec artifacts. Enabling peer review would add an additional quality layer as complexity grows.`
+      rationale: `Project has ${analysis.specs_found} spec artifacts. Enabling peer review would add an additional quality layer as complexity grows.`,
     });
   }
 

--- a/src/lib/sharder.ts
+++ b/src/lib/sharder.ts
@@ -40,18 +40,19 @@ export interface ShardDescriptor {
  * Extract epics from a PRD file.
  */
 export function extractEpics(content: string): Epic[] {
-  const epicPattern = /### Epic (E\d+):\s*(.+)[\s\S]*?(?=### Epic E\d+:|## Non-Functional|---\s*\n## |$)/g;
+  const epicPattern =
+    /### Epic (E\d+):\s*(.+)[\s\S]*?(?=### Epic E\d+:|## Non-Functional|---\s*\n## |$)/g;
   const epics: Epic[] = [];
-  let match: RegExpExecArray | null;
-
-  while ((match = epicPattern.exec(content)) !== null) {
+  for (;;) {
+    const match = epicPattern.exec(content);
+    if (match === null) break;
     const epicContent = match[0];
     const storyMatches = epicContent.match(/#### Story E\d+-S\d+/g);
     epics.push({
       id: match[1] ?? '',
       name: (match[2] ?? '').trim(),
       content: epicContent,
-      storyCount: storyMatches ? storyMatches.length : 0
+      storyCount: storyMatches ? storyMatches.length : 0,
     });
   }
 
@@ -62,11 +63,7 @@ export function extractEpics(content: string): Epic[] {
  * Determine if a PRD should be sharded based on size heuristics.
  */
 export function shouldShard(content: string, thresholds: ShardThresholds = {}): ShardDecision {
-  const {
-    maxEpics = 5,
-    maxStories = 15,
-    maxLines = 800
-  } = thresholds;
+  const { maxEpics = 5, maxStories = 15, maxLines = 800 } = thresholds;
 
   const epics = extractEpics(content);
   const totalStories = epics.reduce((sum, e) => sum + e.storyCount, 0);
@@ -82,20 +79,24 @@ export function shouldShard(content: string, thresholds: ShardThresholds = {}): 
     reason: reasons.length > 0 ? reasons.join('; ') : 'Within limits',
     epicCount: epics.length,
     storyCount: totalStories,
-    lineCount
+    lineCount,
   };
 }
 
 /**
  * Generate a PRD shard for a specific epic or group of epics.
  */
-export function generateShard(parentPrdContent: string, epicIds: string[], shardIndex: number): string {
+export function generateShard(
+  parentPrdContent: string,
+  epicIds: string[],
+  shardIndex: number
+): string {
   const epics = extractEpics(parentPrdContent);
-  const shardEpics = epics.filter(e => epicIds.includes(e.id));
+  const shardEpics = epics.filter((e) => epicIds.includes(e.id));
 
   if (shardEpics.length === 0) return '';
 
-  const epicTitles = shardEpics.map(e => `${e.id} - ${e.name}`).join(', ');
+  const epicTitles = shardEpics.map((e) => `${e.id} - ${e.name}`).join(', ');
   const header = [
     `# PRD Shard ${shardIndex}: ${epicTitles}`,
     '',
@@ -108,7 +109,7 @@ export function generateShard(parentPrdContent: string, epicIds: string[], shard
     '',
   ].join('\n');
 
-  const body = shardEpics.map(e => e.content).join('\n\n---\n\n');
+  const body = shardEpics.map((e) => e.content).join('\n\n---\n\n');
 
   return header + body;
 }
@@ -136,7 +137,15 @@ export function generateIndex(shards: ShardDescriptor[], projectName?: string | 
     lines.push(`| ${shard.index} | ${epicList} | [${shard.filePath}](${shard.filePath}) | Draft |`);
   }
 
-  lines.push('', '---', '', '## Cross-References', '', '<!-- Auto-generated cross-reference links between shards -->', '');
+  lines.push(
+    '',
+    '---',
+    '',
+    '## Cross-References',
+    '',
+    '<!-- Auto-generated cross-reference links between shards -->',
+    ''
+  );
 
   return lines.join('\n');
 }

--- a/src/lib/sharder.ts
+++ b/src/lib/sharder.ts
@@ -1,0 +1,142 @@
+/**
+ * sharder.ts — Atomic Artifacts (Sharding) for large PRDs and specs (Item 8).
+ *
+ * Breaks large PRDs into smaller shards to avoid context saturation.
+ * Each shard covers a domain or epic; a parent index maintains cross-links.
+ *
+ * M3 hardening: no JSON state — pure text processing.
+ * ADR-009: no user-supplied path gating needed (pure text in/out).
+ * ADR-006: no process.exit.
+ */
+
+export interface Epic {
+  id: string;
+  name: string;
+  content: string;
+  storyCount: number;
+}
+
+export interface ShardThresholds {
+  maxEpics?: number | undefined;
+  maxStories?: number | undefined;
+  maxLines?: number | undefined;
+}
+
+export interface ShardDecision {
+  shouldShard: boolean;
+  reason: string;
+  epicCount: number;
+  storyCount: number;
+  lineCount: number;
+}
+
+export interface ShardDescriptor {
+  index: number;
+  epicIds: string[];
+  filePath: string;
+}
+
+/**
+ * Extract epics from a PRD file.
+ */
+export function extractEpics(content: string): Epic[] {
+  const epicPattern = /### Epic (E\d+):\s*(.+)[\s\S]*?(?=### Epic E\d+:|## Non-Functional|---\s*\n## |$)/g;
+  const epics: Epic[] = [];
+  let match: RegExpExecArray | null;
+
+  while ((match = epicPattern.exec(content)) !== null) {
+    const epicContent = match[0];
+    const storyMatches = epicContent.match(/#### Story E\d+-S\d+/g);
+    epics.push({
+      id: match[1] ?? '',
+      name: (match[2] ?? '').trim(),
+      content: epicContent,
+      storyCount: storyMatches ? storyMatches.length : 0
+    });
+  }
+
+  return epics;
+}
+
+/**
+ * Determine if a PRD should be sharded based on size heuristics.
+ */
+export function shouldShard(content: string, thresholds: ShardThresholds = {}): ShardDecision {
+  const {
+    maxEpics = 5,
+    maxStories = 15,
+    maxLines = 800
+  } = thresholds;
+
+  const epics = extractEpics(content);
+  const totalStories = epics.reduce((sum, e) => sum + e.storyCount, 0);
+  const lineCount = content.split('\n').length;
+
+  const reasons: string[] = [];
+  if (epics.length > maxEpics) reasons.push(`${epics.length} epics (max ${maxEpics})`);
+  if (totalStories > maxStories) reasons.push(`${totalStories} stories (max ${maxStories})`);
+  if (lineCount > maxLines) reasons.push(`${lineCount} lines (max ${maxLines})`);
+
+  return {
+    shouldShard: reasons.length > 0,
+    reason: reasons.length > 0 ? reasons.join('; ') : 'Within limits',
+    epicCount: epics.length,
+    storyCount: totalStories,
+    lineCount
+  };
+}
+
+/**
+ * Generate a PRD shard for a specific epic or group of epics.
+ */
+export function generateShard(parentPrdContent: string, epicIds: string[], shardIndex: number): string {
+  const epics = extractEpics(parentPrdContent);
+  const shardEpics = epics.filter(e => epicIds.includes(e.id));
+
+  if (shardEpics.length === 0) return '';
+
+  const epicTitles = shardEpics.map(e => `${e.id} - ${e.name}`).join(', ');
+  const header = [
+    `# PRD Shard ${shardIndex}: ${epicTitles}`,
+    '',
+    `> **Parent Document:** [specs/prd.md](../prd.md)`,
+    `> **Shard:** ${shardIndex} of N`,
+    `> **Epics:** ${epicIds.join(', ')}`,
+    `> **Status:** Draft`,
+    '',
+    '---',
+    '',
+  ].join('\n');
+
+  const body = shardEpics.map(e => e.content).join('\n\n---\n\n');
+
+  return header + body;
+}
+
+/**
+ * Generate a PRD index that links all shards.
+ */
+export function generateIndex(shards: ShardDescriptor[], projectName?: string | undefined): string {
+  const lines = [
+    `# PRD Index - ${projectName ?? 'Project'}`,
+    '',
+    `> **Purpose:** Master index for sharded PRD documents.`,
+    `> **Total Shards:** ${shards.length}`,
+    '',
+    '---',
+    '',
+    '## Shard Map',
+    '',
+    '| Shard | Epics | File | Status |',
+    '|-------|-------|------|--------|',
+  ];
+
+  for (const shard of shards) {
+    const epicList = shard.epicIds.join(', ');
+    lines.push(`| ${shard.index} | ${epicList} | [${shard.filePath}](${shard.filePath}) | Draft |`);
+  }
+
+  lines.push('', '---', '', '## Cross-References', '', '<!-- Auto-generated cross-reference links between shards -->', '');
+
+  return lines.join('\n');
+}

--- a/src/lib/simplicity-gate.ts
+++ b/src/lib/simplicity-gate.ts
@@ -1,0 +1,113 @@
+/**
+ * simplicity-gate.ts -- Simplicity Gate enforcement (Item 9).
+ *
+ * Fails plans that exceed 3 top-level project folders without explicit
+ * justification.
+ *
+ * M3 hardening: no JSON state -- pure filesystem inspection.
+ * ADR-009: projectDir/archContent must be pre-validated by caller.
+ * ADR-006: no process.exit.
+ */
+
+import * as fs from 'fs';
+
+// Directories excluded from the simplicity gate count
+export const EXCLUDED_DIRS: Set<string> = new Set([
+  'node_modules', '.git', '.jumpstart', 'specs', '.github',
+  '.vscode', '.cursor', '.idea', '__pycache__', '.mypy_cache',
+  '.pytest_cache', 'dist', 'build', 'out', 'coverage',
+  '.next', '.nuxt', '.svelte-kit', '.cache',
+  'bin', 'docs', '.devcontainer'
+]);
+
+export interface DirCount {
+  count: number;
+  directories: string[];
+}
+
+/**
+ * Count top-level project directories (excluding standard config/tool dirs).
+ */
+export function countTopLevelDirs(projectDir: string): DirCount {
+  if (!fs.existsSync(projectDir)) {
+    return { count: 0, directories: [] };
+  }
+
+  const entries = fs.readdirSync(projectDir, { withFileTypes: true });
+  const directories = entries
+    .filter(e => e.isDirectory() && !EXCLUDED_DIRS.has(e.name))
+    .map(e => e.name);
+
+  return { count: directories.length, directories };
+}
+
+/**
+ * Extract planned directory structure from architecture or implementation plan.
+ */
+export function extractPlannedDirs(content: string): string[] {
+  const structureMatch = content.match(/```[\s\S]*?\[project-root\]\/[\s\S]*?```/);
+  if (!structureMatch) return [];
+
+  const structure = structureMatch[0];
+  const lines = structure.split('\n');
+  const topLevel: string[] = [];
+
+  for (const line of lines) {
+    const dirMatch = line.match(/^[|\\u251C\\u2514\\u2500\s]*(?:--\s*|──\s*)(\w[\w-]*)\//);
+    if (dirMatch) {
+      const dirName = dirMatch[1];
+      if (dirName && !EXCLUDED_DIRS.has(dirName)) {
+        topLevel.push(dirName);
+      }
+    }
+  }
+
+  return Array.from(new Set(topLevel));
+}
+
+export interface CheckOptions {
+  projectDir?: string | undefined;
+  archContent?: string | undefined;
+  maxDirs?: number | undefined;
+}
+
+export interface CheckResult {
+  passed: boolean;
+  count: number;
+  directories: string[];
+  justificationRequired: boolean;
+  message: string;
+}
+
+/**
+ * Run the simplicity gate check.
+ */
+export function check(options: CheckOptions = {}): CheckResult {
+  const { maxDirs = 3 } = options;
+  let directories: string[] = [];
+  let count = 0;
+
+  if (options.archContent) {
+    directories = extractPlannedDirs(options.archContent);
+    count = directories.length;
+  } else if (options.projectDir) {
+    const result = countTopLevelDirs(options.projectDir);
+    directories = result.directories;
+    count = result.count;
+  }
+
+  const passed = count <= maxDirs;
+  const justificationRequired = !passed;
+
+  let message: string;
+  if (passed) {
+    const plural = count === 1 ? 'y' : 'ies';
+    message = `Simplicity gate passed: ${count} top-level director${plural} (max ${maxDirs}).`;
+  } else {
+    message = `Simplicity gate FAILED: ${count} top-level directories exceeds maximum of ${maxDirs}. ` +
+              `Directories: ${directories.join(', ')}. ` +
+              `Justification required in architecture document.`;
+  }
+
+  return { passed, count, directories, justificationRequired, message };
+}

--- a/src/lib/simplicity-gate.ts
+++ b/src/lib/simplicity-gate.ts
@@ -9,15 +9,32 @@
  * ADR-006: no process.exit.
  */
 
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 
 // Directories excluded from the simplicity gate count
 export const EXCLUDED_DIRS: Set<string> = new Set([
-  'node_modules', '.git', '.jumpstart', 'specs', '.github',
-  '.vscode', '.cursor', '.idea', '__pycache__', '.mypy_cache',
-  '.pytest_cache', 'dist', 'build', 'out', 'coverage',
-  '.next', '.nuxt', '.svelte-kit', '.cache',
-  'bin', 'docs', '.devcontainer'
+  'node_modules',
+  '.git',
+  '.jumpstart',
+  'specs',
+  '.github',
+  '.vscode',
+  '.cursor',
+  '.idea',
+  '__pycache__',
+  '.mypy_cache',
+  '.pytest_cache',
+  'dist',
+  'build',
+  'out',
+  'coverage',
+  '.next',
+  '.nuxt',
+  '.svelte-kit',
+  '.cache',
+  'bin',
+  'docs',
+  '.devcontainer',
 ]);
 
 export interface DirCount {
@@ -35,8 +52,8 @@ export function countTopLevelDirs(projectDir: string): DirCount {
 
   const entries = fs.readdirSync(projectDir, { withFileTypes: true });
   const directories = entries
-    .filter(e => e.isDirectory() && !EXCLUDED_DIRS.has(e.name))
-    .map(e => e.name);
+    .filter((e) => e.isDirectory() && !EXCLUDED_DIRS.has(e.name))
+    .map((e) => e.name);
 
   return { count: directories.length, directories };
 }
@@ -104,9 +121,10 @@ export function check(options: CheckOptions = {}): CheckResult {
     const plural = count === 1 ? 'y' : 'ies';
     message = `Simplicity gate passed: ${count} top-level director${plural} (max ${maxDirs}).`;
   } else {
-    message = `Simplicity gate FAILED: ${count} top-level directories exceeds maximum of ${maxDirs}. ` +
-              `Directories: ${directories.join(', ')}. ` +
-              `Justification required in architecture document.`;
+    message =
+      `Simplicity gate FAILED: ${count} top-level directories exceeds maximum of ${maxDirs}. ` +
+      `Directories: ${directories.join(', ')}. ` +
+      `Justification required in architecture document.`;
   }
 
   return { passed, count, directories, justificationRequired, message };

--- a/src/lib/spec-tester.ts
+++ b/src/lib/spec-tester.ts
@@ -1,0 +1,461 @@
+/**
+ * spec-tester.ts -- Layer 3: "Unit Tests for English" (Item 61).
+ *
+ * Scans specification artifacts for ambiguity, passive voice, metric
+ * coverage gaps, and terminology drift -- the prose equivalent of unit tests.
+ *
+ * M3 hardening: no JSON state -- pure text processing.
+ * ADR-009: specsDir/filePath must be pre-validated by caller.
+ * ADR-006: no process.exit.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+// ─── Ambiguity Detection ──────────────────────────────────────────────────────
+
+export const VAGUE_ADJECTIVES: string[] = [
+  'scalable', 'fast', 'easy', 'robust', 'flexible', 'efficient',
+  'user-friendly', 'seamless', 'intuitive', 'modern', 'simple',
+  'lightweight', 'powerful', 'reliable', 'secure', 'performant',
+  'responsive', 'clean', 'elegant', 'smart', 'quick', 'high-quality',
+  'enterprise-grade', 'production-ready', 'best-in-class', 'world-class',
+  'cutting-edge', 'next-generation', 'state-of-the-art'
+];
+
+export const METRIC_PATTERNS: RegExp[] = [
+  /\d+\s*(?:ms|seconds?|minutes?|hours?|days?)/i,
+  /\d+\s*%/,
+  /\d+\s*(?:req|requests?|rps|qps)\s*(?:\/|per)\s*(?:s|sec|second|minute)/i,
+  /\d+\s*(?:MB|GB|TB|KB|bytes?)/i,
+  /\d+\s*(?:users?|connections?|concurrent)/i,
+  /\d+\s*(?:nines?|9s)/i,
+  /(?:99|99\.9|99\.99)\s*%\s*(?:uptime|availability|SLA)/i,
+  /(?:within|under|below|less than|at most|at least|no more than)\s+\d+/i
+];
+
+export const PASSIVE_PATTERNS: RegExp[] = [
+  /\b(?:is|are|was|were|be|been|being)\s+(?:\w+ed|done|handled|managed|processed|created|updated|deleted|performed|executed|configured|implemented|deployed)\b/gi,
+  /\bwill be\s+(?:\w+ed|done|handled|managed|processed|created|updated|deleted|performed|executed|configured|implemented|deployed)\b/gi,
+  /\bshould be\s+(?:\w+ed|done|handled|managed|processed|created|updated|deleted|performed|executed|configured|implemented|deployed)\b/gi,
+  /\bmust be\s+(?:\w+ed|done|handled|managed|processed|created|updated|deleted|performed|executed|configured|implemented|deployed)\b/gi,
+  /\bcan be\s+(?:\w+ed|done|handled|managed|processed|created|updated|deleted|performed|executed|configured|implemented|deployed)\b/gi,
+  /\bneeds to be\s+\w+ed\b/gi,
+  /\bhas to be\s+\w+ed\b/gi
+];
+
+export interface AmbiguityIssue {
+  word: string;
+  line: number;
+  context: string;
+}
+
+export interface PassiveIssue {
+  pattern: string;
+  line: number;
+  context: string;
+}
+
+export interface GWTIssue {
+  line: number;
+  context: string;
+}
+
+export interface GuessingIssue {
+  word: string;
+  line: number;
+  context: string;
+}
+
+export interface AmbiguityResult {
+  issues: AmbiguityIssue[];
+  count: number;
+}
+
+export interface PassiveResult {
+  issues: PassiveIssue[];
+  count: number;
+}
+
+export interface MetricCoverageResult {
+  total_requirements: number;
+  with_metrics: number;
+  coverage_pct: number;
+  gaps: string[];
+}
+
+export interface TerminologyDriftResult {
+  drifts: Array<{ term: string; variants: string[]; files: string[] }>;
+  count: number;
+}
+
+export interface GWTResult {
+  issues: GWTIssue[];
+  gwt_count: number;
+  non_gwt_count: number;
+}
+
+export interface GuessingResult {
+  issues: GuessingIssue[];
+  count: number;
+}
+
+export interface AllChecksResult {
+  pass: boolean;
+  score: number;
+  ambiguity: AmbiguityResult;
+  passive_voice: PassiveResult;
+  metric_coverage: MetricCoverageResult;
+  terminology_drift: TerminologyDriftResult;
+  gwt_format: GWTResult;
+  guessing_language: GuessingResult;
+}
+
+// ─── checkAmbiguity ───────────────────────────────────────────────────────────
+
+export function checkAmbiguity(content: string): AmbiguityResult {
+  const lines = content.split('\n');
+  const issues: AmbiguityIssue[] = [];
+  let inCodeBlock = false;
+  let inFrontmatter = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+
+    if (line.trim().startsWith('```')) { inCodeBlock = !inCodeBlock; continue; }
+    if (inCodeBlock) continue;
+
+    if (i === 0 && line.trim() === '---') { inFrontmatter = true; continue; }
+    if (inFrontmatter) { if (line.trim() === '---') inFrontmatter = false; continue; }
+
+    if (line.startsWith('#')) continue;
+
+    for (const adj of VAGUE_ADJECTIVES) {
+      const regex = new RegExp(`\\b${adj}\\b`, 'gi');
+      if (regex.test(line)) {
+        const nextLine = lines[i + 1] ?? '';
+        const context = line + nextLine;
+        const hasMetric = METRIC_PATTERNS.some(p => p.test(context));
+        const hasTag = /\[MEASURABLE\]|\[NEEDS CLARIFICATION\]|\[METRIC\]/i.test(context);
+
+        if (!hasMetric && !hasTag) {
+          issues.push({ word: adj, line: i + 1, context: line.trim().substring(0, 120) });
+        }
+      }
+    }
+  }
+
+  return { issues, count: issues.length };
+}
+
+// ─── checkPassiveVoice ────────────────────────────────────────────────────────
+
+export function checkPassiveVoice(content: string): PassiveResult {
+  const lines = content.split('\n');
+  const issues: PassiveIssue[] = [];
+  let inCodeBlock = false;
+  let inFrontmatter = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+
+    if (line.trim().startsWith('```')) { inCodeBlock = !inCodeBlock; continue; }
+    if (inCodeBlock) continue;
+
+    if (i === 0 && line.trim() === '---') { inFrontmatter = true; continue; }
+    if (inFrontmatter) { if (line.trim() === '---') inFrontmatter = false; continue; }
+
+    if (line.startsWith('#')) continue;
+
+    for (const pattern of PASSIVE_PATTERNS) {
+      pattern.lastIndex = 0;
+      const match = pattern.exec(line);
+      if (match) {
+        issues.push({
+          pattern: match[0],
+          line: i + 1,
+          context: line.trim().substring(0, 120)
+        });
+      }
+    }
+  }
+
+  return { issues, count: issues.length };
+}
+
+// ─── checkMetricCoverage ──────────────────────────────────────────────────────
+
+export function checkMetricCoverage(content: string): MetricCoverageResult {
+  const storyMatches = content.match(/####\s+E\d+-S\d+/g) ?? [];
+  const frMatches = content.match(/###?\s+FR-\d+/g) ?? [];
+  const totalRequirements = storyMatches.length + frMatches.length;
+
+  if (totalRequirements === 0) {
+    return { total_requirements: 0, with_metrics: 0, coverage_pct: 100, gaps: [] };
+  }
+
+  const gaps: string[] = [];
+  let withMetrics = 0;
+
+  const sections = content.split(/(?=####?\s+(?:E\d+-S\d+|FR-\d+))/);
+  for (const section of sections) {
+    const idMatch = section.match(/####?\s+(E\d+-S\d+|FR-\d+)/);
+    if (!idMatch) continue;
+
+    const hasQuantified = METRIC_PATTERNS.some(p => p.test(section));
+    const hasMeasurableTag = /\[MEASURABLE\]/i.test(section);
+
+    if (hasQuantified || hasMeasurableTag) {
+      withMetrics++;
+    } else {
+      gaps.push(idMatch[1] ?? '');
+    }
+  }
+
+  const coveragePct = totalRequirements > 0
+    ? Math.round((withMetrics / totalRequirements) * 100)
+    : 100;
+
+  return { total_requirements: totalRequirements, with_metrics: withMetrics, coverage_pct: coveragePct, gaps };
+}
+
+// ─── checkTerminologyDrift ────────────────────────────────────────────────────
+
+export function checkTerminologyDrift(specsDir: string): TerminologyDriftResult {
+  if (!fs.existsSync(specsDir)) {
+    return { drifts: [], count: 0 };
+  }
+
+  const files = fs.readdirSync(specsDir)
+    .filter(f => f.endsWith('.md'))
+    .map(f => ({
+      name: f,
+      content: fs.readFileSync(path.join(specsDir, f), 'utf8').toLowerCase()
+    }));
+
+  const driftGroups = [
+    ['user', 'customer', 'client', 'end-user', 'end user', 'consumer'],
+    ['admin', 'administrator', 'system admin', 'sys admin', 'superuser', 'super user'],
+    ['api', 'endpoint', 'route', 'service'],
+    ['database', 'datastore', 'data store', 'db', 'data layer'],
+    ['login', 'sign in', 'sign-in', 'signin', 'authentication', 'log in'],
+    ['signup', 'sign up', 'sign-up', 'register', 'registration', 'create account']
+  ];
+
+  const drifts: Array<{ term: string; variants: string[]; files: string[] }> = [];
+
+  for (const group of driftGroups) {
+    const usedVariants = new Map<string, string[]>();
+
+    for (const file of files) {
+      for (const term of group) {
+        const escaped = term.replace(/[-\s]/g, '[-\\s]?');
+        const regex = new RegExp(`\\b${escaped}\\b`, 'gi');
+        if (regex.test(file.content)) {
+          if (!usedVariants.has(term)) {
+            usedVariants.set(term, []);
+          }
+          const arr = usedVariants.get(term);
+          if (arr) arr.push(file.name);
+        }
+      }
+    }
+
+    if (usedVariants.size > 1) {
+      const allFiles: string[] = [];
+      usedVariants.forEach(fileList => { allFiles.push(...fileList); });
+      drifts.push({
+        term: group[0] ?? '',
+        variants: Array.from(usedVariants.keys()),
+        files: Array.from(new Set(allFiles))
+      });
+    }
+  }
+
+  return { drifts, count: drifts.length };
+}
+
+// ─── checkGWTFormat ───────────────────────────────────────────────────────────
+
+export function checkGWTFormat(content: string): GWTResult {
+  const lines = content.split('\n');
+  const issues: GWTIssue[] = [];
+  let inAcceptanceCriteria = false;
+  let inCodeBlock = false;
+  let gwtCount = 0;
+  let nonGwtCount = 0;
+
+  const GWT_PATTERN = /^\s*[-*]?\s*\*?\*?\s*(Given|When|Then|And|But)\b/i;
+  const AC_HEADING = /^#+\s*Acceptance\s+Criteria/i;
+  const ANY_HEADING = /^#+\s/;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+
+    if (line.trim().startsWith('```')) { inCodeBlock = !inCodeBlock; continue; }
+    if (inCodeBlock) continue;
+
+    if (AC_HEADING.test(line)) { inAcceptanceCriteria = true; continue; }
+    if (inAcceptanceCriteria && ANY_HEADING.test(line) && !AC_HEADING.test(line)) {
+      inAcceptanceCriteria = false;
+      continue;
+    }
+
+    if (inAcceptanceCriteria && line.trim().length > 0) {
+      if (/^\s*[-*]\s/.test(line) || /^\s*\d+\.\s/.test(line)) {
+        if (GWT_PATTERN.test(line)) {
+          gwtCount++;
+        } else {
+          nonGwtCount++;
+          issues.push({ line: i + 1, context: line.trim().substring(0, 120) });
+        }
+      }
+    }
+  }
+
+  return { issues, gwt_count: gwtCount, non_gwt_count: nonGwtCount };
+}
+
+// ─── checkGuessingLanguage ────────────────────────────────────────────────────
+
+export const GUESSING_WORDS: string[] = [
+  'probably', 'maybe', 'perhaps', 'presumably', 'I think',
+  'I believe', 'I assume', 'might work', 'should work',
+  'not sure', 'unclear', 'TBD', 'TODO', 'FIXME',
+  'we could try', 'possibly', 'it seems', 'apparently',
+  'I guess', 'more or less', 'sort of', 'kind of',
+  'roughly', 'ballpark', 'approximately'
+];
+
+export function checkGuessingLanguage(content: string): GuessingResult {
+  const lines = content.split('\n');
+  const issues: GuessingIssue[] = [];
+  let inCodeBlock = false;
+  let inFrontmatter = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+
+    if (line.trim().startsWith('```')) { inCodeBlock = !inCodeBlock; continue; }
+    if (inCodeBlock) continue;
+    if (i === 0 && line.trim() === '---') { inFrontmatter = true; continue; }
+    if (inFrontmatter) { if (line.trim() === '---') inFrontmatter = false; continue; }
+    if (line.startsWith('#')) continue;
+
+    for (const word of GUESSING_WORDS) {
+      const escaped = word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const regex = new RegExp(`\\b${escaped}\\b`, 'gi');
+      if (regex.test(line)) {
+        if (/\[NEEDS CLARIFICATION[:\]]/i.test(line)) continue;
+        issues.push({ word, line: i + 1, context: line.trim().substring(0, 120) });
+      }
+    }
+  }
+
+  return { issues, count: issues.length };
+}
+
+// ─── runAllChecks ─────────────────────────────────────────────────────────────
+
+export interface RunAllChecksOptions {
+  specsDir?: string | undefined;
+  strict?: boolean | undefined;
+}
+
+export function runAllChecks(content: string, options: RunAllChecksOptions = {}): AllChecksResult {
+  const ambiguity = checkAmbiguity(content);
+  const passiveVoice = checkPassiveVoice(content);
+  const metricCoverage = checkMetricCoverage(content);
+  const terminologyDrift = options.specsDir
+    ? checkTerminologyDrift(options.specsDir)
+    : { drifts: [], count: 0 };
+  const gwtFormat = checkGWTFormat(content);
+  const guessingLanguage = checkGuessingLanguage(content);
+
+  let score = 100;
+  score -= Math.min(ambiguity.count * 5, 30);
+  score -= Math.min(passiveVoice.count * 3, 20);
+  score -= Math.max(0, 100 - metricCoverage.coverage_pct) * 0.3;
+  score -= Math.min(terminologyDrift.count * 10, 20);
+  score -= Math.min(guessingLanguage.count * 5, 15);
+  score = Math.max(0, Math.round(score));
+
+  const pass = options.strict ? score === 100 : score >= 70;
+
+  return {
+    pass,
+    score,
+    ambiguity,
+    passive_voice: passiveVoice,
+    metric_coverage: metricCoverage,
+    terminology_drift: terminologyDrift,
+    gwt_format: gwtFormat,
+    guessing_language: guessingLanguage
+  };
+}
+
+// ─── generateReport ───────────────────────────────────────────────────────────
+
+export function generateReport(filePath: string, options: RunAllChecksOptions = {}): string {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const result = runAllChecks(content, options);
+
+  let report = `# Spec Quality Report: ${path.basename(filePath)}\n\n`;
+  report += `**Overall Score:** ${result.score}/100 ${result.pass ? 'PASS' : 'FAIL'}\n\n`;
+
+  report += `## Ambiguity Check (${result.ambiguity.count} issues)\n\n`;
+  if (result.ambiguity.count > 0) {
+    report += '| Line | Word | Context |\n|------|------|---------|\n';
+    for (const issue of result.ambiguity.issues.slice(0, 20)) {
+      report += `| ${issue.line} | ${issue.word} | ${issue.context.substring(0, 80)} |\n`;
+    }
+  } else {
+    report += 'No ambiguous language detected.\n';
+  }
+
+  report += `\n## Passive Voice (${result.passive_voice.count} issues)\n\n`;
+  if (result.passive_voice.count > 0) {
+    report += '| Line | Pattern | Context |\n|------|------|---------|\n';
+    for (const issue of result.passive_voice.issues.slice(0, 20)) {
+      report += `| ${issue.line} | ${issue.pattern} | ${issue.context.substring(0, 80)} |\n`;
+    }
+  } else {
+    report += 'No passive voice detected.\n';
+  }
+
+  report += `\n## Metric Coverage: ${result.metric_coverage.coverage_pct}%\n\n`;
+  if (result.metric_coverage.gaps.length > 0) {
+    report += `Requirements without metrics: ${result.metric_coverage.gaps.join(', ')}\n`;
+  }
+
+  report += `\n## Terminology Drift (${result.terminology_drift.count} drifts)\n\n`;
+  if (result.terminology_drift.count > 0) {
+    for (const drift of result.terminology_drift.drifts) {
+      report += `- **${drift.term}**: used as "${drift.variants.join('", "')}" across ${drift.files.join(', ')}\n`;
+    }
+  } else {
+    report += 'No terminology drift detected.\n';
+  }
+
+  report += `\n## GWT Format (${result.gwt_format.gwt_count} GWT, ${result.gwt_format.non_gwt_count} non-GWT)\n\n`;
+  if (result.gwt_format.issues.length > 0) {
+    report += '| Line | Criterion |\n|------|-----------|\n';
+    for (const issue of result.gwt_format.issues.slice(0, 20)) {
+      report += `| ${issue.line} | ${issue.context.substring(0, 80)} |\n`;
+    }
+  } else {
+    report += 'All acceptance criteria use Given/When/Then format.\n';
+  }
+
+  report += `\n## Guessing Language (${result.guessing_language.count} issues)\n\n`;
+  if (result.guessing_language.count > 0) {
+    report += '| Line | Word | Context |\n|------|------|---------|\n';
+    for (const issue of result.guessing_language.issues.slice(0, 20)) {
+      report += `| ${issue.line} | ${issue.word} | ${issue.context.substring(0, 80)} |\n`;
+    }
+  } else {
+    report += 'No guessing language detected.\n';
+  }
+
+  return report;
+}

--- a/src/lib/spec-tester.ts
+++ b/src/lib/spec-tester.ts
@@ -9,18 +9,41 @@
  * ADR-006: no process.exit.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 // ─── Ambiguity Detection ──────────────────────────────────────────────────────
 
 export const VAGUE_ADJECTIVES: string[] = [
-  'scalable', 'fast', 'easy', 'robust', 'flexible', 'efficient',
-  'user-friendly', 'seamless', 'intuitive', 'modern', 'simple',
-  'lightweight', 'powerful', 'reliable', 'secure', 'performant',
-  'responsive', 'clean', 'elegant', 'smart', 'quick', 'high-quality',
-  'enterprise-grade', 'production-ready', 'best-in-class', 'world-class',
-  'cutting-edge', 'next-generation', 'state-of-the-art'
+  'scalable',
+  'fast',
+  'easy',
+  'robust',
+  'flexible',
+  'efficient',
+  'user-friendly',
+  'seamless',
+  'intuitive',
+  'modern',
+  'simple',
+  'lightweight',
+  'powerful',
+  'reliable',
+  'secure',
+  'performant',
+  'responsive',
+  'clean',
+  'elegant',
+  'smart',
+  'quick',
+  'high-quality',
+  'enterprise-grade',
+  'production-ready',
+  'best-in-class',
+  'world-class',
+  'cutting-edge',
+  'next-generation',
+  'state-of-the-art',
 ];
 
 export const METRIC_PATTERNS: RegExp[] = [
@@ -31,7 +54,7 @@ export const METRIC_PATTERNS: RegExp[] = [
   /\d+\s*(?:users?|connections?|concurrent)/i,
   /\d+\s*(?:nines?|9s)/i,
   /(?:99|99\.9|99\.99)\s*%\s*(?:uptime|availability|SLA)/i,
-  /(?:within|under|below|less than|at most|at least|no more than)\s+\d+/i
+  /(?:within|under|below|less than|at most|at least|no more than)\s+\d+/i,
 ];
 
 export const PASSIVE_PATTERNS: RegExp[] = [
@@ -41,7 +64,7 @@ export const PASSIVE_PATTERNS: RegExp[] = [
   /\bmust be\s+(?:\w+ed|done|handled|managed|processed|created|updated|deleted|performed|executed|configured|implemented|deployed)\b/gi,
   /\bcan be\s+(?:\w+ed|done|handled|managed|processed|created|updated|deleted|performed|executed|configured|implemented|deployed)\b/gi,
   /\bneeds to be\s+\w+ed\b/gi,
-  /\bhas to be\s+\w+ed\b/gi
+  /\bhas to be\s+\w+ed\b/gi,
 ];
 
 export interface AmbiguityIssue {
@@ -122,11 +145,20 @@ export function checkAmbiguity(content: string): AmbiguityResult {
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i] ?? '';
 
-    if (line.trim().startsWith('```')) { inCodeBlock = !inCodeBlock; continue; }
+    if (line.trim().startsWith('```')) {
+      inCodeBlock = !inCodeBlock;
+      continue;
+    }
     if (inCodeBlock) continue;
 
-    if (i === 0 && line.trim() === '---') { inFrontmatter = true; continue; }
-    if (inFrontmatter) { if (line.trim() === '---') inFrontmatter = false; continue; }
+    if (i === 0 && line.trim() === '---') {
+      inFrontmatter = true;
+      continue;
+    }
+    if (inFrontmatter) {
+      if (line.trim() === '---') inFrontmatter = false;
+      continue;
+    }
 
     if (line.startsWith('#')) continue;
 
@@ -135,7 +167,7 @@ export function checkAmbiguity(content: string): AmbiguityResult {
       if (regex.test(line)) {
         const nextLine = lines[i + 1] ?? '';
         const context = line + nextLine;
-        const hasMetric = METRIC_PATTERNS.some(p => p.test(context));
+        const hasMetric = METRIC_PATTERNS.some((p) => p.test(context));
         const hasTag = /\[MEASURABLE\]|\[NEEDS CLARIFICATION\]|\[METRIC\]/i.test(context);
 
         if (!hasMetric && !hasTag) {
@@ -159,11 +191,20 @@ export function checkPassiveVoice(content: string): PassiveResult {
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i] ?? '';
 
-    if (line.trim().startsWith('```')) { inCodeBlock = !inCodeBlock; continue; }
+    if (line.trim().startsWith('```')) {
+      inCodeBlock = !inCodeBlock;
+      continue;
+    }
     if (inCodeBlock) continue;
 
-    if (i === 0 && line.trim() === '---') { inFrontmatter = true; continue; }
-    if (inFrontmatter) { if (line.trim() === '---') inFrontmatter = false; continue; }
+    if (i === 0 && line.trim() === '---') {
+      inFrontmatter = true;
+      continue;
+    }
+    if (inFrontmatter) {
+      if (line.trim() === '---') inFrontmatter = false;
+      continue;
+    }
 
     if (line.startsWith('#')) continue;
 
@@ -174,7 +215,7 @@ export function checkPassiveVoice(content: string): PassiveResult {
         issues.push({
           pattern: match[0],
           line: i + 1,
-          context: line.trim().substring(0, 120)
+          context: line.trim().substring(0, 120),
         });
       }
     }
@@ -202,7 +243,7 @@ export function checkMetricCoverage(content: string): MetricCoverageResult {
     const idMatch = section.match(/####?\s+(E\d+-S\d+|FR-\d+)/);
     if (!idMatch) continue;
 
-    const hasQuantified = METRIC_PATTERNS.some(p => p.test(section));
+    const hasQuantified = METRIC_PATTERNS.some((p) => p.test(section));
     const hasMeasurableTag = /\[MEASURABLE\]/i.test(section);
 
     if (hasQuantified || hasMeasurableTag) {
@@ -212,11 +253,15 @@ export function checkMetricCoverage(content: string): MetricCoverageResult {
     }
   }
 
-  const coveragePct = totalRequirements > 0
-    ? Math.round((withMetrics / totalRequirements) * 100)
-    : 100;
+  const coveragePct =
+    totalRequirements > 0 ? Math.round((withMetrics / totalRequirements) * 100) : 100;
 
-  return { total_requirements: totalRequirements, with_metrics: withMetrics, coverage_pct: coveragePct, gaps };
+  return {
+    total_requirements: totalRequirements,
+    with_metrics: withMetrics,
+    coverage_pct: coveragePct,
+    gaps,
+  };
 }
 
 // ─── checkTerminologyDrift ────────────────────────────────────────────────────
@@ -226,11 +271,12 @@ export function checkTerminologyDrift(specsDir: string): TerminologyDriftResult 
     return { drifts: [], count: 0 };
   }
 
-  const files = fs.readdirSync(specsDir)
-    .filter(f => f.endsWith('.md'))
-    .map(f => ({
+  const files = fs
+    .readdirSync(specsDir)
+    .filter((f) => f.endsWith('.md'))
+    .map((f) => ({
       name: f,
-      content: fs.readFileSync(path.join(specsDir, f), 'utf8').toLowerCase()
+      content: fs.readFileSync(path.join(specsDir, f), 'utf8').toLowerCase(),
     }));
 
   const driftGroups = [
@@ -239,7 +285,7 @@ export function checkTerminologyDrift(specsDir: string): TerminologyDriftResult 
     ['api', 'endpoint', 'route', 'service'],
     ['database', 'datastore', 'data store', 'db', 'data layer'],
     ['login', 'sign in', 'sign-in', 'signin', 'authentication', 'log in'],
-    ['signup', 'sign up', 'sign-up', 'register', 'registration', 'create account']
+    ['signup', 'sign up', 'sign-up', 'register', 'registration', 'create account'],
   ];
 
   const drifts: Array<{ term: string; variants: string[]; files: string[] }> = [];
@@ -263,11 +309,13 @@ export function checkTerminologyDrift(specsDir: string): TerminologyDriftResult 
 
     if (usedVariants.size > 1) {
       const allFiles: string[] = [];
-      usedVariants.forEach(fileList => { allFiles.push(...fileList); });
+      usedVariants.forEach((fileList) => {
+        allFiles.push(...fileList);
+      });
       drifts.push({
         term: group[0] ?? '',
         variants: Array.from(usedVariants.keys()),
-        files: Array.from(new Set(allFiles))
+        files: Array.from(new Set(allFiles)),
       });
     }
   }
@@ -292,10 +340,16 @@ export function checkGWTFormat(content: string): GWTResult {
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i] ?? '';
 
-    if (line.trim().startsWith('```')) { inCodeBlock = !inCodeBlock; continue; }
+    if (line.trim().startsWith('```')) {
+      inCodeBlock = !inCodeBlock;
+      continue;
+    }
     if (inCodeBlock) continue;
 
-    if (AC_HEADING.test(line)) { inAcceptanceCriteria = true; continue; }
+    if (AC_HEADING.test(line)) {
+      inAcceptanceCriteria = true;
+      continue;
+    }
     if (inAcceptanceCriteria && ANY_HEADING.test(line) && !AC_HEADING.test(line)) {
       inAcceptanceCriteria = false;
       continue;
@@ -319,12 +373,31 @@ export function checkGWTFormat(content: string): GWTResult {
 // ─── checkGuessingLanguage ────────────────────────────────────────────────────
 
 export const GUESSING_WORDS: string[] = [
-  'probably', 'maybe', 'perhaps', 'presumably', 'I think',
-  'I believe', 'I assume', 'might work', 'should work',
-  'not sure', 'unclear', 'TBD', 'TODO', 'FIXME',
-  'we could try', 'possibly', 'it seems', 'apparently',
-  'I guess', 'more or less', 'sort of', 'kind of',
-  'roughly', 'ballpark', 'approximately'
+  'probably',
+  'maybe',
+  'perhaps',
+  'presumably',
+  'I think',
+  'I believe',
+  'I assume',
+  'might work',
+  'should work',
+  'not sure',
+  'unclear',
+  'TBD',
+  'TODO',
+  'FIXME',
+  'we could try',
+  'possibly',
+  'it seems',
+  'apparently',
+  'I guess',
+  'more or less',
+  'sort of',
+  'kind of',
+  'roughly',
+  'ballpark',
+  'approximately',
 ];
 
 export function checkGuessingLanguage(content: string): GuessingResult {
@@ -336,10 +409,19 @@ export function checkGuessingLanguage(content: string): GuessingResult {
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i] ?? '';
 
-    if (line.trim().startsWith('```')) { inCodeBlock = !inCodeBlock; continue; }
+    if (line.trim().startsWith('```')) {
+      inCodeBlock = !inCodeBlock;
+      continue;
+    }
     if (inCodeBlock) continue;
-    if (i === 0 && line.trim() === '---') { inFrontmatter = true; continue; }
-    if (inFrontmatter) { if (line.trim() === '---') inFrontmatter = false; continue; }
+    if (i === 0 && line.trim() === '---') {
+      inFrontmatter = true;
+      continue;
+    }
+    if (inFrontmatter) {
+      if (line.trim() === '---') inFrontmatter = false;
+      continue;
+    }
     if (line.startsWith('#')) continue;
 
     for (const word of GUESSING_WORDS) {
@@ -390,7 +472,7 @@ export function runAllChecks(content: string, options: RunAllChecksOptions = {})
     metric_coverage: metricCoverage,
     terminology_drift: terminologyDrift,
     gwt_format: gwtFormat,
-    guessing_language: guessingLanguage
+    guessing_language: guessingLanguage,
   };
 }
 

--- a/src/lib/template-watcher.ts
+++ b/src/lib/template-watcher.ts
@@ -1,0 +1,174 @@
+/**
+ * template-watcher.ts -- Artifact Hot-Reloading (Item 14).
+ *
+ * Detects template changes and prompts spec updates.
+ *
+ * M3 hardening: snapshot files are plain JSON dicts with string values
+ *   (filename -> hash). assertNoPollution() validates before use.
+ * ADR-009: templatesDir/snapshotPath must be pre-validated by caller.
+ * ADR-006: no process.exit.
+ * defaultState fallback: loadSnapshot returns null on missing file (first run).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+
+export type Snapshot = Record<string, string>;
+
+export interface SnapshotChanges {
+  added: string[];
+  modified: string[];
+  removed: string[];
+}
+
+export interface WatchResult {
+  changed: boolean;
+  changes: SnapshotChanges;
+  warnings: string[];
+}
+
+/** Dangerous keys that must never appear in parsed JSON objects */
+const BLOCKED_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function assertNoPollution(obj: unknown, p = ''): void {
+  if (obj === null || typeof obj !== 'object') return;
+  for (const key of Object.keys(obj as object)) {
+    if (BLOCKED_KEYS.has(key)) {
+      throw new Error(`Prototype pollution key detected at ${p}.${key}`);
+    }
+    assertNoPollution((obj as Record<string, unknown>)[key], `${p}.${key}`);
+  }
+}
+
+/**
+ * Compute a SHA-256 hash for a file.
+ */
+export function fileHash(filePath: string): string {
+  const content = fs.readFileSync(filePath, 'utf8');
+  return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+/**
+ * Build a snapshot of all template files and their hashes.
+ */
+export function buildSnapshot(templatesDir: string): Snapshot {
+  const snapshot: Snapshot = {};
+
+  if (!fs.existsSync(templatesDir)) {
+    return snapshot;
+  }
+
+  const files = fs.readdirSync(templatesDir).filter(f => f.endsWith('.md'));
+  for (const file of files) {
+    snapshot[file] = fileHash(path.join(templatesDir, file));
+  }
+
+  return snapshot;
+}
+
+/**
+ * Load the previous template snapshot from disk.
+ * Returns null on first run or missing file.
+ */
+export function loadSnapshot(snapshotPath: string): Snapshot | null {
+  if (!fs.existsSync(snapshotPath)) return null;
+  try {
+    const raw = JSON.parse(fs.readFileSync(snapshotPath, 'utf8'));
+    assertNoPollution(raw);
+    return raw as Snapshot;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save a template snapshot to disk.
+ */
+export function saveSnapshot(snapshotPath: string, snapshot: Snapshot): void {
+  const dir = path.dirname(snapshotPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.writeFileSync(snapshotPath, JSON.stringify(snapshot, null, 2), 'utf8');
+}
+
+/**
+ * Compare two template snapshots and identify changes.
+ */
+export function compareSnapshots(previous: Snapshot, current: Snapshot): SnapshotChanges {
+  const added: string[] = [];
+  const modified: string[] = [];
+  const removed: string[] = [];
+
+  for (const [file, hash] of Object.entries(current)) {
+    if (!(file in previous)) {
+      added.push(file);
+    } else if (previous[file] !== hash) {
+      modified.push(file);
+    }
+  }
+
+  for (const file of Object.keys(previous)) {
+    if (!(file in current)) {
+      removed.push(file);
+    }
+  }
+
+  return { added, modified, removed };
+}
+
+const TEMPLATE_TO_SPEC: Record<string, string> = {
+  'prd.md': 'specs/prd.md',
+  'architecture.md': 'specs/architecture.md',
+  'implementation-plan.md': 'specs/implementation-plan.md',
+  'product-brief.md': 'specs/product-brief.md',
+  'challenger-brief.md': 'specs/challenger-brief.md',
+  'codebase-context.md': 'specs/codebase-context.md',
+  'adr.md': 'specs/decisions/',
+  'insights.md': 'specs/insights/',
+  'qa-log.md': 'specs/qa-log.md',
+};
+
+/**
+ * Map template files to their corresponding spec artifacts.
+ */
+export function templateToSpec(templateName: string): string {
+  return TEMPLATE_TO_SPEC[templateName] ?? `specs/${templateName}`;
+}
+
+/**
+ * Check for template changes and generate warnings.
+ */
+export function checkForChanges(templatesDir: string, snapshotPath: string): WatchResult {
+  const current = buildSnapshot(templatesDir);
+  const previous = loadSnapshot(snapshotPath);
+  const warnings: string[] = [];
+
+  if (!previous) {
+    // First run -- save baseline
+    saveSnapshot(snapshotPath, current);
+    return { changed: false, changes: { added: [], modified: [], removed: [] }, warnings };
+  }
+
+  const changes = compareSnapshots(previous, current);
+  const changed = changes.added.length > 0 || changes.modified.length > 0 || changes.removed.length > 0;
+
+  if (changed) {
+    for (const file of changes.modified) {
+      const specPath = templateToSpec(file);
+      warnings.push(`Template '${file}' has changed. Spec '${specPath}' may need regeneration.`);
+    }
+    for (const file of changes.added) {
+      warnings.push(`New template '${file}' added. Consider generating corresponding spec.`);
+    }
+    for (const file of changes.removed) {
+      warnings.push(`Template '${file}' was removed. Check if corresponding specs are orphaned.`);
+    }
+
+    // Update snapshot
+    saveSnapshot(snapshotPath, current);
+  }
+
+  return { changed, changes, warnings };
+}

--- a/src/lib/template-watcher.ts
+++ b/src/lib/template-watcher.ts
@@ -10,9 +10,9 @@
  * defaultState fallback: loadSnapshot returns null on missing file (first run).
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
-import * as crypto from 'crypto';
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 export type Snapshot = Record<string, string>;
 
@@ -59,7 +59,7 @@ export function buildSnapshot(templatesDir: string): Snapshot {
     return snapshot;
   }
 
-  const files = fs.readdirSync(templatesDir).filter(f => f.endsWith('.md'));
+  const files = fs.readdirSync(templatesDir).filter((f) => f.endsWith('.md'));
   for (const file of files) {
     snapshot[file] = fileHash(path.join(templatesDir, file));
   }
@@ -152,7 +152,8 @@ export function checkForChanges(templatesDir: string, snapshotPath: string): Wat
   }
 
   const changes = compareSnapshots(previous, current);
-  const changed = changes.added.length > 0 || changes.modified.length > 0 || changes.removed.length > 0;
+  const changed =
+    changes.added.length > 0 || changes.modified.length > 0 || changes.removed.length > 0;
 
   if (changed) {
     for (const file of changes.modified) {

--- a/src/lib/tool-bridge.ts
+++ b/src/lib/tool-bridge.ts
@@ -68,6 +68,7 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { assertInsideRoot } from './path-safety.js';
+import { computeUATCoverage } from './uat-coverage.js';
 import type { TimelineLike } from './simulation-tracer.js';
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -742,15 +743,9 @@ export function createToolBridge(options: ToolBridgeOptions): ToolBridge {
 
     async run_uat_coverage(args) {
       try {
-        const mod = await dynImportFirst(['./uat-coverage.js', '../lib/uat-coverage.js']);
-        if (!mod) return { error: 'uat-coverage unavailable', pass: false };
-        const computeUATCoverage = mod.computeUATCoverage as
-          | ((prdPath: unknown, testDir: unknown) => unknown)
-          | undefined;
-        if (!computeUATCoverage) {
-          return { error: 'computeUATCoverage unavailable', pass: false };
-        }
-        return computeUATCoverage(args.prd_path, args.test_dir);
+        const prdPath = typeof args.prd_path === 'string' ? args.prd_path : '';
+        const testDir = typeof args.test_dir === 'string' ? args.test_dir : '';
+        return computeUATCoverage(prdPath, testDir);
       } catch (err) {
         return { error: (err as Error).message, pass: false };
       }

--- a/src/lib/tool-bridge.ts
+++ b/src/lib/tool-bridge.ts
@@ -68,8 +68,8 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { assertInsideRoot } from './path-safety.js';
-import { computeUATCoverage } from './uat-coverage.js';
 import type { TimelineLike } from './simulation-tracer.js';
+import { computeUATCoverage } from './uat-coverage.js';
 
 // ─────────────────────────────────────────────────────────────────────────
 // Public types

--- a/src/lib/uat-coverage.ts
+++ b/src/lib/uat-coverage.ts
@@ -10,8 +10,8 @@
  * ADR-006: no process.exit.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 export interface StoryAC {
   story_id: string;
@@ -57,7 +57,7 @@ function walkTestFiles(dir: string): string[] {
   const results: string[] = [];
 
   function walk(currentDir: string): void {
-    let entries;
+    let entries: fs.Dirent<string>[];
     try {
       entries = fs.readdirSync(currentDir, { withFileTypes: true });
     } catch {
@@ -70,7 +70,7 @@ function walkTestFiles(dir: string): string[] {
           walk(fullPath);
         }
       } else {
-        const isTestFile = TEST_PATTERNS.some(p => entry.name.includes(p));
+        const isTestFile = TEST_PATTERNS.some((p) => entry.name.includes(p));
         if (isTestFile) {
           results.push(fullPath);
         }
@@ -96,10 +96,7 @@ export function extractAcceptanceCriteria(prdContent: string): StoryAC[] {
 
   for (const storyId of storyIds) {
     const escapedId = storyId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const sectionRegex = new RegExp(
-      `${escapedId}[\\s\\S]*?(?=E\\d+-S\\d+|## |$)`,
-      'g'
-    );
+    const sectionRegex = new RegExp(`${escapedId}[\\s\\S]*?(?=E\\d+-S\\d+|## |$)`, 'g');
     const section = sectionRegex.exec(prdContent);
 
     if (!section) {
@@ -112,8 +109,9 @@ export function extractAcceptanceCriteria(prdContent: string): StoryAC[] {
     // Extract Gherkin blocks
     const gherkinLines: string[] = [];
     const gherkinPattern = /^\s*(Given|When|Then|And|But)\s+(.+)/gm;
-    let gherkinMatch: RegExpExecArray | null;
-    while ((gherkinMatch = gherkinPattern.exec(sectionText)) !== null) {
+    for (;;) {
+      const gherkinMatch = gherkinPattern.exec(sectionText);
+      if (gherkinMatch === null) break;
       gherkinLines.push(`${gherkinMatch[1] ?? ''} ${(gherkinMatch[2] ?? '').trim()}`);
     }
 
@@ -125,16 +123,18 @@ export function extractAcceptanceCriteria(prdContent: string): StoryAC[] {
 
     if (acSection) {
       const bulletPattern = /^\s*[-*]\s+(.+)/gm;
-      let bulletMatch: RegExpExecArray | null;
-      while ((bulletMatch = bulletPattern.exec(acSection[1] ?? '')) !== null) {
+      for (;;) {
+        const bulletMatch = bulletPattern.exec(acSection[1] ?? '');
+        if (bulletMatch === null) break;
         criteria.push((bulletMatch[1] ?? '').trim());
       }
     }
 
     if (criteria.length === 0) {
       const bulletPattern = /^\s*[-*]\s+(.+)/gm;
-      let bulletMatch: RegExpExecArray | null;
-      while ((bulletMatch = bulletPattern.exec(sectionText)) !== null) {
+      for (;;) {
+        const bulletMatch = bulletPattern.exec(sectionText);
+        if (bulletMatch === null) break;
         const text = (bulletMatch[1] ?? '').trim();
         if (text.length > 10 && !text.startsWith('#') && !text.startsWith('|')) {
           criteria.push(text);
@@ -153,7 +153,10 @@ export function extractAcceptanceCriteria(prdContent: string): StoryAC[] {
 /**
  * Scan test files for references to story IDs.
  */
-export function scanTestCoverage(testDir: string, storyIds: string[]): Map<string, StoryCoverageEntry> {
+export function scanTestCoverage(
+  testDir: string,
+  storyIds: string[]
+): Map<string, StoryCoverageEntry> {
   const coverage = new Map<string, StoryCoverageEntry>();
   for (const id of storyIds) {
     coverage.set(id, { files: [], keywords: [] });
@@ -201,14 +204,69 @@ export function scanTestCoverage(testDir: string, storyIds: string[]): Map<strin
 // ─── extractKeywords ─────────────────────────────────────────────────────────
 
 const STOPWORDS = new Set([
-  'the', 'a', 'an', 'is', 'are', 'was', 'were', 'be', 'been', 'being',
-  'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would', 'shall',
-  'should', 'may', 'might', 'must', 'can', 'could', 'and', 'but', 'or',
-  'nor', 'not', 'so', 'yet', 'both', 'either', 'neither', 'each',
-  'every', 'all', 'any', 'few', 'more', 'most', 'other', 'some',
-  'such', 'than', 'too', 'very', 'just', 'that', 'this', 'these',
-  'those', 'with', 'from', 'into', 'for', 'about', 'given', 'when',
-  'then', 'user', 'system'
+  'the',
+  'a',
+  'an',
+  'is',
+  'are',
+  'was',
+  'were',
+  'be',
+  'been',
+  'being',
+  'have',
+  'has',
+  'had',
+  'do',
+  'does',
+  'did',
+  'will',
+  'would',
+  'shall',
+  'should',
+  'may',
+  'might',
+  'must',
+  'can',
+  'could',
+  'and',
+  'but',
+  'or',
+  'nor',
+  'not',
+  'so',
+  'yet',
+  'both',
+  'either',
+  'neither',
+  'each',
+  'every',
+  'all',
+  'any',
+  'few',
+  'more',
+  'most',
+  'other',
+  'some',
+  'such',
+  'than',
+  'too',
+  'very',
+  'just',
+  'that',
+  'this',
+  'these',
+  'those',
+  'with',
+  'from',
+  'into',
+  'for',
+  'about',
+  'given',
+  'when',
+  'then',
+  'user',
+  'system',
 ]);
 
 export function extractKeywords(text: string): string[] {
@@ -216,7 +274,7 @@ export function extractKeywords(text: string): string[] {
     .toLowerCase()
     .replace(/[^a-z0-9\s]/g, ' ')
     .split(/\s+/)
-    .filter(w => w.length > 3 && !STOPWORDS.has(w));
+    .filter((w) => w.length > 3 && !STOPWORDS.has(w));
 }
 
 // ─── matchCriteriaToTests ────────────────────────────────────────────────────
@@ -254,10 +312,8 @@ export function matchCriteriaToTests(storyCriteria: StoryAC[], testDir: string):
       testContents.forEach((content, file) => {
         const hasStoryRef = content.includes(story.story_id.toLowerCase());
 
-        const keywordHits = keywords.filter(k => content.includes(k.toLowerCase()));
-        const keywordCoverage = keywords.length > 0
-          ? keywordHits.length / keywords.length
-          : 0;
+        const keywordHits = keywords.filter((k) => content.includes(k.toLowerCase()));
+        const keywordCoverage = keywords.length > 0 ? keywordHits.length / keywords.length : 0;
 
         if (hasStoryRef || keywordCoverage >= 0.5) {
           matchingFiles.push(path.relative(testDir, file));
@@ -268,7 +324,7 @@ export function matchCriteriaToTests(storyCriteria: StoryAC[], testDir: string):
         story_id: story.story_id,
         criterion,
         covered: matchingFiles.length > 0,
-        test_files: Array.from(new Set(matchingFiles))
+        test_files: Array.from(new Set(matchingFiles)),
       });
     }
   }
@@ -285,25 +341,23 @@ export function computeUATCoverage(prdPath: string, testDir: string): UATCoverag
 
   const prdContent = fs.readFileSync(prdPath, 'utf8');
   const storyCriteria = extractAcceptanceCriteria(prdContent);
-  const storyIds = storyCriteria.map(s => s.story_id);
+  const storyIds = storyCriteria.map((s) => s.story_id);
 
   const storyCoverage = scanTestCoverage(testDir, storyIds);
   const criteriaResults = matchCriteriaToTests(storyCriteria, testDir);
 
   const totalCriteria = criteriaResults.length;
-  const coveredCriteria = criteriaResults.filter(r => r.covered).length;
-  const criteriaCoveragePct = totalCriteria > 0
-    ? Math.round((coveredCriteria / totalCriteria) * 100)
-    : 100;
+  const coveredCriteria = criteriaResults.filter((r) => r.covered).length;
+  const criteriaCoveragePct =
+    totalCriteria > 0 ? Math.round((coveredCriteria / totalCriteria) * 100) : 100;
 
   const totalStories = storyIds.length;
-  const coveredStories = storyIds.filter(id => {
+  const coveredStories = storyIds.filter((id) => {
     const entry = storyCoverage.get(id);
     return entry && entry.files.length > 0;
   });
-  const storyCoveragePct = totalStories > 0
-    ? Math.round((coveredStories.length / totalStories) * 100)
-    : 100;
+  const storyCoveragePct =
+    totalStories > 0 ? Math.round((coveredStories.length / totalStories) * 100) : 100;
 
   return {
     total_stories: totalStories,
@@ -312,13 +366,13 @@ export function computeUATCoverage(prdPath: string, testDir: string): UATCoverag
     total_criteria: totalCriteria,
     covered_criteria: coveredCriteria,
     criteria_coverage_pct: criteriaCoveragePct,
-    story_details: storyCriteria.map(s => ({
+    story_details: storyCriteria.map((s) => ({
       story_id: s.story_id,
       criteria_count: s.criteria.length + s.gherkin.length,
-      test_files: (storyCoverage.get(s.story_id) ?? { files: [] }).files
+      test_files: (storyCoverage.get(s.story_id) ?? { files: [] }).files,
     })),
     criteria_details: criteriaResults,
-    pass: criteriaCoveragePct >= 80
+    pass: criteriaCoveragePct >= 80,
   };
 }
 
@@ -338,13 +392,11 @@ export function generateUATReport(prdPath: string, testDir: string): string {
 
   for (const story of result.story_details) {
     const status = story.test_files.length > 0 ? 'PASS' : 'FAIL';
-    const files = story.test_files.length > 0
-      ? story.test_files.join(', ')
-      : '_none_';
+    const files = story.test_files.length > 0 ? story.test_files.join(', ') : '_none_';
     report += `| ${story.story_id} | ${story.criteria_count} | ${files} | ${status} |\n`;
   }
 
-  const uncovered = result.criteria_details.filter(c => !c.covered);
+  const uncovered = result.criteria_details.filter((c) => !c.covered);
   if (uncovered.length > 0) {
     report += `\n## Uncovered Acceptance Criteria\n\n`;
     for (const item of uncovered) {
@@ -352,7 +404,7 @@ export function generateUATReport(prdPath: string, testDir: string): string {
     }
   }
 
-  const covered = result.criteria_details.filter(c => c.covered);
+  const covered = result.criteria_details.filter((c) => c.covered);
   if (covered.length > 0) {
     report += `\n## Covered Acceptance Criteria\n\n`;
     for (const item of covered) {

--- a/src/lib/uat-coverage.ts
+++ b/src/lib/uat-coverage.ts
@@ -1,0 +1,364 @@
+/**
+ * uat-coverage.ts -- Automated User Acceptance Testing (UAT) Alignment.
+ *
+ * Extends coverage.ts to verify that PRD acceptance criteria (Gherkin-style
+ * Given/When/Then or plain-text AC) are actually covered by the generated
+ * test suite.
+ *
+ * M3 hardening: no JSON state -- pure text processing.
+ * ADR-009: prdPath/testDir must be pre-validated by caller.
+ * ADR-006: no process.exit.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface StoryAC {
+  story_id: string;
+  criteria: string[];
+  gherkin: string[];
+}
+
+export interface StoryCoverageEntry {
+  files: string[];
+  keywords: string[];
+}
+
+export interface CriterionResult {
+  story_id: string;
+  criterion: string;
+  covered: boolean;
+  test_files: string[];
+}
+
+export interface StoryDetail {
+  story_id: string;
+  criteria_count: number;
+  test_files: string[];
+}
+
+export interface UATCoverageResult {
+  total_stories: number;
+  covered_stories: number;
+  story_coverage_pct: number;
+  total_criteria: number;
+  covered_criteria: number;
+  criteria_coverage_pct: number;
+  story_details: StoryDetail[];
+  criteria_details: CriterionResult[];
+  pass: boolean;
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+const TEST_PATTERNS = ['.test.', '.spec.', '_test.', '_spec.', '.feature'];
+
+function walkTestFiles(dir: string): string[] {
+  const results: string[] = [];
+
+  function walk(currentDir: string): void {
+    let entries;
+    try {
+      entries = fs.readdirSync(currentDir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const fullPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name !== 'node_modules' && entry.name !== '.git') {
+          walk(fullPath);
+        }
+      } else {
+        const isTestFile = TEST_PATTERNS.some(p => entry.name.includes(p));
+        if (isTestFile) {
+          results.push(fullPath);
+        }
+      }
+    }
+  }
+
+  walk(dir);
+  return results;
+}
+
+export { walkTestFiles };
+
+// ─── extractAcceptanceCriteria ───────────────────────────────────────────────
+
+/**
+ * Extract acceptance criteria from a PRD document.
+ */
+export function extractAcceptanceCriteria(prdContent: string): StoryAC[] {
+  const stories: StoryAC[] = [];
+  const storyPattern = /\b(E\d+-S\d+)\b/g;
+  const storyIds = Array.from(new Set(prdContent.match(storyPattern) ?? []));
+
+  for (const storyId of storyIds) {
+    const escapedId = storyId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const sectionRegex = new RegExp(
+      `${escapedId}[\\s\\S]*?(?=E\\d+-S\\d+|## |$)`,
+      'g'
+    );
+    const section = sectionRegex.exec(prdContent);
+
+    if (!section) {
+      stories.push({ story_id: storyId, criteria: [], gherkin: [] });
+      continue;
+    }
+
+    const sectionText = section[0];
+
+    // Extract Gherkin blocks
+    const gherkinLines: string[] = [];
+    const gherkinPattern = /^\s*(Given|When|Then|And|But)\s+(.+)/gm;
+    let gherkinMatch: RegExpExecArray | null;
+    while ((gherkinMatch = gherkinPattern.exec(sectionText)) !== null) {
+      gherkinLines.push(`${gherkinMatch[1] ?? ''} ${(gherkinMatch[2] ?? '').trim()}`);
+    }
+
+    // Extract bullet-point acceptance criteria
+    const criteria: string[] = [];
+    const acSection = sectionText.match(
+      /(?:acceptance\s+criteria|AC|criteria)[:\s]*\n([\s\S]*?)(?=\n(?:#{1,3}\s|\n\n)|$)/i
+    );
+
+    if (acSection) {
+      const bulletPattern = /^\s*[-*]\s+(.+)/gm;
+      let bulletMatch: RegExpExecArray | null;
+      while ((bulletMatch = bulletPattern.exec(acSection[1] ?? '')) !== null) {
+        criteria.push((bulletMatch[1] ?? '').trim());
+      }
+    }
+
+    if (criteria.length === 0) {
+      const bulletPattern = /^\s*[-*]\s+(.+)/gm;
+      let bulletMatch: RegExpExecArray | null;
+      while ((bulletMatch = bulletPattern.exec(sectionText)) !== null) {
+        const text = (bulletMatch[1] ?? '').trim();
+        if (text.length > 10 && !text.startsWith('#') && !text.startsWith('|')) {
+          criteria.push(text);
+        }
+      }
+    }
+
+    stories.push({ story_id: storyId, criteria, gherkin: gherkinLines });
+  }
+
+  return stories;
+}
+
+// ─── scanTestCoverage ─────────────────────────────────────────────────────────
+
+/**
+ * Scan test files for references to story IDs.
+ */
+export function scanTestCoverage(testDir: string, storyIds: string[]): Map<string, StoryCoverageEntry> {
+  const coverage = new Map<string, StoryCoverageEntry>();
+  for (const id of storyIds) {
+    coverage.set(id, { files: [], keywords: [] });
+  }
+
+  if (!fs.existsSync(testDir)) {
+    return coverage;
+  }
+
+  const testFiles = walkTestFiles(testDir);
+
+  for (const testFile of testFiles) {
+    let content: string;
+    try {
+      content = fs.readFileSync(testFile, 'utf8');
+    } catch {
+      continue;
+    }
+
+    for (const storyId of storyIds) {
+      const entry = coverage.get(storyId);
+      if (!entry) continue;
+
+      if (content.includes(storyId)) {
+        entry.files.push(path.relative(testDir, testFile));
+      }
+
+      const escapedId = storyId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const testBlockPattern = new RegExp(
+        `(?:describe|it|test)\\s*\\(\\s*['"\`].*${escapedId}.*['"\`]`,
+        'i'
+      );
+      if (testBlockPattern.test(content)) {
+        const relFile = path.relative(testDir, testFile);
+        if (!entry.files.includes(relFile)) {
+          entry.files.push(relFile);
+        }
+      }
+    }
+  }
+
+  return coverage;
+}
+
+// ─── extractKeywords ─────────────────────────────────────────────────────────
+
+const STOPWORDS = new Set([
+  'the', 'a', 'an', 'is', 'are', 'was', 'were', 'be', 'been', 'being',
+  'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would', 'shall',
+  'should', 'may', 'might', 'must', 'can', 'could', 'and', 'but', 'or',
+  'nor', 'not', 'so', 'yet', 'both', 'either', 'neither', 'each',
+  'every', 'all', 'any', 'few', 'more', 'most', 'other', 'some',
+  'such', 'than', 'too', 'very', 'just', 'that', 'this', 'these',
+  'those', 'with', 'from', 'into', 'for', 'about', 'given', 'when',
+  'then', 'user', 'system'
+]);
+
+export function extractKeywords(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter(w => w.length > 3 && !STOPWORDS.has(w));
+}
+
+// ─── matchCriteriaToTests ────────────────────────────────────────────────────
+
+export function matchCriteriaToTests(storyCriteria: StoryAC[], testDir: string): CriterionResult[] {
+  const results: CriterionResult[] = [];
+
+  if (!fs.existsSync(testDir)) {
+    for (const story of storyCriteria) {
+      const allCriteria = [...story.criteria, ...story.gherkin];
+      for (const criterion of allCriteria) {
+        results.push({ story_id: story.story_id, criterion, covered: false, test_files: [] });
+      }
+    }
+    return results;
+  }
+
+  const testFiles = walkTestFiles(testDir);
+  const testContents = new Map<string, string>();
+  for (const file of testFiles) {
+    try {
+      testContents.set(file, fs.readFileSync(file, 'utf8').toLowerCase());
+    } catch {
+      // skip
+    }
+  }
+
+  for (const story of storyCriteria) {
+    const allCriteria = [...story.criteria, ...story.gherkin];
+
+    for (const criterion of allCriteria) {
+      const keywords = extractKeywords(criterion);
+      const matchingFiles: string[] = [];
+
+      testContents.forEach((content, file) => {
+        const hasStoryRef = content.includes(story.story_id.toLowerCase());
+
+        const keywordHits = keywords.filter(k => content.includes(k.toLowerCase()));
+        const keywordCoverage = keywords.length > 0
+          ? keywordHits.length / keywords.length
+          : 0;
+
+        if (hasStoryRef || keywordCoverage >= 0.5) {
+          matchingFiles.push(path.relative(testDir, file));
+        }
+      });
+
+      results.push({
+        story_id: story.story_id,
+        criterion,
+        covered: matchingFiles.length > 0,
+        test_files: Array.from(new Set(matchingFiles))
+      });
+    }
+  }
+
+  return results;
+}
+
+// ─── computeUATCoverage ──────────────────────────────────────────────────────
+
+export function computeUATCoverage(prdPath: string, testDir: string): UATCoverageResult {
+  if (!fs.existsSync(prdPath)) {
+    throw new Error(`PRD not found: ${prdPath}`);
+  }
+
+  const prdContent = fs.readFileSync(prdPath, 'utf8');
+  const storyCriteria = extractAcceptanceCriteria(prdContent);
+  const storyIds = storyCriteria.map(s => s.story_id);
+
+  const storyCoverage = scanTestCoverage(testDir, storyIds);
+  const criteriaResults = matchCriteriaToTests(storyCriteria, testDir);
+
+  const totalCriteria = criteriaResults.length;
+  const coveredCriteria = criteriaResults.filter(r => r.covered).length;
+  const criteriaCoveragePct = totalCriteria > 0
+    ? Math.round((coveredCriteria / totalCriteria) * 100)
+    : 100;
+
+  const totalStories = storyIds.length;
+  const coveredStories = storyIds.filter(id => {
+    const entry = storyCoverage.get(id);
+    return entry && entry.files.length > 0;
+  });
+  const storyCoveragePct = totalStories > 0
+    ? Math.round((coveredStories.length / totalStories) * 100)
+    : 100;
+
+  return {
+    total_stories: totalStories,
+    covered_stories: coveredStories.length,
+    story_coverage_pct: storyCoveragePct,
+    total_criteria: totalCriteria,
+    covered_criteria: coveredCriteria,
+    criteria_coverage_pct: criteriaCoveragePct,
+    story_details: storyCriteria.map(s => ({
+      story_id: s.story_id,
+      criteria_count: s.criteria.length + s.gherkin.length,
+      test_files: (storyCoverage.get(s.story_id) ?? { files: [] }).files
+    })),
+    criteria_details: criteriaResults,
+    pass: criteriaCoveragePct >= 80
+  };
+}
+
+// ─── generateUATReport ───────────────────────────────────────────────────────
+
+export function generateUATReport(prdPath: string, testDir: string): string {
+  const result = computeUATCoverage(prdPath, testDir);
+
+  let report = `# UAT Coverage Report: Acceptance Criteria -> Tests\n\n`;
+  report += `**Story Coverage:** ${result.story_coverage_pct}% (${result.covered_stories}/${result.total_stories} stories)\n`;
+  report += `**Criteria Coverage:** ${result.criteria_coverage_pct}% (${result.covered_criteria}/${result.total_criteria} criteria)\n`;
+  report += `**Status:** ${result.pass ? 'PASS' : 'FAIL'} (threshold: 80%)\n\n`;
+
+  report += `## Story Summary\n\n`;
+  report += `| Story | Criteria | Test Files | Status |\n`;
+  report += `|-------|----------|------------|--------|\n`;
+
+  for (const story of result.story_details) {
+    const status = story.test_files.length > 0 ? 'PASS' : 'FAIL';
+    const files = story.test_files.length > 0
+      ? story.test_files.join(', ')
+      : '_none_';
+    report += `| ${story.story_id} | ${story.criteria_count} | ${files} | ${status} |\n`;
+  }
+
+  const uncovered = result.criteria_details.filter(c => !c.covered);
+  if (uncovered.length > 0) {
+    report += `\n## Uncovered Acceptance Criteria\n\n`;
+    for (const item of uncovered) {
+      report += `- **${item.story_id}**: ${item.criterion}\n`;
+    }
+  }
+
+  const covered = result.criteria_details.filter(c => c.covered);
+  if (covered.length > 0) {
+    report += `\n## Covered Acceptance Criteria\n\n`;
+    for (const item of covered) {
+      report += `- **${item.story_id}**: ${item.criterion} -> ${item.test_files.join(', ')}\n`;
+    }
+  }
+
+  return report;
+}

--- a/tests/test-boundary-check.test.ts
+++ b/tests/test-boundary-check.test.ts
@@ -1,15 +1,12 @@
 /**
  * tests/test-boundary-check.test.ts -- vitest suite for src/lib/boundary-check.ts
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
-import {
-  extractBoundaries,
-  extractPlanScope,
-  checkBoundaries,
-} from '../src/lib/boundary-check.js';
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { checkBoundaries, extractBoundaries, extractPlanScope } from '../src/lib/boundary-check.js';
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
@@ -111,7 +108,11 @@ Use React for frontend.
 
 describe('checkBoundaries', () => {
   it('returns error when brief file not found', () => {
-    const result = checkBoundaries({ brief: '/nonexistent/brief.md', plan: '/nonexistent/plan.md', root: '.' });
+    const result = checkBoundaries({
+      brief: '/nonexistent/brief.md',
+      plan: '/nonexistent/plan.md',
+      root: '.',
+    });
     expect(result.pass).toBe(false);
     expect(result.error).toContain('Cannot read brief');
   });
@@ -124,29 +125,41 @@ describe('checkBoundaries', () => {
   });
 
   it('passes when plan does not contain excluded terms', () => {
-    const brief = write('brief.md', `
+    const brief = write(
+      'brief.md',
+      `
 ## Constraints
 - No MongoDB
 - Avoid Redis
-`);
-    const plan = write('plan.md', `
+`
+    );
+    const plan = write(
+      'plan.md',
+      `
 ### M1-T01: Build API
 Use PostgreSQL for storage.
-`);
+`
+    );
     const result = checkBoundaries({ brief, plan, root: tmpDir });
     expect(result.pass).toBe(true);
     expect(result.violations.length).toBe(0);
   });
 
   it('detects violations when plan contains excluded terms', () => {
-    const brief = write('brief.md', `
+    const brief = write(
+      'brief.md',
+      `
 ## Constraints
 - Do not use mongodb in the implementation
-`);
-    const plan = write('plan.md', `
+`
+    );
+    const plan = write(
+      'plan.md',
+      `
 ### M1-T01: Build API
 Set up mongodb for persistence.
-`);
+`
+    );
     const result = checkBoundaries({ brief, plan, root: tmpDir });
     expect(result.violations.length).toBeGreaterThan(0);
   });
@@ -172,7 +185,9 @@ Set up mongodb for persistence.
 
 describe('pollution-key safety', () => {
   it('extractBoundaries does not crash on __proto__ bytes in content', () => {
-    const content = Buffer.from('{"__proto__":{"evil":1}}\n## Constraints\n- No MongoDB\n').toString();
+    const content = Buffer.from(
+      '{"__proto__":{"evil":1}}\n## Constraints\n- No MongoDB\n'
+    ).toString();
     expect(() => extractBoundaries(content)).not.toThrow();
   });
 

--- a/tests/test-boundary-check.test.ts
+++ b/tests/test-boundary-check.test.ts
@@ -1,0 +1,183 @@
+/**
+ * tests/test-boundary-check.test.ts -- vitest suite for src/lib/boundary-check.ts
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  extractBoundaries,
+  extractPlanScope,
+  checkBoundaries,
+} from '../src/lib/boundary-check.js';
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boundary-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function write(name: string, content: string) {
+  const p = path.join(tmpDir, name);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, content, 'utf8');
+  return p;
+}
+
+// ─── extractBoundaries ───────────────────────────────────────────────────────
+
+describe('extractBoundaries', () => {
+  it('returns empty array for content with no boundary sections', () => {
+    const result = extractBoundaries('# Product Brief\n\nGeneral content');
+    expect(result).toEqual([]);
+  });
+
+  it('extracts boundaries from "Constraints" section', () => {
+    const content = `
+## Constraints
+- No third-party payment processors
+- Avoid Redis for session storage
+`;
+    const result = extractBoundaries(content);
+    expect(result.length).toBe(2);
+    expect(result[0]?.statement).toContain('payment processors');
+  });
+
+  it('extracts boundaries from "Out of Scope" section', () => {
+    const content = `
+## Out of Scope
+- Mobile app development
+- Multi-language support
+`;
+    const result = extractBoundaries(content);
+    expect(result.length).toBe(2);
+  });
+
+  it('stops extracting when hitting non-boundary heading', () => {
+    const content = `
+## Constraints
+- No MongoDB
+## Architecture
+## Goals
+`;
+    const result = extractBoundaries(content);
+    expect(result.length).toBe(1);
+    expect(result[0]?.statement).toContain('MongoDB');
+  });
+
+  it('extracts numbered list items', () => {
+    const content = `
+## Constraints
+1. No external API calls
+2. Do not use Docker
+`;
+    const result = extractBoundaries(content);
+    expect(result.length).toBe(2);
+  });
+});
+
+// ─── extractPlanScope ────────────────────────────────────────────────────────
+
+describe('extractPlanScope', () => {
+  it('returns empty array for content with no task sections', () => {
+    const result = extractPlanScope('No tasks here');
+    expect(result).toEqual([]);
+  });
+
+  it('extracts task IDs and descriptions', () => {
+    const content = `
+### M1-T01: Build user authentication
+Use PostgreSQL for user storage.
+
+### M1-T02: Create dashboard
+Use React for frontend.
+`;
+    const result = extractPlanScope(content);
+    expect(result.length).toBe(2);
+    const t01 = result[0];
+    if (!t01) throw new Error('expected task');
+    expect(t01.id).toBe('M1-T01');
+    expect(t01.description).toContain('user authentication');
+  });
+});
+
+// ─── checkBoundaries ─────────────────────────────────────────────────────────
+
+describe('checkBoundaries', () => {
+  it('returns error when brief file not found', () => {
+    const result = checkBoundaries({ brief: '/nonexistent/brief.md', plan: '/nonexistent/plan.md', root: '.' });
+    expect(result.pass).toBe(false);
+    expect(result.error).toContain('Cannot read brief');
+  });
+
+  it('returns error when plan file not found', () => {
+    const brief = write('brief.md', '# Brief\n');
+    const result = checkBoundaries({ brief, plan: '/nonexistent/plan.md', root: tmpDir });
+    expect(result.pass).toBe(false);
+    expect(result.error).toContain('Cannot read plan');
+  });
+
+  it('passes when plan does not contain excluded terms', () => {
+    const brief = write('brief.md', `
+## Constraints
+- No MongoDB
+- Avoid Redis
+`);
+    const plan = write('plan.md', `
+### M1-T01: Build API
+Use PostgreSQL for storage.
+`);
+    const result = checkBoundaries({ brief, plan, root: tmpDir });
+    expect(result.pass).toBe(true);
+    expect(result.violations.length).toBe(0);
+  });
+
+  it('detects violations when plan contains excluded terms', () => {
+    const brief = write('brief.md', `
+## Constraints
+- Do not use mongodb in the implementation
+`);
+    const plan = write('plan.md', `
+### M1-T01: Build API
+Set up mongodb for persistence.
+`);
+    const result = checkBoundaries({ brief, plan, root: tmpDir });
+    expect(result.violations.length).toBeGreaterThan(0);
+  });
+
+  it('returns warning when no boundaries found in brief', () => {
+    const brief = write('brief.md', '# Brief\n\nGeneral content only');
+    const plan = write('plan.md', '# Plan\n\nM1-T01: Do something');
+    const result = checkBoundaries({ brief, plan, root: tmpDir });
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings[0]?.message).toContain('No boundary');
+  });
+
+  it('includes score 0-100', () => {
+    const brief = write('brief.md', '# Brief\n');
+    const plan = write('plan.md', '# Plan\n');
+    const result = checkBoundaries({ brief, plan, root: tmpDir });
+    expect(result.score).toBeGreaterThanOrEqual(0);
+    expect(result.score).toBeLessThanOrEqual(100);
+  });
+});
+
+// ─── pollution-key safety (no JSON state) ───────────────────────────────────
+
+describe('pollution-key safety', () => {
+  it('extractBoundaries does not crash on __proto__ bytes in content', () => {
+    const content = Buffer.from('{"__proto__":{"evil":1}}\n## Constraints\n- No MongoDB\n').toString();
+    expect(() => extractBoundaries(content)).not.toThrow();
+  });
+
+  it('extractPlanScope does not crash on constructor key in content', () => {
+    const content = Buffer.from('{"constructor":{"prototype":{}}}\n### M1-T01: task\n').toString();
+    expect(() => extractPlanScope(content)).not.toThrow();
+  });
+});

--- a/tests/test-coverage.test.ts
+++ b/tests/test-coverage.test.ts
@@ -1,0 +1,167 @@
+/**
+ * tests/test-coverage.test.ts — vitest suite for src/lib/coverage.ts
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  extractStoryIds,
+  extractTaskMappings,
+  computeCoverage,
+  generateCoverageReport,
+} from '../src/lib/coverage.js';
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'coverage-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function write(name: string, content: string) {
+  const p = path.join(tmpDir, name);
+  fs.writeFileSync(p, content, 'utf8');
+  return p;
+}
+
+// ─── extractStoryIds ─────────────────────────────────────────────────────────
+
+describe('extractStoryIds', () => {
+  it('finds story IDs matching E\\d+-S\\d+ pattern', () => {
+    const ids = extractStoryIds('Story E01-S01 and E02-S03 are here');
+    expect(ids).toContain('E01-S01');
+    expect(ids).toContain('E02-S03');
+  });
+
+  it('deduplicates repeated IDs', () => {
+    const ids = extractStoryIds('E01-S01 appears twice: E01-S01');
+    expect(ids.filter(x => x === 'E01-S01').length).toBe(1);
+  });
+
+  it('returns empty array for no stories', () => {
+    expect(extractStoryIds('No stories here')).toEqual([]);
+  });
+
+  it('does not match partial patterns like E1-S (no trailing digit group)', () => {
+    const ids = extractStoryIds('E1-S is not a valid ID');
+    expect(ids).toEqual([]);
+  });
+});
+
+// ─── extractTaskMappings ─────────────────────────────────────────────────────
+
+describe('extractTaskMappings', () => {
+  it('finds tasks with M\\d+-T\\d+ pattern', () => {
+    const plan = 'M1-T01: Do E01-S01\nM1-T02: Do E01-S02\n';
+    const map = extractTaskMappings(plan);
+    expect(map.has('M1-T01')).toBe(true);
+    expect(map.has('M1-T02')).toBe(true);
+  });
+
+  it('associates story IDs with tasks', () => {
+    const plan = 'M1-T01 covers E01-S01 and E01-S02\nM1-T02';
+    const map = extractTaskMappings(plan);
+    const t01 = map.get('M1-T01') ?? [];
+    expect(t01).toContain('E01-S01');
+  });
+
+  it('returns empty map for no tasks', () => {
+    const map = extractTaskMappings('No tasks here');
+    expect(map.size).toBe(0);
+  });
+});
+
+// ─── computeCoverage ─────────────────────────────────────────────────────────
+
+describe('computeCoverage', () => {
+  it('reports 100% when all stories referenced in plan', () => {
+    const prd = write('prd.md', '# PRD\nE01-S01 user story\nE01-S02 another story');
+    const plan = write('plan.md', 'M1-T01: covers E01-S01\nM1-T02: covers E01-S02');
+    const result = computeCoverage(prd, plan);
+    expect(result.coverage_pct).toBe(100);
+    expect(result.uncovered).toEqual([]);
+  });
+
+  it('reports uncovered stories', () => {
+    const prd = write('prd.md', 'E01-S01 story\nE01-S02 story');
+    const plan = write('plan.md', 'M1-T01: only E01-S01');
+    const result = computeCoverage(prd, plan);
+    expect(result.uncovered).toContain('E01-S02');
+    expect(result.covered).toContain('E01-S01');
+    expect(result.coverage_pct).toBeLessThan(100);
+  });
+
+  it('returns 100% when PRD has no stories', () => {
+    const prd = write('prd.md', 'No story IDs');
+    const plan = write('plan.md', 'No tasks');
+    const result = computeCoverage(prd, plan);
+    expect(result.coverage_pct).toBe(100);
+    expect(result.total_stories).toBe(0);
+  });
+
+  it('throws when PRD not found', () => {
+    const plan = write('plan.md', '');
+    expect(() => computeCoverage('/nonexistent/prd.md', plan)).toThrow('PRD not found');
+  });
+
+  it('throws when plan not found', () => {
+    const prd = write('prd.md', '');
+    expect(() => computeCoverage(prd, '/nonexistent/plan.md')).toThrow('Implementation plan not found');
+  });
+
+  it('includes total_tasks in result', () => {
+    const prd = write('prd.md', 'E01-S01');
+    const plan = write('plan.md', 'M1-T01: E01-S01\nM1-T02: something');
+    const result = computeCoverage(prd, plan);
+    expect(result.total_tasks).toBe(2);
+  });
+});
+
+// ─── generateCoverageReport ──────────────────────────────────────────────────
+
+describe('generateCoverageReport', () => {
+  it('returns markdown with coverage percentage', () => {
+    const prd = write('prd.md', 'E01-S01 story');
+    const plan = write('plan.md', 'M1-T01: E01-S01');
+    const report = generateCoverageReport(prd, plan);
+    expect(report).toContain('100%');
+    expect(report).toContain('Coverage Report');
+  });
+
+  it('lists uncovered stories when present', () => {
+    const prd = write('prd.md', 'E01-S01\nE01-S02');
+    const plan = write('plan.md', 'M1-T01: E01-S01');
+    const report = generateCoverageReport(prd, plan);
+    expect(report).toContain('E01-S02');
+    expect(report).toContain('Uncovered');
+  });
+
+  it('all-pass message when 100% covered', () => {
+    const prd = write('prd.md', 'E01-S01');
+    const plan = write('plan.md', 'M1-T01: E01-S01');
+    const report = generateCoverageReport(prd, plan);
+    expect(report).toContain('covered by implementation tasks');
+  });
+});
+
+// ─── pollution-key safety ────────────────────────────────────────────────────
+
+describe('pollution-key safety (no JSON state)', () => {
+  it('extractStoryIds does not crash on __proto__ in content', () => {
+    const content = Buffer.from('{"__proto__":{"evil":1}} E01-S01').toString();
+    const ids = extractStoryIds(content);
+    expect(ids).toContain('E01-S01');
+  });
+
+  it('extractStoryIds does not crash on constructor key in content', () => {
+    const content = Buffer.from('{"constructor":{"prototype":{}}} E02-S01').toString();
+    const ids = extractStoryIds(content);
+    expect(ids).toContain('E02-S01');
+  });
+});

--- a/tests/test-coverage.test.ts
+++ b/tests/test-coverage.test.ts
@@ -1,14 +1,15 @@
 /**
  * tests/test-coverage.test.ts — vitest suite for src/lib/coverage.ts
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  computeCoverage,
   extractStoryIds,
   extractTaskMappings,
-  computeCoverage,
   generateCoverageReport,
 } from '../src/lib/coverage.js';
 
@@ -41,7 +42,7 @@ describe('extractStoryIds', () => {
 
   it('deduplicates repeated IDs', () => {
     const ids = extractStoryIds('E01-S01 appears twice: E01-S01');
-    expect(ids.filter(x => x === 'E01-S01').length).toBe(1);
+    expect(ids.filter((x) => x === 'E01-S01').length).toBe(1);
   });
 
   it('returns empty array for no stories', () => {
@@ -112,7 +113,9 @@ describe('computeCoverage', () => {
 
   it('throws when plan not found', () => {
     const prd = write('prd.md', '');
-    expect(() => computeCoverage(prd, '/nonexistent/plan.md')).toThrow('Implementation plan not found');
+    expect(() => computeCoverage(prd, '/nonexistent/plan.md')).toThrow(
+      'Implementation plan not found'
+    );
   });
 
   it('includes total_tasks in result', () => {

--- a/tests/test-export.test.ts
+++ b/tests/test-export.test.ts
@@ -1,0 +1,222 @@
+/**
+ * tests/test-export.test.ts — vitest suite for src/lib/export.ts
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  exportHandoffPackage,
+  gatherHandoffData,
+  isApproved,
+  PHASES,
+  renderHandoffMarkdown,
+  SECONDARY_ARTIFACTS,
+} from '../src/lib/export.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+function setupProject() {
+  const jsDir = path.join(tmpDir, '.jumpstart');
+  fs.mkdirSync(jsDir, { recursive: true });
+  fs.mkdirSync(path.join(tmpDir, 'specs'), { recursive: true });
+}
+
+function writeSpec(rel: string, content: string) {
+  const full = path.join(tmpDir, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+}
+
+const APPROVED_CONTENT = `# Brief\n\n## Phase Gate Approval\n\n**Approved by:** Sam\n\n- [x] Reviewed\n`;
+const DRAFT_CONTENT = `# Brief\n\nContent here.\n`;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'export-'));
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ─── PHASES / SECONDARY_ARTIFACTS constants ───────────────────────────────────
+
+describe('constants', () => {
+  it('PHASES has 6 entries covering -1 to 4', () => {
+    expect(PHASES.length).toBe(6);
+    const phases = PHASES.map((p) => p.phase);
+    expect(phases).toContain(-1);
+    expect(phases).toContain(4);
+  });
+
+  it('SECONDARY_ARTIFACTS contains implementation-plan.md', () => {
+    expect(SECONDARY_ARTIFACTS).toContain('specs/implementation-plan.md');
+  });
+});
+
+// ─── isApproved ───────────────────────────────────────────────────────────────
+
+describe('isApproved', () => {
+  it('returns false for empty content', () => {
+    expect(isApproved('')).toBe(false);
+  });
+
+  it('returns false without Phase Gate Approval section', () => {
+    expect(isApproved('# Brief\n\nSome content\n')).toBe(false);
+  });
+
+  it('returns false when Approved by is Pending', () => {
+    const content = '# Brief\n\n## Phase Gate Approval\n\n**Approved by:** Pending\n';
+    expect(isApproved(content)).toBe(false);
+  });
+
+  it('returns true when approved and all boxes checked', () => {
+    expect(isApproved(APPROVED_CONTENT)).toBe(true);
+  });
+
+  it('returns false when some checkboxes are unchecked', () => {
+    const content =
+      '# Brief\n\n## Phase Gate Approval\n\n**Approved by:** Sam\n\n- [x] Done\n- [ ] Pending\n';
+    expect(isApproved(content)).toBe(false);
+  });
+});
+
+// ─── gatherHandoffData ────────────────────────────────────────────────────────
+
+describe('gatherHandoffData', () => {
+  it('returns empty project when no files exist', () => {
+    const data = gatherHandoffData({ root: tmpDir });
+    expect(data.project_name).toBe(path.basename(tmpDir));
+    expect(data.phases.length).toBe(PHASES.length);
+    expect(data.approved_artifacts).toEqual([]);
+  });
+
+  it('detects approved artifact', () => {
+    setupProject();
+    writeSpec('specs/product-brief.md', APPROVED_CONTENT);
+    const data = gatherHandoffData({ root: tmpDir });
+    expect(data.approved_artifacts).toContain('specs/product-brief.md');
+  });
+
+  it('marks draft artifacts with draft status', () => {
+    setupProject();
+    writeSpec('specs/product-brief.md', DRAFT_CONTENT);
+    const data = gatherHandoffData({ root: tmpDir });
+    const phase1 = data.phases.find((p) => p.phase === 1);
+    expect(phase1?.status).toBe('draft');
+  });
+
+  it('loads project name from config.yaml', () => {
+    setupProject();
+    fs.writeFileSync(
+      path.join(tmpDir, '.jumpstart', 'config.yaml'),
+      "project:\n  name: 'My Cool Project'\n"
+    );
+    const data = gatherHandoffData({ root: tmpDir });
+    expect(data.project_name).toBe('My Cool Project');
+  });
+
+  it('scans for ADRs in specs/decisions/', () => {
+    setupProject();
+    fs.mkdirSync(path.join(tmpDir, 'specs', 'decisions'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, 'specs', 'decisions', 'adr-001.md'),
+      '# ADR-001: Use TypeScript\n\n**Status:** Accepted\n'
+    );
+    const data = gatherHandoffData({ root: tmpDir });
+    expect(data.decisions.length).toBe(1);
+    expect(data.decisions[0]?.title).toBe('ADR-001: Use TypeScript');
+    expect(data.decisions[0]?.status).toBe('Accepted');
+  });
+
+  it('scans for [NEEDS CLARIFICATION] tags in specs', () => {
+    setupProject();
+    writeSpec('specs/prd.md', 'Some story [NEEDS CLARIFICATION: who is the user?]');
+    const data = gatherHandoffData({ root: tmpDir });
+    expect(data.open_items.length).toBeGreaterThan(0);
+    expect(data.open_items[0]?.tag).toContain('NEEDS CLARIFICATION');
+  });
+
+  it('includes exported_at ISO timestamp', () => {
+    const data = gatherHandoffData({ root: tmpDir });
+    expect(data.exported_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('defaults state with null phase when state.json missing', () => {
+    const data = gatherHandoffData({ root: tmpDir });
+    expect(data.implementation_status.current_phase).toBeNull();
+  });
+
+  it('handles polluted state.json gracefully (falls back to defaultState)', () => {
+    setupProject();
+    fs.mkdirSync(path.join(tmpDir, '.jumpstart', 'state'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.jumpstart', 'state', 'state.json'),
+      '{"__proto__":{"evil":1},"current_phase":2}'
+    );
+    expect(() => gatherHandoffData({ root: tmpDir })).not.toThrow();
+    const data = gatherHandoffData({ root: tmpDir });
+    expect(data.implementation_status.current_phase).toBeNull(); // fallback
+  });
+});
+
+// ─── renderHandoffMarkdown ────────────────────────────────────────────────────
+
+describe('renderHandoffMarkdown', () => {
+  it('renders project name in title', () => {
+    const data = gatherHandoffData({ root: tmpDir });
+    const md = renderHandoffMarkdown(data);
+    expect(md).toContain('# Handoff Package');
+  });
+
+  it('renders Phase Status table', () => {
+    const data = gatherHandoffData({ root: tmpDir });
+    const md = renderHandoffMarkdown(data);
+    expect(md).toContain('## Phase Status');
+    expect(md).toContain('| Phase |');
+  });
+
+  it('renders Implementation Status section', () => {
+    const data = gatherHandoffData({ root: tmpDir });
+    const md = renderHandoffMarkdown(data);
+    expect(md).toContain('## Implementation Status');
+  });
+});
+
+// ─── exportHandoffPackage ─────────────────────────────────────────────────────
+
+describe('exportHandoffPackage', () => {
+  it('creates output file and returns success', () => {
+    const outputPath = path.join(tmpDir, 'handoff-test.md');
+    const result = exportHandoffPackage({ root: tmpDir, output: outputPath });
+    expect(result.success).toBe(true);
+    expect(result.output_path).toBe(outputPath);
+    expect(fs.existsSync(outputPath)).toBe(true);
+  });
+
+  it('writes JSON content when json option is true', () => {
+    const outputPath = path.join(tmpDir, 'handoff-test.json');
+    exportHandoffPackage({ root: tmpDir, output: outputPath, json: true });
+    const content = fs.readFileSync(outputPath, 'utf8');
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    expect(parsed.project_name).toBeDefined();
+    expect(parsed.phases).toBeDefined();
+  });
+
+  it('stats includes expected fields', () => {
+    const outputPath = path.join(tmpDir, 'handoff-test.md');
+    const result = exportHandoffPackage({ root: tmpDir, output: outputPath });
+    expect(typeof result.stats.phases).toBe('number');
+    expect(typeof result.stats.approved).toBe('number');
+    expect(typeof result.stats.has_coverage).toBe('boolean');
+  });
+
+  it('creates output directory if it does not exist', () => {
+    const outputPath = path.join(tmpDir, 'new-dir', 'handoff.md');
+    const result = exportHandoffPackage({ root: tmpDir, output: outputPath });
+    expect(result.success).toBe(true);
+    expect(fs.existsSync(outputPath)).toBe(true);
+  });
+});

--- a/tests/test-freshness-gate.test.ts
+++ b/tests/test-freshness-gate.test.ts
@@ -1,0 +1,172 @@
+/**
+ * tests/test-freshness-gate.test.ts — vitest suite for src/lib/freshness-gate.ts
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  CITATION_PATTERNS,
+  TECH_KEYWORDS,
+  auditDocument,
+  auditSpecs,
+  generateAuditReport,
+} from '../src/lib/freshness-gate.js';
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'freshness-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeSpec(name: string, content: string) {
+  const p = path.join(tmpDir, name);
+  fs.writeFileSync(p, content, 'utf8');
+  return p;
+}
+
+// ─── CITATION_PATTERNS & TECH_KEYWORDS exports ───────────────────────────────
+
+describe('exports', () => {
+  it('exports CITATION_PATTERNS as array of RegExp', () => {
+    expect(Array.isArray(CITATION_PATTERNS)).toBe(true);
+    expect(CITATION_PATTERNS[0]).toBeInstanceOf(RegExp);
+  });
+
+  it('exports TECH_KEYWORDS as non-empty array', () => {
+    expect(Array.isArray(TECH_KEYWORDS)).toBe(true);
+    expect(TECH_KEYWORDS.length).toBeGreaterThan(0);
+  });
+
+  it('TECH_KEYWORDS includes common tech names', () => {
+    expect(TECH_KEYWORDS).toContain('react');
+    expect(TECH_KEYWORDS).toContain('typescript');
+    expect(TECH_KEYWORDS).toContain('docker');
+  });
+});
+
+// ─── auditDocument ───────────────────────────────────────────────────────────
+
+describe('auditDocument', () => {
+  it('returns score 100 for content with no tech keywords', () => {
+    const result = auditDocument('A simple document about planning.');
+    expect(result.score).toBe(100);
+    expect(result.techs).toHaveLength(0);
+    expect(result.uncited).toHaveLength(0);
+  });
+
+  it('detects tech keywords without citations as uncited', () => {
+    const result = auditDocument('We will use React and TypeScript for the frontend.');
+    expect(result.techs).toContain('react');
+    expect(result.techs).toContain('typescript');
+    expect(result.uncited.length).toBeGreaterThan(0);
+    expect(result.score).toBeLessThan(100);
+  });
+
+  it('detects Context7 citations and improves score', () => {
+    const result = auditDocument(
+      'We will use React [Context7: react@18] and TypeScript [Context7: typescript@5].'
+    );
+    expect(result.citations.length).toBeGreaterThan(0);
+    // With citations present, uncited should shrink or be zero
+    expect(result.score).toBeGreaterThanOrEqual(0);
+  });
+
+  it('detects c7 comment-style citations', () => {
+    const result = auditDocument('Using Docker <!-- c7:docker --> in our stack.');
+    expect(result.citations.length).toBeGreaterThan(0);
+  });
+
+  it('returns score 100 when no techs but has content', () => {
+    const result = auditDocument('Just prose with no tech references whatsoever.');
+    expect(result.score).toBe(100);
+  });
+});
+
+// ─── auditSpecs ──────────────────────────────────────────────────────────────
+
+describe('auditSpecs', () => {
+  it('returns overallScore 100 and warning when directory not found', () => {
+    const result = auditSpecs('/nonexistent/specs-dir');
+    expect(result.overallScore).toBe(100);
+    expect(result.warnings.some(w => w.includes('not found'))).toBe(true);
+  });
+
+  it('returns overallScore 100 for empty specs directory', () => {
+    const result = auditSpecs(tmpDir);
+    expect(result.overallScore).toBe(100);
+    expect(result.files).toHaveLength(0);
+  });
+
+  it('audits markdown files in directory', () => {
+    writeSpec('arch.md', 'Using React for frontend.');
+    const result = auditSpecs(tmpDir);
+    expect(result.files.length).toBe(1);
+    const entry = result.files[0];
+    if (!entry) throw new Error('expected entry');
+    expect(entry.path).toBe('arch.md');
+    expect(entry.techs).toContain('react');
+  });
+
+  it('generates warnings for uncited technologies', () => {
+    writeSpec('prd.md', 'We use PostgreSQL and Redis.');
+    const result = auditSpecs(tmpDir);
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it('skips non-markdown files', () => {
+    writeSpec('notes.txt', 'Using React in code');
+    const result = auditSpecs(tmpDir);
+    expect(result.files).toHaveLength(0);
+  });
+});
+
+// ─── generateAuditReport ─────────────────────────────────────────────────────
+
+describe('generateAuditReport', () => {
+  it('returns markdown with header and score', () => {
+    const report = generateAuditReport(tmpDir);
+    expect(report).toContain('Documentation Freshness Audit');
+    expect(report).toContain('Overall Score');
+  });
+
+  it('mentions No spec files for empty directory', () => {
+    const report = generateAuditReport(tmpDir);
+    expect(report).toContain('No spec files found');
+  });
+
+  it('includes file-level table when specs exist', () => {
+    writeSpec('prd.md', 'Using React without citation.');
+    const report = generateAuditReport(tmpDir);
+    expect(report).toContain('File-Level Results');
+    expect(report).toContain('prd.md');
+  });
+
+  it('includes remediation section when warnings present', () => {
+    writeSpec('arch.md', 'We use TypeScript and Prisma here.');
+    const report = generateAuditReport(tmpDir);
+    expect(report).toContain('Remediation');
+  });
+});
+
+// ─── pollution-key safety ────────────────────────────────────────────────────
+
+describe('pollution-key safety (no JSON state)', () => {
+  it('auditDocument does not crash on raw __proto__ bytes in content', () => {
+    const content = Buffer.from('{"__proto__":{"evil":1}} Using react here').toString();
+    const result = auditDocument(content);
+    expect(result.techs).toContain('react');
+  });
+
+  it('auditDocument does not crash on raw constructor key bytes', () => {
+    const content = Buffer.from('{"constructor":{"prototype":{}}} docker setup').toString();
+    const result = auditDocument(content);
+    expect(result.techs).toContain('docker');
+  });
+});

--- a/tests/test-freshness-gate.test.ts
+++ b/tests/test-freshness-gate.test.ts
@@ -1,16 +1,17 @@
 /**
  * tests/test-freshness-gate.test.ts — vitest suite for src/lib/freshness-gate.ts
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
-  CITATION_PATTERNS,
-  TECH_KEYWORDS,
   auditDocument,
   auditSpecs,
+  CITATION_PATTERNS,
   generateAuditReport,
+  TECH_KEYWORDS,
 } from '../src/lib/freshness-gate.js';
 
 // ─── helpers ────────────────────────────────────────────────────────────────
@@ -95,7 +96,7 @@ describe('auditSpecs', () => {
   it('returns overallScore 100 and warning when directory not found', () => {
     const result = auditSpecs('/nonexistent/specs-dir');
     expect(result.overallScore).toBe(100);
-    expect(result.warnings.some(w => w.includes('not found'))).toBe(true);
+    expect(result.warnings.some((w) => w.includes('not found'))).toBe(true);
   });
 
   it('returns overallScore 100 for empty specs directory', () => {

--- a/tests/test-handoff.test.ts
+++ b/tests/test-handoff.test.ts
@@ -2,12 +2,12 @@
  * tests/test-handoff.test.ts — vitest suite for src/lib/handoff.ts
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import {
-  PHASE_MAP,
-  isArtifactApproved,
-  getHandoff,
   executeHandoff,
+  getHandoff,
+  isArtifactApproved,
+  PHASE_MAP,
   setHandoffTimelineHook,
 } from '../src/lib/handoff.js';
 
@@ -68,7 +68,7 @@ describe('getHandoff', () => {
 
   it('returns phase -1 handoff (Scout → Challenger)', () => {
     const result = getHandoff(-1);
-    if ('error' in result) throw new Error('unexpected error: ' + result.error);
+    if ('error' in result) throw new Error(`unexpected error: ${result.error}`);
     expect(result.ready).toBe(true);
     expect(result.next_phase).toBe(0);
     expect(result.next_agent).toBe('challenger');
@@ -78,14 +78,14 @@ describe('getHandoff', () => {
 
   it('returns phase 0 handoff (Challenger → Analyst)', () => {
     const result = getHandoff(0);
-    if ('error' in result) throw new Error('unexpected error: ' + result.error);
+    if ('error' in result) throw new Error(`unexpected error: ${result.error}`);
     expect(result.next_phase).toBe(1);
     expect(result.next_agent).toBe('analyst');
   });
 
   it('returns phase 1 handoff (Analyst → PM)', () => {
     const result = getHandoff(1);
-    if ('error' in result) throw new Error('unexpected error: ' + result.error);
+    if ('error' in result) throw new Error(`unexpected error: ${result.error}`);
     expect(result.next_phase).toBe(2);
     expect(result.next_agent).toBe('pm');
     expect(result.context_files).toContain('specs/product-brief.md');
@@ -93,7 +93,7 @@ describe('getHandoff', () => {
 
   it('returns phase 2 handoff (PM → Architect)', () => {
     const result = getHandoff(2);
-    if ('error' in result) throw new Error('unexpected error: ' + result.error);
+    if ('error' in result) throw new Error(`unexpected error: ${result.error}`);
     expect(result.next_phase).toBe(3);
     expect(result.next_agent).toBe('architect');
     expect(result.artifacts_to_create).toContain('specs/architecture.md');
@@ -101,14 +101,14 @@ describe('getHandoff', () => {
 
   it('returns phase 3 handoff (Architect → Developer)', () => {
     const result = getHandoff(3);
-    if ('error' in result) throw new Error('unexpected error: ' + result.error);
+    if ('error' in result) throw new Error(`unexpected error: ${result.error}`);
     expect(result.next_phase).toBe(4);
     expect(result.next_agent).toBe('developer');
   });
 
   it('returns terminal state for phase 4 (Developer)', () => {
     const result = getHandoff(4);
-    if ('error' in result) throw new Error('unexpected error: ' + result.error);
+    if ('error' in result) throw new Error(`unexpected error: ${result.error}`);
     expect(result.ready).toBe(false);
     expect(result.next_phase).toBeNull();
     expect(result.next_agent).toBeNull();
@@ -149,17 +149,25 @@ describe('executeHandoff', () => {
 
   it('records timeline event when hook is set and result is ready', () => {
     const events: unknown[] = [];
-    setHandoffTimelineHook({ recordEvent: (e) => { events.push(e); } });
+    setHandoffTimelineHook({
+      recordEvent: (e) => {
+        events.push(e);
+      },
+    });
     executeHandoff(1);
     expect(events.length).toBe(1);
     const ev = events[0] as Record<string, unknown>;
-    expect(ev['event_type']).toBe('handoff');
-    expect(ev['phase']).toBe(1);
+    expect(ev.event_type).toBe('handoff');
+    expect(ev.phase).toBe(1);
   });
 
   it('does not record timeline event when result is not ready', () => {
     const events: unknown[] = [];
-    setHandoffTimelineHook({ recordEvent: (e) => { events.push(e); } });
+    setHandoffTimelineHook({
+      recordEvent: (e) => {
+        events.push(e);
+      },
+    });
     executeHandoff(4); // terminal phase
     expect(events.length).toBe(0);
   });
@@ -171,11 +179,15 @@ describe('executeHandoff', () => {
 
   it('timeline event action string references source and target phases', () => {
     const events: unknown[] = [];
-    setHandoffTimelineHook({ recordEvent: (e) => { events.push(e); } });
+    setHandoffTimelineHook({
+      recordEvent: (e) => {
+        events.push(e);
+      },
+    });
     executeHandoff(2);
     const ev = events[0] as Record<string, unknown>;
-    expect(String(ev['action'])).toContain('Phase 2');
-    expect(String(ev['action'])).toContain('Phase 3');
+    expect(String(ev.action)).toContain('Phase 2');
+    expect(String(ev.action)).toContain('Phase 3');
   });
 });
 
@@ -183,13 +195,13 @@ describe('executeHandoff', () => {
 
 describe('PHASE_MAP', () => {
   it('has entries for phases -1 through 4', () => {
-    ['-1', '0', '1', '2', '3', '4'].forEach(key => {
+    ['-1', '0', '1', '2', '3', '4'].forEach((key) => {
       expect(PHASE_MAP[key]).toBeDefined();
     });
   });
 
   it('all non-terminal phases have non-null next_agent', () => {
-    ['-1', '0', '1', '2', '3'].forEach(key => {
+    ['-1', '0', '1', '2', '3'].forEach((key) => {
       expect(PHASE_MAP[key]?.next_agent).not.toBeNull();
     });
   });
@@ -204,7 +216,9 @@ describe('PHASE_MAP', () => {
 
 describe('pollution-key safety', () => {
   it('isArtifactApproved does not crash on __proto__ bytes in content', () => {
-    const raw = Buffer.from('{"__proto__":{"evil":1}} ## Phase Gate Approval\n**Approved by:** Sam\n').toString();
+    const raw = Buffer.from(
+      '{"__proto__":{"evil":1}} ## Phase Gate Approval\n**Approved by:** Sam\n'
+    ).toString();
     expect(() => isArtifactApproved(raw)).not.toThrow();
   });
 

--- a/tests/test-handoff.test.ts
+++ b/tests/test-handoff.test.ts
@@ -1,0 +1,214 @@
+/**
+ * tests/test-handoff.test.ts — vitest suite for src/lib/handoff.ts
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  PHASE_MAP,
+  isArtifactApproved,
+  getHandoff,
+  executeHandoff,
+  setHandoffTimelineHook,
+} from '../src/lib/handoff.js';
+
+// ─── isArtifactApproved ───────────────────────────────────────────────────────
+
+describe('isArtifactApproved', () => {
+  it('returns false for empty string', () => {
+    expect(isArtifactApproved('')).toBe(false);
+  });
+
+  it('returns false when Phase Gate Approval section is missing', () => {
+    const content = '# Product Brief\n\nSome content here\n';
+    expect(isArtifactApproved(content)).toBe(false);
+  });
+
+  it('returns false when Approved by is Pending', () => {
+    const content = `# Brief\n\n## Phase Gate Approval\n\n**Approved by:** Pending\n\n- [x] Checked\n`;
+    expect(isArtifactApproved(content)).toBe(false);
+  });
+
+  it('returns false when some checkboxes are unchecked', () => {
+    const content = `# Brief\n\n## Phase Gate Approval\n\n**Approved by:** Sam\n\n- [x] Item 1\n- [ ] Item 2\n`;
+    expect(isArtifactApproved(content)).toBe(false);
+  });
+
+  it('returns true when all checkboxes are checked and approved by is set', () => {
+    const content = `# Brief\n\n## Phase Gate Approval\n\n**Approved by:** Sam\n\n- [x] Item 1\n- [x] Item 2\n`;
+    expect(isArtifactApproved(content)).toBe(true);
+  });
+
+  it('returns true with no checkboxes but Approved by set (no items to fail)', () => {
+    const content = `# Brief\n\n## Phase Gate Approval\n\n**Approved by:** Sam\n\nAll good.\n`;
+    expect(isArtifactApproved(content)).toBe(true);
+  });
+
+  it('is case-insensitive for Phase Gate Approval header', () => {
+    const content = `# Brief\n\n## phase gate approval\n\n**Approved by:** Sam\n\n- [x] Done\n`;
+    expect(isArtifactApproved(content)).toBe(true);
+  });
+
+  it('returns false when Approved by is "pending" (lowercase)', () => {
+    const content = `# Brief\n\n## Phase Gate Approval\n\n**Approved by:** pending\n`;
+    expect(isArtifactApproved(content)).toBe(false);
+  });
+});
+
+// ─── getHandoff ───────────────────────────────────────────────────────────────
+
+describe('getHandoff', () => {
+  it('returns error for unknown phase', () => {
+    const result = getHandoff(99);
+    expect('error' in result).toBe(true);
+    if ('error' in result) {
+      expect(result.error).toContain('Unknown phase: 99');
+    }
+    expect(result.ready).toBe(false);
+  });
+
+  it('returns phase -1 handoff (Scout → Challenger)', () => {
+    const result = getHandoff(-1);
+    if ('error' in result) throw new Error('unexpected error: ' + result.error);
+    expect(result.ready).toBe(true);
+    expect(result.next_phase).toBe(0);
+    expect(result.next_agent).toBe('challenger');
+    expect(result.artifacts_to_create).toContain('specs/challenger-brief.md');
+    expect(result.context_files).toContain('.jumpstart/config.yaml');
+  });
+
+  it('returns phase 0 handoff (Challenger → Analyst)', () => {
+    const result = getHandoff(0);
+    if ('error' in result) throw new Error('unexpected error: ' + result.error);
+    expect(result.next_phase).toBe(1);
+    expect(result.next_agent).toBe('analyst');
+  });
+
+  it('returns phase 1 handoff (Analyst → PM)', () => {
+    const result = getHandoff(1);
+    if ('error' in result) throw new Error('unexpected error: ' + result.error);
+    expect(result.next_phase).toBe(2);
+    expect(result.next_agent).toBe('pm');
+    expect(result.context_files).toContain('specs/product-brief.md');
+  });
+
+  it('returns phase 2 handoff (PM → Architect)', () => {
+    const result = getHandoff(2);
+    if ('error' in result) throw new Error('unexpected error: ' + result.error);
+    expect(result.next_phase).toBe(3);
+    expect(result.next_agent).toBe('architect');
+    expect(result.artifacts_to_create).toContain('specs/architecture.md');
+  });
+
+  it('returns phase 3 handoff (Architect → Developer)', () => {
+    const result = getHandoff(3);
+    if ('error' in result) throw new Error('unexpected error: ' + result.error);
+    expect(result.next_phase).toBe(4);
+    expect(result.next_agent).toBe('developer');
+  });
+
+  it('returns terminal state for phase 4 (Developer)', () => {
+    const result = getHandoff(4);
+    if ('error' in result) throw new Error('unexpected error: ' + result.error);
+    expect(result.ready).toBe(false);
+    expect(result.next_phase).toBeNull();
+    expect(result.next_agent).toBeNull();
+    expect(result.message).toContain('final phase');
+  });
+
+  it('includes current_name for known phases', () => {
+    const result = getHandoff(2);
+    if ('error' in result) throw new Error('unexpected error');
+    expect(result.current_name).toBe('PM');
+  });
+
+  it('includes current_phase in the result', () => {
+    const result = getHandoff(1);
+    if ('error' in result) throw new Error('unexpected error');
+    expect(result.current_phase).toBe(1);
+  });
+});
+
+// ─── executeHandoff ───────────────────────────────────────────────────────────
+
+describe('executeHandoff', () => {
+  beforeEach(() => {
+    setHandoffTimelineHook(null);
+  });
+
+  it('returns same result as getHandoff for valid phase', () => {
+    const exec = executeHandoff(2);
+    const get = getHandoff(2);
+    expect(exec).toEqual(get);
+  });
+
+  it('returns same result as getHandoff for unknown phase', () => {
+    const exec = executeHandoff(99);
+    const get = getHandoff(99);
+    expect(exec).toEqual(get);
+  });
+
+  it('records timeline event when hook is set and result is ready', () => {
+    const events: unknown[] = [];
+    setHandoffTimelineHook({ recordEvent: (e) => { events.push(e); } });
+    executeHandoff(1);
+    expect(events.length).toBe(1);
+    const ev = events[0] as Record<string, unknown>;
+    expect(ev['event_type']).toBe('handoff');
+    expect(ev['phase']).toBe(1);
+  });
+
+  it('does not record timeline event when result is not ready', () => {
+    const events: unknown[] = [];
+    setHandoffTimelineHook({ recordEvent: (e) => { events.push(e); } });
+    executeHandoff(4); // terminal phase
+    expect(events.length).toBe(0);
+  });
+
+  it('does not crash when no timeline hook is set', () => {
+    setHandoffTimelineHook(null);
+    expect(() => executeHandoff(2)).not.toThrow();
+  });
+
+  it('timeline event action string references source and target phases', () => {
+    const events: unknown[] = [];
+    setHandoffTimelineHook({ recordEvent: (e) => { events.push(e); } });
+    executeHandoff(2);
+    const ev = events[0] as Record<string, unknown>;
+    expect(String(ev['action'])).toContain('Phase 2');
+    expect(String(ev['action'])).toContain('Phase 3');
+  });
+});
+
+// ─── PHASE_MAP completeness ───────────────────────────────────────────────────
+
+describe('PHASE_MAP', () => {
+  it('has entries for phases -1 through 4', () => {
+    ['-1', '0', '1', '2', '3', '4'].forEach(key => {
+      expect(PHASE_MAP[key]).toBeDefined();
+    });
+  });
+
+  it('all non-terminal phases have non-null next_agent', () => {
+    ['-1', '0', '1', '2', '3'].forEach(key => {
+      expect(PHASE_MAP[key]?.next_agent).not.toBeNull();
+    });
+  });
+
+  it('terminal phase 4 has null next_phase and next_agent', () => {
+    expect(PHASE_MAP['4']?.next_phase).toBeNull();
+    expect(PHASE_MAP['4']?.next_agent).toBeNull();
+  });
+});
+
+// ─── pollution-key safety ────────────────────────────────────────────────────
+
+describe('pollution-key safety', () => {
+  it('isArtifactApproved does not crash on __proto__ bytes in content', () => {
+    const raw = Buffer.from('{"__proto__":{"evil":1}} ## Phase Gate Approval\n**Approved by:** Sam\n').toString();
+    expect(() => isArtifactApproved(raw)).not.toThrow();
+  });
+
+  it('getHandoff does not crash on NaN input', () => {
+    expect(() => getHandoff(NaN)).not.toThrow();
+  });
+});

--- a/tests/test-init.test.ts
+++ b/tests/test-init.test.ts
@@ -2,35 +2,32 @@
  * tests/test-init.test.ts — vitest suite for src/lib/init.ts
  */
 
-import { describe, it, expect } from 'vitest';
-import {
-  SKILL_PRESETS,
-  generateInitConfig,
-} from '../src/lib/init.js';
+import { describe, expect, it } from 'vitest';
+import { generateInitConfig, SKILL_PRESETS } from '../src/lib/init.js';
 
 // ─── SKILL_PRESETS ────────────────────────────────────────────────────────────
 
 describe('SKILL_PRESETS', () => {
   it('has presets for beginner, intermediate, expert', () => {
-    expect(SKILL_PRESETS['beginner']).toBeDefined();
-    expect(SKILL_PRESETS['intermediate']).toBeDefined();
-    expect(SKILL_PRESETS['expert']).toBeDefined();
+    expect(SKILL_PRESETS.beginner).toBeDefined();
+    expect(SKILL_PRESETS.intermediate).toBeDefined();
+    expect(SKILL_PRESETS.expert).toBeDefined();
   });
 
   it('beginner preset has detailed explanation depth', () => {
-    expect(SKILL_PRESETS['beginner']?.explanation_depth).toBe('detailed');
+    expect(SKILL_PRESETS.beginner?.explanation_depth).toBe('detailed');
   });
 
   it('expert preset has minimal explanation depth', () => {
-    expect(SKILL_PRESETS['expert']?.explanation_depth).toBe('minimal');
+    expect(SKILL_PRESETS.expert?.explanation_depth).toBe('minimal');
   });
 
   it('beginner preset has auto_hints enabled', () => {
-    expect(SKILL_PRESETS['beginner']?.auto_hints).toBe(true);
+    expect(SKILL_PRESETS.beginner?.auto_hints).toBe(true);
   });
 
   it('expert preset has verbose_gates disabled', () => {
-    expect(SKILL_PRESETS['expert']?.verbose_gates).toBe(false);
+    expect(SKILL_PRESETS.expert?.verbose_gates).toBe(false);
   });
 });
 
@@ -117,10 +114,14 @@ describe('generateInitConfig', () => {
 
 describe('pollution-key safety', () => {
   it('generateInitConfig does not crash on __proto__ in skill_level string', () => {
-    expect(() => generateInitConfig({ skill_level: '__proto__', project_type: 'greenfield' })).not.toThrow();
+    expect(() =>
+      generateInitConfig({ skill_level: '__proto__', project_type: 'greenfield' })
+    ).not.toThrow();
   });
 
   it('generateInitConfig does not crash on constructor in project_type string', () => {
-    expect(() => generateInitConfig({ skill_level: 'beginner', project_type: 'constructor' })).not.toThrow();
+    expect(() =>
+      generateInitConfig({ skill_level: 'beginner', project_type: 'constructor' })
+    ).not.toThrow();
   });
 });

--- a/tests/test-init.test.ts
+++ b/tests/test-init.test.ts
@@ -1,0 +1,126 @@
+/**
+ * tests/test-init.test.ts — vitest suite for src/lib/init.ts
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  SKILL_PRESETS,
+  generateInitConfig,
+} from '../src/lib/init.js';
+
+// ─── SKILL_PRESETS ────────────────────────────────────────────────────────────
+
+describe('SKILL_PRESETS', () => {
+  it('has presets for beginner, intermediate, expert', () => {
+    expect(SKILL_PRESETS['beginner']).toBeDefined();
+    expect(SKILL_PRESETS['intermediate']).toBeDefined();
+    expect(SKILL_PRESETS['expert']).toBeDefined();
+  });
+
+  it('beginner preset has detailed explanation depth', () => {
+    expect(SKILL_PRESETS['beginner']?.explanation_depth).toBe('detailed');
+  });
+
+  it('expert preset has minimal explanation depth', () => {
+    expect(SKILL_PRESETS['expert']?.explanation_depth).toBe('minimal');
+  });
+
+  it('beginner preset has auto_hints enabled', () => {
+    expect(SKILL_PRESETS['beginner']?.auto_hints).toBe(true);
+  });
+
+  it('expert preset has verbose_gates disabled', () => {
+    expect(SKILL_PRESETS['expert']?.verbose_gates).toBe(false);
+  });
+});
+
+// ─── generateInitConfig ───────────────────────────────────────────────────────
+
+describe('generateInitConfig', () => {
+  it('uses intermediate as default skill level', () => {
+    const result = generateInitConfig({});
+    expect(result.skill_level).toBe('intermediate');
+  });
+
+  it('uses greenfield as default project type', () => {
+    const result = generateInitConfig({});
+    expect(result.project_type).toBe('greenfield');
+  });
+
+  it('normalizes skill level to lowercase', () => {
+    const result = generateInitConfig({ skill_level: 'BEGINNER' });
+    expect(result.skill_level).toBe('beginner');
+  });
+
+  it('returns detailed explanation depth for beginner', () => {
+    const result = generateInitConfig({ skill_level: 'beginner' });
+    expect(result.explanation_depth).toBe('detailed');
+  });
+
+  it('returns standard explanation depth for intermediate', () => {
+    const result = generateInitConfig({ skill_level: 'intermediate' });
+    expect(result.explanation_depth).toBe('standard');
+  });
+
+  it('returns minimal explanation depth for expert', () => {
+    const result = generateInitConfig({ skill_level: 'expert' });
+    expect(result.explanation_depth).toBe('minimal');
+  });
+
+  it('falls back to intermediate preset for unknown skill level', () => {
+    const result = generateInitConfig({ skill_level: 'grandmaster' });
+    expect(result.explanation_depth).toBe('standard');
+  });
+
+  it('includes recommendations array', () => {
+    const result = generateInitConfig({ skill_level: 'beginner' });
+    expect(Array.isArray(result.recommendations)).toBe(true);
+    expect(result.recommendations.length).toBeGreaterThan(0);
+  });
+
+  it('includes config_overrides object', () => {
+    const result = generateInitConfig({ skill_level: 'expert' });
+    expect(typeof result.config_overrides).toBe('object');
+    expect(result.config_overrides['workflow.explanation_level']).toBe('minimal');
+  });
+
+  it('adds brownfield recommendation first for brownfield project type', () => {
+    const result = generateInitConfig({ skill_level: 'beginner', project_type: 'brownfield' });
+    expect(result.recommendations[0]).toContain('jumpstart.scout');
+  });
+
+  it('adds additional brownfield recommendation at end for brownfield', () => {
+    const result = generateInitConfig({ skill_level: 'beginner', project_type: 'brownfield' });
+    const last = result.recommendations[result.recommendations.length - 1];
+    expect(last).toContain('Scout output');
+  });
+
+  it('does not prepend brownfield recommendation for greenfield', () => {
+    const result = generateInitConfig({ skill_level: 'beginner', project_type: 'greenfield' });
+    expect(result.recommendations[0]).not.toContain('scout');
+  });
+
+  it('includes show_examples field', () => {
+    const beginner = generateInitConfig({ skill_level: 'beginner' });
+    const expert = generateInitConfig({ skill_level: 'expert' });
+    expect(beginner.show_examples).toBe(true);
+    expect(expert.show_examples).toBe(false);
+  });
+
+  it('brownfield project type is preserved in result', () => {
+    const result = generateInitConfig({ project_type: 'brownfield' });
+    expect(result.project_type).toBe('brownfield');
+  });
+});
+
+// ─── pollution-key safety ────────────────────────────────────────────────────
+
+describe('pollution-key safety', () => {
+  it('generateInitConfig does not crash on __proto__ in skill_level string', () => {
+    expect(() => generateInitConfig({ skill_level: '__proto__', project_type: 'greenfield' })).not.toThrow();
+  });
+
+  it('generateInitConfig does not crash on constructor in project_type string', () => {
+    expect(() => generateInitConfig({ skill_level: 'beginner', project_type: 'constructor' })).not.toThrow();
+  });
+});

--- a/tests/test-invariants-check.test.ts
+++ b/tests/test-invariants-check.test.ts
@@ -1,16 +1,17 @@
 /**
  * tests/test-invariants-check.test.ts — vitest suite for src/lib/invariants-check.ts
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
-  loadInvariants,
   checkAgainstArchitecture,
   checkAgainstPlan,
   generateReport,
   type Invariant,
+  loadInvariants,
 } from '../src/lib/invariants-check.js';
 
 // ─── helpers ────────────────────────────────────────────────────────────────
@@ -50,7 +51,8 @@ describe('loadInvariants', () => {
   });
 
   it('parses table rows into invariant objects', () => {
-    const content = TABLE_HEADER + tableRow('INV-01', 'Encryption', 'Security', 'Data must be encrypted at rest');
+    const content =
+      TABLE_HEADER + tableRow('INV-01', 'Encryption', 'Security', 'Data must be encrypted at rest');
     const fp = write('invariants.md', content);
     const result = loadInvariants(fp);
     expect(result.length).toBe(1);
@@ -63,7 +65,7 @@ describe('loadInvariants', () => {
 
   it('uses "Manual review" as default verification when 5th cell absent', () => {
     // Row has 5 pipes but only 4 non-empty cells (no verification cell value)
-    const content = TABLE_HEADER + '| INV-02 | Audit | Compliance | Must log all actions |  |\n';
+    const content = `${TABLE_HEADER}| INV-02 | Audit | Compliance | Must log all actions |  |\n`;
     const fp = write('invariants.md', content);
     const result = loadInvariants(fp);
     const inv = result[0];
@@ -77,7 +79,13 @@ describe('loadInvariants', () => {
 
 describe('checkAgainstArchitecture', () => {
   const invariants: Invariant[] = [
-    { id: 'INV-01', name: 'Encryption', category: 'Security', requirement: 'encrypt data at rest using AES', verification: 'Auto' },
+    {
+      id: 'INV-01',
+      name: 'Encryption',
+      category: 'Security',
+      requirement: 'encrypt data at rest using AES',
+      verification: 'Auto',
+    },
   ];
 
   it('passes invariant when keywords are found in architecture', () => {
@@ -106,8 +114,20 @@ describe('checkAgainstArchitecture', () => {
 
 describe('checkAgainstPlan', () => {
   const invariants: Invariant[] = [
-    { id: 'INV-01', name: 'Encryption at Rest', category: 'Security', requirement: 'encrypt', verification: 'Auto' },
-    { id: 'INV-02', name: 'Audit Logging', category: 'Compliance', requirement: 'log', verification: 'Auto' },
+    {
+      id: 'INV-01',
+      name: 'Encryption at Rest',
+      category: 'Security',
+      requirement: 'encrypt',
+      verification: 'Auto',
+    },
+    {
+      id: 'INV-02',
+      name: 'Audit Logging',
+      category: 'Compliance',
+      requirement: 'log',
+      verification: 'Auto',
+    },
   ];
 
   it('marks invariant as addressed when name words appear in plan', () => {
@@ -164,7 +184,7 @@ describe('generateReport', () => {
 
 describe('pollution-key safety (no JSON state)', () => {
   it('loadInvariants does not crash on raw __proto__ bytes in file', () => {
-    const content = Buffer.from('{"__proto__":{"evil":1}}\n' + TABLE_HEADER).toString();
+    const content = Buffer.from(`{"__proto__":{"evil":1}}\n${TABLE_HEADER}`).toString();
     const fp = write('inv.md', content);
     expect(() => loadInvariants(fp)).not.toThrow();
   });
@@ -172,7 +192,7 @@ describe('pollution-key safety (no JSON state)', () => {
   it('checkAgainstArchitecture does not crash on constructor key in content', () => {
     const content = Buffer.from('{"constructor":{"prototype":{}}} We encrypt data').toString();
     const invariants: Invariant[] = [
-      { id: 'INV-01', name: 'Enc', category: 'Sec', requirement: 'encrypt', verification: 'Auto' }
+      { id: 'INV-01', name: 'Enc', category: 'Sec', requirement: 'encrypt', verification: 'Auto' },
     ];
     expect(() => checkAgainstArchitecture(content, invariants)).not.toThrow();
   });

--- a/tests/test-invariants-check.test.ts
+++ b/tests/test-invariants-check.test.ts
@@ -1,0 +1,179 @@
+/**
+ * tests/test-invariants-check.test.ts — vitest suite for src/lib/invariants-check.ts
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  loadInvariants,
+  checkAgainstArchitecture,
+  checkAgainstPlan,
+  generateReport,
+  type Invariant,
+} from '../src/lib/invariants-check.js';
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'invariants-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function write(name: string, content: string) {
+  const p = path.join(tmpDir, name);
+  fs.writeFileSync(p, content, 'utf8');
+  return p;
+}
+
+const TABLE_HEADER = `| ID | Name | Category | Requirement | Verification |\n|---|---|---|---|---|\n`;
+function tableRow(id: string, name: string, cat: string, req: string, verif = 'Manual') {
+  return `| ${id} | ${name} | ${cat} | ${req} | ${verif} |\n`;
+}
+
+// ─── loadInvariants ──────────────────────────────────────────────────────────
+
+describe('loadInvariants', () => {
+  it('returns empty array when file does not exist', () => {
+    const result = loadInvariants('/nonexistent/invariants.md');
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when file has no table', () => {
+    const fp = write('invariants.md', '# Invariants\n\nNo table here.');
+    expect(loadInvariants(fp)).toEqual([]);
+  });
+
+  it('parses table rows into invariant objects', () => {
+    const content = TABLE_HEADER + tableRow('INV-01', 'Encryption', 'Security', 'Data must be encrypted at rest');
+    const fp = write('invariants.md', content);
+    const result = loadInvariants(fp);
+    expect(result.length).toBe(1);
+    const inv = result[0];
+    if (!inv) throw new Error('expected invariant');
+    expect(inv.id).toBe('INV-01');
+    expect(inv.name).toBe('Encryption');
+    expect(inv.category).toBe('Security');
+  });
+
+  it('uses "Manual review" as default verification when 5th cell absent', () => {
+    // Row has 5 pipes but only 4 non-empty cells (no verification cell value)
+    const content = TABLE_HEADER + '| INV-02 | Audit | Compliance | Must log all actions |  |\n';
+    const fp = write('invariants.md', content);
+    const result = loadInvariants(fp);
+    const inv = result[0];
+    if (!inv) throw new Error('expected invariant');
+    // The 5th cell is empty, so verification defaults to 'Manual review'
+    expect(inv.verification).toBe('Manual review');
+  });
+});
+
+// ─── checkAgainstArchitecture ────────────────────────────────────────────────
+
+describe('checkAgainstArchitecture', () => {
+  const invariants: Invariant[] = [
+    { id: 'INV-01', name: 'Encryption', category: 'Security', requirement: 'encrypt data at rest using AES', verification: 'Auto' },
+  ];
+
+  it('passes invariant when keywords are found in architecture', () => {
+    const arch = 'We encrypt all data at rest using AES-256.';
+    const result = checkAgainstArchitecture(arch, invariants);
+    expect(result.passed.length).toBe(1);
+    expect(result.failed.length).toBe(0);
+  });
+
+  it('fails invariant when keywords are absent from architecture', () => {
+    const arch = 'We use a simple in-memory store for caching.';
+    const result = checkAgainstArchitecture(arch, invariants);
+    expect(result.failed.length).toBe(1);
+    expect(result.warnings.length).toBe(1);
+  });
+
+  it('returns empty results for empty invariants list', () => {
+    const result = checkAgainstArchitecture('any content', []);
+    expect(result.passed).toEqual([]);
+    expect(result.failed).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+});
+
+// ─── checkAgainstPlan ────────────────────────────────────────────────────────
+
+describe('checkAgainstPlan', () => {
+  const invariants: Invariant[] = [
+    { id: 'INV-01', name: 'Encryption at Rest', category: 'Security', requirement: 'encrypt', verification: 'Auto' },
+    { id: 'INV-02', name: 'Audit Logging', category: 'Compliance', requirement: 'log', verification: 'Auto' },
+  ];
+
+  it('marks invariant as addressed when name words appear in plan', () => {
+    const plan = 'Phase 1: Implement encryption at rest for all databases.';
+    const result = checkAgainstPlan(plan, invariants);
+    expect(result.addressed).toContain('INV-01');
+  });
+
+  it('marks invariant as unaddressed when name words are absent', () => {
+    const plan = 'Phase 1: Build user authentication module.';
+    // "Audit" is short (5 chars), "Logging" should match
+    const result = checkAgainstPlan(plan, invariants);
+    // Both should be absent in this basic plan
+    expect(Array.isArray(result.unaddressed)).toBe(true);
+  });
+});
+
+// ─── generateReport ──────────────────────────────────────────────────────────
+
+describe('generateReport', () => {
+  it('returns no-invariants report when file missing', () => {
+    const report = generateReport('/nonexistent/inv.md', tmpDir);
+    expect(report.invariantCount).toBe(0);
+    expect(report.summary).toContain('No invariants defined');
+  });
+
+  it('returns report with archCoverage when architecture.md exists', () => {
+    const inv = TABLE_HEADER + tableRow('INV-01', 'Encryption', 'Security', 'encrypt data at rest');
+    const invPath = write('invariants.md', inv);
+    write('architecture.md', 'We encrypt all data at rest using TLS.');
+    const report = generateReport(invPath, tmpDir);
+    expect(report.invariantCount).toBe(1);
+    expect(report.archCoverage).not.toBeNull();
+  });
+
+  it('null archCoverage when architecture.md missing', () => {
+    const inv = TABLE_HEADER + tableRow('INV-01', 'Encryption', 'Security', 'encrypt data');
+    const invPath = write('invariants.md', inv);
+    const report = generateReport(invPath, tmpDir);
+    expect(report.archCoverage).toBeNull();
+  });
+
+  it('summary includes count when all pass', () => {
+    const inv = TABLE_HEADER + tableRow('INV-01', 'Encryption', 'Security', 'encrypt data at rest');
+    const invPath = write('invariants.md', inv);
+    write('architecture.md', 'We encrypt all data at rest using TLS and AES.');
+    const report = generateReport(invPath, tmpDir);
+    expect(typeof report.summary).toBe('string');
+    expect(report.summary.length).toBeGreaterThan(0);
+  });
+});
+
+// ─── pollution-key safety ────────────────────────────────────────────────────
+
+describe('pollution-key safety (no JSON state)', () => {
+  it('loadInvariants does not crash on raw __proto__ bytes in file', () => {
+    const content = Buffer.from('{"__proto__":{"evil":1}}\n' + TABLE_HEADER).toString();
+    const fp = write('inv.md', content);
+    expect(() => loadInvariants(fp)).not.toThrow();
+  });
+
+  it('checkAgainstArchitecture does not crash on constructor key in content', () => {
+    const content = Buffer.from('{"constructor":{"prototype":{}}} We encrypt data').toString();
+    const invariants: Invariant[] = [
+      { id: 'INV-01', name: 'Enc', category: 'Sec', requirement: 'encrypt', verification: 'Auto' }
+    ];
+    expect(() => checkAgainstArchitecture(content, invariants)).not.toThrow();
+  });
+});

--- a/tests/test-knowledge-graph.test.ts
+++ b/tests/test-knowledge-graph.test.ts
@@ -1,21 +1,21 @@
 /**
  * tests/test-knowledge-graph.test.ts — vitest suite for src/lib/knowledge-graph.ts
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
-  NODE_TYPES,
-  EDGE_TYPES,
-  defaultState,
-  loadState,
-  saveState,
-  addNode,
   addEdge,
-  queryGraph,
+  addNode,
+  defaultState,
+  EDGE_TYPES,
   generateReport,
-  type KGState,
+  loadState,
+  NODE_TYPES,
+  queryGraph,
+  saveState,
 } from '../src/lib/knowledge-graph.js';
 
 // ─── helpers ────────────────────────────────────────────────────────────────
@@ -68,7 +68,14 @@ describe('loadState / saveState', () => {
 
   it('round-trips state through save/load', () => {
     const orig = defaultState();
-    orig.nodes.push({ id: 'KG-1', name: 'test', type: 'pattern', tags: [], metadata: {}, created_at: 'now' });
+    orig.nodes.push({
+      id: 'KG-1',
+      name: 'test',
+      type: 'pattern',
+      tags: [],
+      metadata: {},
+      created_at: 'now',
+    });
     saveState(orig, stateFile);
     const loaded = loadState(stateFile);
     expect(loaded.nodes.length).toBe(1);
@@ -85,14 +92,22 @@ describe('loadState / saveState', () => {
 
   it('returns defaultState when file contains __proto__ pollution key', () => {
     // Raw bytes that JSON.parse would see as __proto__ key
-    fs.writeFileSync(stateFile, '{"__proto__":{"evil":1},"version":"1.0.0","nodes":[],"edges":[],"last_updated":null}', 'utf8');
+    fs.writeFileSync(
+      stateFile,
+      '{"__proto__":{"evil":1},"version":"1.0.0","nodes":[],"edges":[],"last_updated":null}',
+      'utf8'
+    );
     const s = loadState(stateFile);
     // Should fall back to defaultState due to pollution detection
     expect(s.nodes).toEqual([]);
   });
 
   it('returns defaultState when file contains constructor pollution key', () => {
-    fs.writeFileSync(stateFile, '{"constructor":{"prototype":{}},"version":"1.0.0","nodes":[],"edges":[],"last_updated":null}', 'utf8');
+    fs.writeFileSync(
+      stateFile,
+      '{"constructor":{"prototype":{}},"version":"1.0.0","nodes":[],"edges":[],"last_updated":null}',
+      'utf8'
+    );
     const s = loadState(stateFile);
     expect(s.nodes).toEqual([]);
   });
@@ -192,7 +207,7 @@ describe('generateReport', () => {
     addNode('P2', 'pattern', { stateFile });
     addNode('S1', 'skill', { stateFile });
     const result = generateReport({ stateFile });
-    expect(result.by_type['pattern']).toBe(2);
-    expect(result.by_type['skill']).toBe(1);
+    expect(result.by_type.pattern).toBe(2);
+    expect(result.by_type.skill).toBe(1);
   });
 });

--- a/tests/test-knowledge-graph.test.ts
+++ b/tests/test-knowledge-graph.test.ts
@@ -1,0 +1,198 @@
+/**
+ * tests/test-knowledge-graph.test.ts — vitest suite for src/lib/knowledge-graph.ts
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  NODE_TYPES,
+  EDGE_TYPES,
+  defaultState,
+  loadState,
+  saveState,
+  addNode,
+  addEdge,
+  queryGraph,
+  generateReport,
+  type KGState,
+} from '../src/lib/knowledge-graph.js';
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+let stateFile: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kg-test-'));
+  stateFile = path.join(tmpDir, 'kg.json');
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ─── constants ───────────────────────────────────────────────────────────────
+
+describe('constants', () => {
+  it('NODE_TYPES includes expected types', () => {
+    expect(NODE_TYPES).toContain('pattern');
+    expect(NODE_TYPES).toContain('decision');
+    expect(NODE_TYPES).toContain('skill');
+  });
+
+  it('EDGE_TYPES includes expected types', () => {
+    expect(EDGE_TYPES).toContain('uses');
+    expect(EDGE_TYPES).toContain('depends-on');
+  });
+});
+
+// ─── defaultState ────────────────────────────────────────────────────────────
+
+describe('defaultState', () => {
+  it('returns empty nodes and edges', () => {
+    const s = defaultState();
+    expect(s.nodes).toEqual([]);
+    expect(s.edges).toEqual([]);
+    expect(s.last_updated).toBeNull();
+  });
+});
+
+// ─── loadState / saveState ───────────────────────────────────────────────────
+
+describe('loadState / saveState', () => {
+  it('returns defaultState when file does not exist', () => {
+    const s = loadState('/nonexistent/state.json');
+    expect(s.nodes).toEqual([]);
+  });
+
+  it('round-trips state through save/load', () => {
+    const orig = defaultState();
+    orig.nodes.push({ id: 'KG-1', name: 'test', type: 'pattern', tags: [], metadata: {}, created_at: 'now' });
+    saveState(orig, stateFile);
+    const loaded = loadState(stateFile);
+    expect(loaded.nodes.length).toBe(1);
+    const n = loaded.nodes[0];
+    if (!n) throw new Error('expected node');
+    expect(n.name).toBe('test');
+  });
+
+  it('returns defaultState when JSON is malformed', () => {
+    fs.writeFileSync(stateFile, 'NOT_JSON', 'utf8');
+    const s = loadState(stateFile);
+    expect(s.nodes).toEqual([]);
+  });
+
+  it('returns defaultState when file contains __proto__ pollution key', () => {
+    // Raw bytes that JSON.parse would see as __proto__ key
+    fs.writeFileSync(stateFile, '{"__proto__":{"evil":1},"version":"1.0.0","nodes":[],"edges":[],"last_updated":null}', 'utf8');
+    const s = loadState(stateFile);
+    // Should fall back to defaultState due to pollution detection
+    expect(s.nodes).toEqual([]);
+  });
+
+  it('returns defaultState when file contains constructor pollution key', () => {
+    fs.writeFileSync(stateFile, '{"constructor":{"prototype":{}},"version":"1.0.0","nodes":[],"edges":[],"last_updated":null}', 'utf8');
+    const s = loadState(stateFile);
+    expect(s.nodes).toEqual([]);
+  });
+});
+
+// ─── addNode ─────────────────────────────────────────────────────────────────
+
+describe('addNode', () => {
+  it('adds a node and returns success', () => {
+    const result = addNode('MyPattern', 'pattern', { stateFile });
+    expect(result.success).toBe(true);
+    expect(result.node?.name).toBe('MyPattern');
+    expect(result.node?.type).toBe('pattern');
+  });
+
+  it('persists the node to state file', () => {
+    addNode('Stored', 'skill', { stateFile });
+    const state = loadState(stateFile);
+    expect(state.nodes.length).toBe(1);
+  });
+
+  it('returns error for missing name', () => {
+    const result = addNode('', 'pattern', { stateFile });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('required');
+  });
+
+  it('returns error for unknown type', () => {
+    const result = addNode('Test', 'unknown-type', { stateFile });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Unknown type');
+  });
+});
+
+// ─── addEdge ─────────────────────────────────────────────────────────────────
+
+describe('addEdge', () => {
+  it('adds an edge and returns success', () => {
+    const result = addEdge('KG-1', 'KG-2', 'uses', { stateFile });
+    expect(result.success).toBe(true);
+    expect(result.edge?.from).toBe('KG-1');
+    expect(result.edge?.type).toBe('uses');
+  });
+
+  it('returns error for missing fromId', () => {
+    const result = addEdge('', 'KG-2', 'uses', { stateFile });
+    expect(result.success).toBe(false);
+  });
+
+  it('returns error for unknown edge type', () => {
+    const result = addEdge('KG-1', 'KG-2', 'unknown-edge', { stateFile });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Unknown edge type');
+  });
+});
+
+// ─── queryGraph ──────────────────────────────────────────────────────────────
+
+describe('queryGraph', () => {
+  it('returns empty results for empty state', () => {
+    const result = queryGraph({ stateFile });
+    expect(result.success).toBe(true);
+    expect(result.nodes).toBe(0);
+    expect(result.results).toEqual([]);
+  });
+
+  it('filters nodes by type', () => {
+    addNode('P1', 'pattern', { stateFile });
+    addNode('S1', 'skill', { stateFile });
+    const result = queryGraph({ stateFile, type: 'pattern' });
+    expect(result.nodes).toBe(1);
+    const n = result.results[0];
+    if (!n) throw new Error('expected node');
+    expect(n.type).toBe('pattern');
+  });
+
+  it('filters nodes by search term', () => {
+    addNode('EncryptionPattern', 'pattern', { stateFile });
+    addNode('CachingSkill', 'skill', { stateFile });
+    const result = queryGraph({ stateFile, search: 'encrypt' });
+    expect(result.nodes).toBe(1);
+  });
+});
+
+// ─── generateReport ──────────────────────────────────────────────────────────
+
+describe('generateReport', () => {
+  it('returns zero counts for empty state', () => {
+    const result = generateReport({ stateFile });
+    expect(result.success).toBe(true);
+    expect(result.total_nodes).toBe(0);
+    expect(result.total_edges).toBe(0);
+  });
+
+  it('counts nodes by type correctly', () => {
+    addNode('P1', 'pattern', { stateFile });
+    addNode('P2', 'pattern', { stateFile });
+    addNode('S1', 'skill', { stateFile });
+    const result = generateReport({ stateFile });
+    expect(result.by_type['pattern']).toBe(2);
+    expect(result.by_type['skill']).toBe(1);
+  });
+});

--- a/tests/test-lint-runner.test.ts
+++ b/tests/test-lint-runner.test.ts
@@ -2,15 +2,11 @@
  * tests/test-lint-runner.test.ts — vitest suite for src/lib/lint-runner.ts
  */
 
-import { describe, it, expect } from 'vitest';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
-import {
-  detectLinter,
-  parseFindings,
-  runLint,
-} from '../src/lib/lint-runner.js';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { detectLinter, parseFindings, runLint } from '../src/lib/lint-runner.js';
 
 // ─── detectLinter ─────────────────────────────────────────────────────────────
 
@@ -177,13 +173,16 @@ describe('runLint', () => {
 
 // ─── pollution-key safety ────────────────────────────────────────────────────
 
-import { beforeEach, afterEach } from 'vitest';
+import { afterEach, beforeEach } from 'vitest';
 
 describe('pollution-key safety', () => {
   it('detectLinter does not crash on __proto__ bytes in package.json', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lint-pollution-'));
     try {
-      fs.writeFileSync(path.join(tmpDir, 'package.json'), '{"__proto__":{"evil":1},"scripts":{"lint":"echo test"}}');
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        '{"__proto__":{"evil":1},"scripts":{"lint":"echo test"}}'
+      );
       expect(() => detectLinter(tmpDir)).not.toThrow();
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/tests/test-lint-runner.test.ts
+++ b/tests/test-lint-runner.test.ts
@@ -1,0 +1,197 @@
+/**
+ * tests/test-lint-runner.test.ts — vitest suite for src/lib/lint-runner.ts
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  detectLinter,
+  parseFindings,
+  runLint,
+} from '../src/lib/lint-runner.js';
+
+// ─── detectLinter ─────────────────────────────────────────────────────────────
+
+describe('detectLinter', () => {
+  let tmpDir: string;
+  const write = (name: string, content: string) => {
+    fs.writeFileSync(path.join(tmpDir, name), content);
+  };
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lint-runner-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns null for a directory with no linter config', () => {
+    expect(detectLinter(tmpDir)).toBeNull();
+  });
+
+  it('detects ESLint from .eslintrc.json', () => {
+    write('.eslintrc.json', '{}');
+    const result = detectLinter(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result?.name).toBe('ESLint');
+  });
+
+  it('detects ESLint flat config from eslint.config.mjs', () => {
+    write('eslint.config.mjs', 'export default []');
+    const result = detectLinter(tmpDir);
+    expect(result?.name).toBe('ESLint (flat)');
+  });
+
+  it('detects Biome from biome.json', () => {
+    write('biome.json', '{}');
+    const result = detectLinter(tmpDir);
+    expect(result?.name).toBe('Biome');
+  });
+
+  it('prefers npm lint script when package.json has lint', () => {
+    write('package.json', JSON.stringify({ scripts: { lint: 'eslint src/' } }));
+    const result = detectLinter(tmpDir);
+    expect(result?.name).toBe('npm lint script');
+    expect(result?.command).toContain('npm run lint');
+  });
+
+  it('falls back to config file detection when package.json has no lint', () => {
+    write('package.json', JSON.stringify({ scripts: { build: 'tsc' } }));
+    write('.eslintrc.json', '{}');
+    const result = detectLinter(tmpDir);
+    expect(result?.name).toBe('ESLint');
+  });
+
+  it('handles malformed package.json gracefully', () => {
+    write('package.json', 'NOT_JSON');
+    expect(() => detectLinter(tmpDir)).not.toThrow();
+  });
+});
+
+// ─── parseFindings ─────────────────────────────────────────────────────────
+
+describe('parseFindings', () => {
+  it('returns empty array for empty output', () => {
+    expect(parseFindings('')).toEqual([]);
+  });
+
+  it('parses ESLint error format', () => {
+    const output = '/src/app.ts:10:5: error Unexpected var (no-var)';
+    const findings = parseFindings(output);
+    expect(findings.length).toBe(1);
+    expect(findings[0]?.severity).toBe('error');
+    expect(findings[0]?.line).toBe(10);
+    expect(findings[0]?.file).toBe('/src/app.ts');
+  });
+
+  it('parses ESLint warning format', () => {
+    const output = '/src/util.ts:3:1: warning Missing semicolon (semi)';
+    const findings = parseFindings(output);
+    expect(findings[0]?.severity).toBe('warning');
+  });
+
+  it('parses generic file:line: message format', () => {
+    const output = 'src/foo.py:42: E401 multiple imports on one line';
+    const findings = parseFindings(output);
+    expect(findings.length).toBe(1);
+    expect(findings[0]?.line).toBe(42);
+  });
+
+  it('ignores indented lines (likely error context)', () => {
+    const output = '  ^ hint about the error above';
+    expect(parseFindings(output)).toEqual([]);
+  });
+
+  it('handles multiple findings', () => {
+    const output = [
+      '/src/a.ts:1:1: error Rule A (a-rule)',
+      '/src/b.ts:5:3: warning Rule B (b-rule)',
+    ].join('\n');
+    expect(parseFindings(output).length).toBe(2);
+  });
+});
+
+// ─── runLint ──────────────────────────────────────────────────────────────────
+
+describe('runLint', () => {
+  let tmpDir: string;
+  const write = (name: string, content: string) => {
+    fs.writeFileSync(path.join(tmpDir, name), content);
+    return path.join(tmpDir, name);
+  };
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lint-runner-run-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns no-linter message when no linter is detected', () => {
+    const result = runLint({ root: tmpDir });
+    expect(result.linter).toBeNull();
+    expect(result.pass).toBe(true);
+    expect(result.message).toContain('No linter detected');
+  });
+
+  it('accepts a string as root (backward compat)', () => {
+    const result = runLint(tmpDir);
+    expect(result.linter).toBeNull();
+    expect(result.pass).toBe(true);
+  });
+
+  it('returns no-files message when all specified files do not exist', () => {
+    write('package.json', JSON.stringify({ scripts: { lint: 'echo ok' } }));
+    const result = runLint({ files: ['nonexistent.ts'], root: tmpDir });
+    expect(result.files_checked).toBe(0);
+    expect(result.message).toContain('No existing files');
+  });
+
+  it('result has required fields', () => {
+    const result = runLint({ root: tmpDir });
+    expect(typeof result.files_checked).toBe('number');
+    expect(typeof result.errors).toBe('number');
+    expect(typeof result.warnings).toBe('number');
+    expect(Array.isArray(result.findings)).toBe(true);
+    expect(Array.isArray(result.fix_tasks)).toBe(true);
+    expect(typeof result.pass).toBe('boolean');
+  });
+
+  it('uses custom lint_command from config', () => {
+    // A command that always exits 0 and outputs nothing
+    const result = runLint({ root: tmpDir, config: { lint_command: 'echo clean' } });
+    expect(result.linter).toBe('custom');
+    expect(result.pass).toBe(true);
+  });
+
+  it('fix_tasks contain error details', () => {
+    // Manually test the fix_tasks logic via parseFindings + structure
+    const output = '/src/x.ts:1:1: error No unused vars (no-unused-vars)';
+    const findings = parseFindings(output);
+    expect(findings[0]?.severity).toBe('error');
+    // The fix_tasks would have one entry for this file if runLint were called
+  });
+});
+
+// ─── pollution-key safety ────────────────────────────────────────────────────
+
+import { beforeEach, afterEach } from 'vitest';
+
+describe('pollution-key safety', () => {
+  it('detectLinter does not crash on __proto__ bytes in package.json', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lint-pollution-'));
+    try {
+      fs.writeFileSync(path.join(tmpDir, 'package.json'), '{"__proto__":{"evil":1},"scripts":{"lint":"echo test"}}');
+      expect(() => detectLinter(tmpDir)).not.toThrow();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('parseFindings does not crash on __proto__ bytes in output', () => {
+    const raw = Buffer.from('{"__proto__":{"evil":1}} /src/x.ts:1:1: error Bad thing').toString();
+    expect(() => parseFindings(raw)).not.toThrow();
+  });
+});

--- a/tests/test-module-loader.test.ts
+++ b/tests/test-module-loader.test.ts
@@ -2,15 +2,15 @@
  * tests/test-module-loader.test.ts — vitest suite for src/lib/module-loader.ts
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   discoverModules,
-  validateManifest,
-  loadModule,
   loadAllModules,
+  loadModule,
+  validateManifest,
 } from '../src/lib/module-loader.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -89,33 +89,48 @@ describe('validateManifest', () => {
   });
 
   it('rejects missing name', () => {
-    const result = validateManifest({ version: '1.0.0', description: 'A long enough description' } as never);
+    const result = validateManifest({
+      version: '1.0.0',
+      description: 'A long enough description',
+    } as never);
     expect(result.valid).toBe(false);
-    expect(result.errors.some(e => e.includes('name'))).toBe(true);
+    expect(result.errors.some((e) => e.includes('name'))).toBe(true);
   });
 
   it('rejects non-kebab-case name', () => {
-    const result = validateManifest({ name: 'My_Module', version: '1.0.0', description: 'A long enough description' } as never);
+    const result = validateManifest({
+      name: 'My_Module',
+      version: '1.0.0',
+      description: 'A long enough description',
+    } as never);
     expect(result.valid).toBe(false);
-    expect(result.errors.some(e => e.includes('kebab'))).toBe(true);
+    expect(result.errors.some((e) => e.includes('kebab'))).toBe(true);
   });
 
   it('rejects invalid semver version', () => {
-    const result = validateManifest({ name: 'mod', version: 'v1', description: 'A long enough description' } as never);
+    const result = validateManifest({
+      name: 'mod',
+      version: 'v1',
+      description: 'A long enough description',
+    } as never);
     expect(result.valid).toBe(false);
-    expect(result.errors.some(e => e.includes('semver'))).toBe(true);
+    expect(result.errors.some((e) => e.includes('semver'))).toBe(true);
   });
 
   it('rejects short description', () => {
-    const result = validateManifest({ name: 'mod', version: '1.0.0', description: 'Short' } as never);
+    const result = validateManifest({
+      name: 'mod',
+      version: '1.0.0',
+      description: 'Short',
+    } as never);
     expect(result.valid).toBe(false);
-    expect(result.errors.some(e => e.includes('description'))).toBe(true);
+    expect(result.errors.some((e) => e.includes('description'))).toBe(true);
   });
 
   it('rejects non-array agents field', () => {
     const result = validateManifest({ ...VALID_MANIFEST, agents: 'not-array' } as never);
     expect(result.valid).toBe(false);
-    expect(result.errors.some(e => e.includes('"agents"'))).toBe(true);
+    expect(result.errors.some((e) => e.includes('"agents"'))).toBe(true);
   });
 });
 
@@ -152,7 +167,11 @@ describe('loadModule', () => {
   });
 
   it('resolves resource paths, filtering out non-existent files', () => {
-    setupModule('res-mod', { ...VALID_MANIFEST, name: 'res-mod', agents: ['agent.md', 'missing.md'] });
+    setupModule('res-mod', {
+      ...VALID_MANIFEST,
+      name: 'res-mod',
+      agents: ['agent.md', 'missing.md'],
+    });
     // Create only agent.md
     const modDir = path.join(tmpDir, 'res-mod');
     fs.writeFileSync(path.join(modDir, 'agent.md'), 'agent content');
@@ -201,8 +220,11 @@ describe('pollution-key safety', () => {
     const modDir = path.join(tmpDir, 'poison-mod');
     fs.mkdirSync(modDir);
     // Raw bytes with __proto__ key — must not cause object pollution
-    fs.writeFileSync(path.join(modDir, 'module.json'), '{"__proto__":{"evil":1},"name":"poison","version":"1.0.0","description":"A long enough description"}');
-    const mods = discoverModules(tmpDir);
+    fs.writeFileSync(
+      path.join(modDir, 'module.json'),
+      '{"__proto__":{"evil":1},"name":"poison","version":"1.0.0","description":"A long enough description"}'
+    );
+    const _mods = discoverModules(tmpDir);
     // Should be skipped or returned without crashing
     expect(() => discoverModules(tmpDir)).not.toThrow();
   });
@@ -210,7 +232,10 @@ describe('pollution-key safety', () => {
   it('loadModule rejects constructor key in manifest', () => {
     const modDir = path.join(tmpDir, 'constructor-mod');
     fs.mkdirSync(modDir);
-    fs.writeFileSync(path.join(modDir, 'module.json'), '{"constructor":{"evil":1},"name":"constructor-mod","version":"1.0.0","description":"A long enough description"}');
+    fs.writeFileSync(
+      path.join(modDir, 'module.json'),
+      '{"constructor":{"evil":1},"name":"constructor-mod","version":"1.0.0","description":"A long enough description"}'
+    );
     const result = loadModule(tmpDir, 'constructor-mod');
     expect(result.loaded).toBe(false);
   });

--- a/tests/test-module-loader.test.ts
+++ b/tests/test-module-loader.test.ts
@@ -1,0 +1,217 @@
+/**
+ * tests/test-module-loader.test.ts — vitest suite for src/lib/module-loader.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  discoverModules,
+  validateManifest,
+  loadModule,
+  loadAllModules,
+} from '../src/lib/module-loader.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+function setupModule(name: string, manifest: Record<string, unknown>) {
+  const modDir = path.join(tmpDir, name);
+  fs.mkdirSync(modDir, { recursive: true });
+  fs.writeFileSync(path.join(modDir, 'module.json'), JSON.stringify(manifest));
+  return modDir;
+}
+
+const VALID_MANIFEST = {
+  name: 'test-module',
+  version: '1.0.0',
+  description: 'A valid test module for testing purposes',
+};
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'module-loader-'));
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ─── discoverModules ──────────────────────────────────────────────────────────
+
+describe('discoverModules', () => {
+  it('returns empty array for non-existent directory', () => {
+    expect(discoverModules('/nonexistent/path/modules')).toEqual([]);
+  });
+
+  it('returns empty array for empty directory', () => {
+    expect(discoverModules(tmpDir)).toEqual([]);
+  });
+
+  it('skips files (non-directories)', () => {
+    fs.writeFileSync(path.join(tmpDir, 'some-file.txt'), 'hello');
+    expect(discoverModules(tmpDir)).toEqual([]);
+  });
+
+  it('skips directories without module.json', () => {
+    fs.mkdirSync(path.join(tmpDir, 'empty-mod'));
+    expect(discoverModules(tmpDir)).toEqual([]);
+  });
+
+  it('discovers a valid module', () => {
+    setupModule('my-mod', VALID_MANIFEST);
+    const mods = discoverModules(tmpDir);
+    expect(mods.length).toBe(1);
+    expect(mods[0]?.name).toBe('test-module');
+  });
+
+  it('falls back to directory name when manifest has no name', () => {
+    setupModule('fallback-mod', { version: '1.0.0', description: 'no name field' });
+    const mods = discoverModules(tmpDir);
+    expect(mods[0]?.name).toBe('fallback-mod');
+  });
+
+  it('skips modules with invalid JSON manifests', () => {
+    const modDir = path.join(tmpDir, 'bad-json');
+    fs.mkdirSync(modDir);
+    fs.writeFileSync(path.join(modDir, 'module.json'), 'NOT_JSON');
+    expect(discoverModules(tmpDir)).toEqual([]);
+  });
+});
+
+// ─── validateManifest ─────────────────────────────────────────────────────────
+
+describe('validateManifest', () => {
+  it('accepts a valid manifest', () => {
+    const result = validateManifest(VALID_MANIFEST as never);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('rejects missing name', () => {
+    const result = validateManifest({ version: '1.0.0', description: 'A long enough description' } as never);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('name'))).toBe(true);
+  });
+
+  it('rejects non-kebab-case name', () => {
+    const result = validateManifest({ name: 'My_Module', version: '1.0.0', description: 'A long enough description' } as never);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('kebab'))).toBe(true);
+  });
+
+  it('rejects invalid semver version', () => {
+    const result = validateManifest({ name: 'mod', version: 'v1', description: 'A long enough description' } as never);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('semver'))).toBe(true);
+  });
+
+  it('rejects short description', () => {
+    const result = validateManifest({ name: 'mod', version: '1.0.0', description: 'Short' } as never);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('description'))).toBe(true);
+  });
+
+  it('rejects non-array agents field', () => {
+    const result = validateManifest({ ...VALID_MANIFEST, agents: 'not-array' } as never);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('"agents"'))).toBe(true);
+  });
+});
+
+// ─── loadModule ───────────────────────────────────────────────────────────────
+
+describe('loadModule', () => {
+  it('returns error when module directory does not exist', () => {
+    const result = loadModule(tmpDir, 'nonexistent');
+    expect(result.loaded).toBe(false);
+    expect(result.error).toContain('not found');
+  });
+
+  it('returns error when module.json is missing', () => {
+    fs.mkdirSync(path.join(tmpDir, 'no-manifest'));
+    const result = loadModule(tmpDir, 'no-manifest');
+    expect(result.loaded).toBe(false);
+    expect(result.error).toContain('module.json');
+  });
+
+  it('loads a valid module successfully', () => {
+    setupModule('valid-mod', VALID_MANIFEST);
+    const result = loadModule(tmpDir, 'valid-mod');
+    expect(result.loaded).toBe(true);
+    expect(result.module?.name).toBe('test-module');
+    expect(result.module?.version).toBe('1.0.0');
+    expect(result.error).toBeNull();
+  });
+
+  it('returns error for invalid manifest', () => {
+    setupModule('bad-mod', { name: 'BAD_NAME', version: '0.0.1', description: 'desc' });
+    const result = loadModule(tmpDir, 'bad-mod');
+    expect(result.loaded).toBe(false);
+    expect(result.error).toContain('Invalid manifest');
+  });
+
+  it('resolves resource paths, filtering out non-existent files', () => {
+    setupModule('res-mod', { ...VALID_MANIFEST, name: 'res-mod', agents: ['agent.md', 'missing.md'] });
+    // Create only agent.md
+    const modDir = path.join(tmpDir, 'res-mod');
+    fs.writeFileSync(path.join(modDir, 'agent.md'), 'agent content');
+    const result = loadModule(tmpDir, 'res-mod');
+    expect(result.loaded).toBe(true);
+    expect(result.module?.agents.length).toBe(1);
+    expect(result.module?.agents[0]).toContain('agent.md');
+  });
+});
+
+// ─── loadAllModules ───────────────────────────────────────────────────────────
+
+describe('loadAllModules', () => {
+  it('returns empty result for empty modules dir', () => {
+    const result = loadAllModules(tmpDir);
+    expect(result.modules).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('loads all discovered modules when no enabledList specified', () => {
+    setupModule('mod-a', { ...VALID_MANIFEST, name: 'mod-a' });
+    setupModule('mod-b', { ...VALID_MANIFEST, name: 'mod-b' });
+    const result = loadAllModules(tmpDir);
+    expect(result.modules.length).toBe(2);
+  });
+
+  it('filters modules by enabledList', () => {
+    setupModule('mod-a', { ...VALID_MANIFEST, name: 'mod-a' });
+    setupModule('mod-b', { ...VALID_MANIFEST, name: 'mod-b' });
+    const result = loadAllModules(tmpDir, ['mod-a']);
+    expect(result.modules.length).toBe(1);
+    expect(result.modules[0]?.name).toBe('mod-a');
+  });
+
+  it('returns empty modules when enabledList does not match any discovered', () => {
+    setupModule('mod-a', { ...VALID_MANIFEST, name: 'mod-a' });
+    const result = loadAllModules(tmpDir, ['mod-z']);
+    expect(result.modules).toEqual([]);
+  });
+});
+
+// ─── pollution-key safety ────────────────────────────────────────────────────
+
+describe('pollution-key safety', () => {
+  it('discoverModules skips module with __proto__ key in manifest', () => {
+    const modDir = path.join(tmpDir, 'poison-mod');
+    fs.mkdirSync(modDir);
+    // Raw bytes with __proto__ key — must not cause object pollution
+    fs.writeFileSync(path.join(modDir, 'module.json'), '{"__proto__":{"evil":1},"name":"poison","version":"1.0.0","description":"A long enough description"}');
+    const mods = discoverModules(tmpDir);
+    // Should be skipped or returned without crashing
+    expect(() => discoverModules(tmpDir)).not.toThrow();
+  });
+
+  it('loadModule rejects constructor key in manifest', () => {
+    const modDir = path.join(tmpDir, 'constructor-mod');
+    fs.mkdirSync(modDir);
+    fs.writeFileSync(path.join(modDir, 'module.json'), '{"constructor":{"evil":1},"name":"constructor-mod","version":"1.0.0","description":"A long enough description"}');
+    const result = loadModule(tmpDir, 'constructor-mod');
+    expect(result.loaded).toBe(false);
+  });
+});

--- a/tests/test-quickstart.test.ts
+++ b/tests/test-quickstart.test.ts
@@ -2,15 +2,14 @@
  * tests/test-quickstart.test.ts — vitest suite for src/lib/quickstart.ts
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
-  DOMAIN_OPTIONS,
-  CEREMONY_OPTIONS,
-  buildQuickstartConfig,
-  getFirstCommand,
-  generateQuickstartSummary,
-  getConfigPatches,
   applyConfigPatches,
+  buildQuickstartConfig,
+  CEREMONY_OPTIONS,
+  DOMAIN_OPTIONS,
+  generateQuickstartSummary,
+  getFirstCommand,
 } from '../src/lib/quickstart.js';
 
 // ─── DOMAIN_OPTIONS / CEREMONY_OPTIONS ───────────────────────────────────────
@@ -35,7 +34,7 @@ describe('DOMAIN_OPTIONS', () => {
 
 describe('CEREMONY_OPTIONS', () => {
   it('has exactly 3 options: light, standard, rigorous', () => {
-    const values = CEREMONY_OPTIONS.map(o => o.value);
+    const values = CEREMONY_OPTIONS.map((o) => o.value);
     expect(values).toContain('light');
     expect(values).toContain('standard');
     expect(values).toContain('rigorous');
@@ -122,13 +121,13 @@ describe('generateQuickstartSummary', () => {
   it('includes project name in summary lines', () => {
     const config = buildQuickstartConfig({ projectName: 'my-project' });
     const summary = generateQuickstartSummary(config);
-    expect(summary.lines.some(l => l.includes('my-project'))).toBe(true);
+    expect(summary.lines.some((l) => l.includes('my-project'))).toBe(true);
   });
 
   it('includes ceremony in summary lines', () => {
     const config = buildQuickstartConfig({ ceremony: 'rigorous' });
     const summary = generateQuickstartSummary(config);
-    expect(summary.lines.some(l => l.includes('rigorous'))).toBe(true);
+    expect(summary.lines.some((l) => l.includes('rigorous'))).toBe(true);
   });
 });
 
@@ -168,11 +167,15 @@ describe('applyConfigPatches', () => {
 
 describe('pollution-key safety', () => {
   it('buildQuickstartConfig does not crash on __proto__ in domain', () => {
-    expect(() => buildQuickstartConfig({ domain: '__proto__', ceremony: 'standard' })).not.toThrow();
+    expect(() =>
+      buildQuickstartConfig({ domain: '__proto__', ceremony: 'standard' })
+    ).not.toThrow();
   });
 
   it('applyConfigPatches does not crash on __proto__ bytes in content', () => {
-    const raw = Buffer.from('{"__proto__":{"evil":1}}\nceremony:\n  profile: standard\n').toString();
+    const raw = Buffer.from(
+      '{"__proto__":{"evil":1}}\nceremony:\n  profile: standard\n'
+    ).toString();
     const config = buildQuickstartConfig({ ceremony: 'light' });
     expect(() => applyConfigPatches(raw, config)).not.toThrow();
   });

--- a/tests/test-quickstart.test.ts
+++ b/tests/test-quickstart.test.ts
@@ -1,0 +1,179 @@
+/**
+ * tests/test-quickstart.test.ts — vitest suite for src/lib/quickstart.ts
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  DOMAIN_OPTIONS,
+  CEREMONY_OPTIONS,
+  buildQuickstartConfig,
+  getFirstCommand,
+  generateQuickstartSummary,
+  getConfigPatches,
+  applyConfigPatches,
+} from '../src/lib/quickstart.js';
+
+// ─── DOMAIN_OPTIONS / CEREMONY_OPTIONS ───────────────────────────────────────
+
+describe('DOMAIN_OPTIONS', () => {
+  it('contains at least 5 options', () => {
+    expect(DOMAIN_OPTIONS.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('each option has value, title, description', () => {
+    for (const opt of DOMAIN_OPTIONS) {
+      expect(typeof opt.value).toBe('string');
+      expect(typeof opt.title).toBe('string');
+      expect(typeof opt.description).toBe('string');
+    }
+  });
+
+  it('contains "other" as last option', () => {
+    expect(DOMAIN_OPTIONS[DOMAIN_OPTIONS.length - 1]?.value).toBe('other');
+  });
+});
+
+describe('CEREMONY_OPTIONS', () => {
+  it('has exactly 3 options: light, standard, rigorous', () => {
+    const values = CEREMONY_OPTIONS.map(o => o.value);
+    expect(values).toContain('light');
+    expect(values).toContain('standard');
+    expect(values).toContain('rigorous');
+  });
+});
+
+// ─── buildQuickstartConfig ────────────────────────────────────────────────────
+
+describe('buildQuickstartConfig', () => {
+  it('returns defaults for empty input', () => {
+    const config = buildQuickstartConfig({});
+    expect(config.projectType).toBe('greenfield');
+    expect(config.ceremony).toBe('standard');
+    expect(config.targetDir).toBe('.');
+    expect(config.copilot).toBe(true);
+  });
+
+  it('uses provided projectName', () => {
+    const config = buildQuickstartConfig({ projectName: 'my-app' });
+    expect(config.projectName).toBe('my-app');
+  });
+
+  it('uses "other" domain customDomain when domain is "other"', () => {
+    const config = buildQuickstartConfig({ domain: 'other', customDomain: 'gaming' });
+    expect(config.domain).toBe('gaming');
+  });
+
+  it('falls back to "general" when domain is "other" but customDomain is empty', () => {
+    const config = buildQuickstartConfig({ domain: 'other', customDomain: null });
+    expect(config.domain).toBe('general');
+  });
+
+  it('uses direct domain when not "other"', () => {
+    const config = buildQuickstartConfig({ domain: 'api-service' });
+    expect(config.domain).toBe('api-service');
+  });
+
+  it('sets brownfield projectType correctly', () => {
+    const config = buildQuickstartConfig({ projectType: 'brownfield' });
+    expect(config.projectType).toBe('brownfield');
+  });
+
+  it('returns force: false and dryRun: false always', () => {
+    const config = buildQuickstartConfig({});
+    expect(config.force).toBe(false);
+    expect(config.dryRun).toBe(false);
+  });
+});
+
+// ─── getFirstCommand ──────────────────────────────────────────────────────────
+
+describe('getFirstCommand', () => {
+  it('returns /jumpstart.challenge for greenfield', () => {
+    const config = buildQuickstartConfig({ projectType: 'greenfield' });
+    const result = getFirstCommand(config);
+    expect(result.command).toBe('/jumpstart.challenge');
+  });
+
+  it('returns /jumpstart.scout for brownfield', () => {
+    const config = buildQuickstartConfig({ projectType: 'brownfield' });
+    const result = getFirstCommand(config);
+    expect(result.command).toBe('/jumpstart.scout');
+  });
+
+  it('includes message string', () => {
+    const config = buildQuickstartConfig({});
+    const result = getFirstCommand(config);
+    expect(typeof result.message).toBe('string');
+    expect(result.message.length).toBeGreaterThan(10);
+  });
+});
+
+// ─── generateQuickstartSummary ────────────────────────────────────────────────
+
+describe('generateQuickstartSummary', () => {
+  it('returns lines, firstCommand, firstMessage', () => {
+    const config = buildQuickstartConfig({ projectName: 'test-proj' });
+    const summary = generateQuickstartSummary(config);
+    expect(Array.isArray(summary.lines)).toBe(true);
+    expect(typeof summary.firstCommand).toBe('string');
+    expect(typeof summary.firstMessage).toBe('string');
+  });
+
+  it('includes project name in summary lines', () => {
+    const config = buildQuickstartConfig({ projectName: 'my-project' });
+    const summary = generateQuickstartSummary(config);
+    expect(summary.lines.some(l => l.includes('my-project'))).toBe(true);
+  });
+
+  it('includes ceremony in summary lines', () => {
+    const config = buildQuickstartConfig({ ceremony: 'rigorous' });
+    const summary = generateQuickstartSummary(config);
+    expect(summary.lines.some(l => l.includes('rigorous'))).toBe(true);
+  });
+});
+
+// ─── applyConfigPatches ───────────────────────────────────────────────────────
+
+describe('applyConfigPatches', () => {
+  it('returns content unchanged when domain is general and ceremony is standard', () => {
+    const config = buildQuickstartConfig({});
+    const content = 'project:\n  type: greenfield\nceremony:\n  profile: standard\n';
+    expect(applyConfigPatches(content, config)).toBe(content);
+  });
+
+  it('patches ceremony profile line for non-standard ceremony', () => {
+    const config = buildQuickstartConfig({ ceremony: 'light' });
+    const content = 'ceremony:\n  profile: standard\n';
+    const patched = applyConfigPatches(content, config);
+    expect(patched).toContain('profile: light');
+  });
+
+  it('adds domain after type line for non-general domain', () => {
+    const config = buildQuickstartConfig({ domain: 'api-service' });
+    const content = 'project:\n  type: greenfield\n';
+    const patched = applyConfigPatches(content, config);
+    expect(patched).toContain('domain: api-service');
+  });
+
+  it('applies multiple patches (domain + ceremony)', () => {
+    const config = buildQuickstartConfig({ domain: 'saas', ceremony: 'rigorous' });
+    const content = 'project:\n  type: greenfield\nceremony:\n  profile: standard\n';
+    const patched = applyConfigPatches(content, config);
+    expect(patched).toContain('domain: saas');
+    expect(patched).toContain('profile: rigorous');
+  });
+});
+
+// ─── pollution-key safety ────────────────────────────────────────────────────
+
+describe('pollution-key safety', () => {
+  it('buildQuickstartConfig does not crash on __proto__ in domain', () => {
+    expect(() => buildQuickstartConfig({ domain: '__proto__', ceremony: 'standard' })).not.toThrow();
+  });
+
+  it('applyConfigPatches does not crash on __proto__ bytes in content', () => {
+    const raw = Buffer.from('{"__proto__":{"evil":1}}\nceremony:\n  profile: standard\n').toString();
+    const config = buildQuickstartConfig({ ceremony: 'light' });
+    expect(() => applyConfigPatches(raw, config)).not.toThrow();
+  });
+});

--- a/tests/test-self-evolve.test.ts
+++ b/tests/test-self-evolve.test.ts
@@ -2,14 +2,11 @@
  * tests/test-self-evolve.test.ts — vitest suite for src/lib/self-evolve.ts
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
-import {
-  analyzeAndPropose,
-  generateProposalArtifact,
-} from '../src/lib/self-evolve.js';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { analyzeAndPropose, generateProposalArtifact } from '../src/lib/self-evolve.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -89,27 +86,27 @@ describe('analyzeAndPropose', () => {
     setupProject('workflow:\n');
     for (let i = 0; i < 4; i++) writeSpec(`spec-${i}.md`);
     const result = analyzeAndPropose(tmpDir);
-    expect(result.proposals.some(p => p.setting === 'usage_tracking')).toBe(true);
+    expect(result.proposals.some((p) => p.setting === 'usage_tracking')).toBe(true);
   });
 
   it('proposes skill_level when config has skill_level: null', () => {
     setupProject('user:\n  skill_level: null\n');
     const result = analyzeAndPropose(tmpDir);
-    expect(result.proposals.some(p => p.setting === 'user.skill_level')).toBe(true);
+    expect(result.proposals.some((p) => p.setting === 'user.skill_level')).toBe(true);
   });
 
   it('proposes diagram verification when > 5 ADRs and auto_verify_at_gate is false', () => {
     setupProject('diagram_verification:\n  auto_verify_at_gate: false\n');
     for (let i = 0; i < 6; i++) writeADR(`adr-00${i}.md`);
     const result = analyzeAndPropose(tmpDir);
-    expect(result.proposals.some(p => p.setting.includes('auto_verify_at_gate'))).toBe(true);
+    expect(result.proposals.some((p) => p.setting.includes('auto_verify_at_gate'))).toBe(true);
   });
 
   it('proposes peer_review_required when > 4 specs and peer_review is false', () => {
     setupProject('testing:\n  peer_review_required: false\n');
     for (let i = 0; i < 5; i++) writeSpec(`spec-${i}.md`);
     const result = analyzeAndPropose(tmpDir);
-    expect(result.proposals.some(p => p.setting.includes('peer_review_required'))).toBe(true);
+    expect(result.proposals.some((p) => p.setting.includes('peer_review_required'))).toBe(true);
   });
 });
 
@@ -117,15 +114,39 @@ describe('analyzeAndPropose', () => {
 
 describe('generateProposalArtifact', () => {
   it('returns "no changes" message when proposals is empty', () => {
-    const result = { proposals: [], analysis: { specs_found: 0, adrs_found: 0, has_usage_log: false, has_correction_log: false, quality_score: null, modules_loaded: 0 } };
+    const result = {
+      proposals: [],
+      analysis: {
+        specs_found: 0,
+        adrs_found: 0,
+        has_usage_log: false,
+        has_correction_log: false,
+        quality_score: null,
+        modules_loaded: 0,
+      },
+    };
     const md = generateProposalArtifact(result);
     expect(md).toContain('No changes proposed');
   });
 
   it('generates markdown with proposal table when proposals exist', () => {
     const result = {
-      proposals: [{ setting: 'usage_tracking', current: 'disabled', proposed: 'enabled', rationale: 'Enable to track usage' }],
-      analysis: { specs_found: 5, adrs_found: 0, has_usage_log: false, has_correction_log: false, quality_score: null, modules_loaded: 0 }
+      proposals: [
+        {
+          setting: 'usage_tracking',
+          current: 'disabled',
+          proposed: 'enabled',
+          rationale: 'Enable to track usage',
+        },
+      ],
+      analysis: {
+        specs_found: 5,
+        adrs_found: 0,
+        has_usage_log: false,
+        has_correction_log: false,
+        quality_score: null,
+        modules_loaded: 0,
+      },
     };
     const md = generateProposalArtifact(result);
     expect(md).toContain('## Proposed Changes');
@@ -135,7 +156,14 @@ describe('generateProposalArtifact', () => {
   it('includes analysis table in output', () => {
     const result = {
       proposals: [{ setting: 'x', current: 1, proposed: 2, rationale: 'reason' }],
-      analysis: { specs_found: 3, adrs_found: 0, has_usage_log: false, has_correction_log: false, quality_score: null, modules_loaded: 0 }
+      analysis: {
+        specs_found: 3,
+        adrs_found: 0,
+        has_usage_log: false,
+        has_correction_log: false,
+        quality_score: null,
+        modules_loaded: 0,
+      },
     };
     const md = generateProposalArtifact(result);
     expect(md).toContain('## Project Analysis');
@@ -144,7 +172,14 @@ describe('generateProposalArtifact', () => {
   it('includes approval section', () => {
     const result = {
       proposals: [{ setting: 'x', current: 1, proposed: 2, rationale: 'reason' }],
-      analysis: { specs_found: 0, adrs_found: 0, has_usage_log: false, has_correction_log: false, quality_score: null, modules_loaded: 0 }
+      analysis: {
+        specs_found: 0,
+        adrs_found: 0,
+        has_usage_log: false,
+        has_correction_log: false,
+        quality_score: null,
+        modules_loaded: 0,
+      },
     };
     const md = generateProposalArtifact(result);
     expect(md).toContain('Pending');

--- a/tests/test-self-evolve.test.ts
+++ b/tests/test-self-evolve.test.ts
@@ -1,0 +1,164 @@
+/**
+ * tests/test-self-evolve.test.ts — vitest suite for src/lib/self-evolve.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  analyzeAndPropose,
+  generateProposalArtifact,
+} from '../src/lib/self-evolve.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+function setupProject(configContent: string) {
+  const jsDir = path.join(tmpDir, '.jumpstart');
+  fs.mkdirSync(jsDir, { recursive: true });
+  fs.writeFileSync(path.join(jsDir, 'config.yaml'), configContent);
+  return tmpDir;
+}
+
+function writeSpec(name: string) {
+  const specsDir = path.join(tmpDir, 'specs');
+  fs.mkdirSync(specsDir, { recursive: true });
+  fs.writeFileSync(path.join(specsDir, name), `# ${name}`);
+}
+
+function writeADR(name: string) {
+  const adrDir = path.join(tmpDir, 'specs', 'decisions');
+  fs.mkdirSync(adrDir, { recursive: true });
+  fs.writeFileSync(path.join(adrDir, name), `# ${name}`);
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'self-evolve-'));
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ─── analyzeAndPropose ────────────────────────────────────────────────────────
+
+describe('analyzeAndPropose', () => {
+  it('returns empty proposals when no config.yaml found', () => {
+    const result = analyzeAndPropose(tmpDir);
+    expect(result.proposals).toEqual([]);
+    expect(result.analysis.specs_found).toBe(0);
+  });
+
+  it('returns zero specs when specs dir is missing', () => {
+    setupProject('workflow:\n  ceremony: standard\n');
+    const result = analyzeAndPropose(tmpDir);
+    expect(result.analysis.specs_found).toBe(0);
+  });
+
+  it('counts spec files correctly', () => {
+    setupProject('workflow:\n');
+    writeSpec('product-brief.md');
+    writeSpec('prd.md');
+    const result = analyzeAndPropose(tmpDir);
+    expect(result.analysis.specs_found).toBe(2);
+  });
+
+  it('counts ADRs correctly', () => {
+    setupProject('workflow:\n');
+    writeADR('adr-001.md');
+    writeADR('adr-002.md');
+    const result = analyzeAndPropose(tmpDir);
+    expect(result.analysis.adrs_found).toBe(2);
+  });
+
+  it('detects missing usage log', () => {
+    setupProject('workflow:\n');
+    const result = analyzeAndPropose(tmpDir);
+    expect(result.analysis.has_usage_log).toBe(false);
+  });
+
+  it('detects existing usage log', () => {
+    setupProject('workflow:\n');
+    fs.writeFileSync(path.join(tmpDir, '.jumpstart', 'usage-log.json'), '{}');
+    const result = analyzeAndPropose(tmpDir);
+    expect(result.analysis.has_usage_log).toBe(true);
+  });
+
+  it('proposes usage_tracking when project has > 3 specs and no usage log', () => {
+    setupProject('workflow:\n');
+    for (let i = 0; i < 4; i++) writeSpec(`spec-${i}.md`);
+    const result = analyzeAndPropose(tmpDir);
+    expect(result.proposals.some(p => p.setting === 'usage_tracking')).toBe(true);
+  });
+
+  it('proposes skill_level when config has skill_level: null', () => {
+    setupProject('user:\n  skill_level: null\n');
+    const result = analyzeAndPropose(tmpDir);
+    expect(result.proposals.some(p => p.setting === 'user.skill_level')).toBe(true);
+  });
+
+  it('proposes diagram verification when > 5 ADRs and auto_verify_at_gate is false', () => {
+    setupProject('diagram_verification:\n  auto_verify_at_gate: false\n');
+    for (let i = 0; i < 6; i++) writeADR(`adr-00${i}.md`);
+    const result = analyzeAndPropose(tmpDir);
+    expect(result.proposals.some(p => p.setting.includes('auto_verify_at_gate'))).toBe(true);
+  });
+
+  it('proposes peer_review_required when > 4 specs and peer_review is false', () => {
+    setupProject('testing:\n  peer_review_required: false\n');
+    for (let i = 0; i < 5; i++) writeSpec(`spec-${i}.md`);
+    const result = analyzeAndPropose(tmpDir);
+    expect(result.proposals.some(p => p.setting.includes('peer_review_required'))).toBe(true);
+  });
+});
+
+// ─── generateProposalArtifact ─────────────────────────────────────────────────
+
+describe('generateProposalArtifact', () => {
+  it('returns "no changes" message when proposals is empty', () => {
+    const result = { proposals: [], analysis: { specs_found: 0, adrs_found: 0, has_usage_log: false, has_correction_log: false, quality_score: null, modules_loaded: 0 } };
+    const md = generateProposalArtifact(result);
+    expect(md).toContain('No changes proposed');
+  });
+
+  it('generates markdown with proposal table when proposals exist', () => {
+    const result = {
+      proposals: [{ setting: 'usage_tracking', current: 'disabled', proposed: 'enabled', rationale: 'Enable to track usage' }],
+      analysis: { specs_found: 5, adrs_found: 0, has_usage_log: false, has_correction_log: false, quality_score: null, modules_loaded: 0 }
+    };
+    const md = generateProposalArtifact(result);
+    expect(md).toContain('## Proposed Changes');
+    expect(md).toContain('usage_tracking');
+  });
+
+  it('includes analysis table in output', () => {
+    const result = {
+      proposals: [{ setting: 'x', current: 1, proposed: 2, rationale: 'reason' }],
+      analysis: { specs_found: 3, adrs_found: 0, has_usage_log: false, has_correction_log: false, quality_score: null, modules_loaded: 0 }
+    };
+    const md = generateProposalArtifact(result);
+    expect(md).toContain('## Project Analysis');
+  });
+
+  it('includes approval section', () => {
+    const result = {
+      proposals: [{ setting: 'x', current: 1, proposed: 2, rationale: 'reason' }],
+      analysis: { specs_found: 0, adrs_found: 0, has_usage_log: false, has_correction_log: false, quality_score: null, modules_loaded: 0 }
+    };
+    const md = generateProposalArtifact(result);
+    expect(md).toContain('Pending');
+  });
+});
+
+// ─── pollution-key safety ────────────────────────────────────────────────────
+
+describe('pollution-key safety', () => {
+  it('analyzeAndPropose does not crash on __proto__ bytes in config.yaml', () => {
+    const jsDir = path.join(tmpDir, '.jumpstart');
+    fs.mkdirSync(jsDir, { recursive: true });
+    const raw = Buffer.from('{"__proto__":{"evil":1}}\nskill_level: null\n').toString();
+    fs.writeFileSync(path.join(jsDir, 'config.yaml'), raw);
+    expect(() => analyzeAndPropose(tmpDir)).not.toThrow();
+  });
+});

--- a/tests/test-sharder.test.ts
+++ b/tests/test-sharder.test.ts
@@ -1,0 +1,179 @@
+/**
+ * tests/test-sharder.test.ts -- vitest suite for src/lib/sharder.ts
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  extractEpics,
+  shouldShard,
+  generateShard,
+  generateIndex,
+  type ShardDescriptor,
+} from '../src/lib/sharder.js';
+
+// ─── sample PRD content ─────────────────────────────────────────────────────
+
+const SAMPLE_PRD = `
+# PRD
+
+## Goals
+
+### Epic E01: Authentication
+User login and registration stories.
+
+#### Story E01-S01
+Login functionality.
+
+#### Story E01-S02
+Registration functionality.
+
+### Epic E02: Dashboard
+Dashboard stories.
+
+#### Story E02-S01
+Main dashboard view.
+`;
+
+// ─── extractEpics ────────────────────────────────────────────────────────────
+
+describe('extractEpics', () => {
+  it('returns empty array for content with no epics', () => {
+    expect(extractEpics('No epics here')).toEqual([]);
+  });
+
+  it('extracts epic IDs and names', () => {
+    const epics = extractEpics(SAMPLE_PRD);
+    expect(epics.length).toBeGreaterThanOrEqual(2);
+    const ids = epics.map(e => e.id);
+    expect(ids).toContain('E01');
+    expect(ids).toContain('E02');
+  });
+
+  it('counts stories within each epic', () => {
+    const epics = extractEpics(SAMPLE_PRD);
+    const e01 = epics.find(e => e.id === 'E01');
+    if (!e01) throw new Error('expected E01');
+    expect(e01.storyCount).toBe(2);
+  });
+
+  it('includes epic content', () => {
+    const epics = extractEpics(SAMPLE_PRD);
+    const e01 = epics.find(e => e.id === 'E01');
+    if (!e01) throw new Error('expected E01');
+    expect(e01.content).toContain('Authentication');
+  });
+});
+
+// ─── shouldShard ─────────────────────────────────────────────────────────────
+
+describe('shouldShard', () => {
+  it('returns shouldShard:false for small PRD', () => {
+    const result = shouldShard('Short content\nonly two lines');
+    expect(result.shouldShard).toBe(false);
+    expect(result.reason).toBe('Within limits');
+  });
+
+  it('returns shouldShard:true when epics exceed maxEpics', () => {
+    // Create content with 6 epics (default max is 5)
+    let content = '';
+    for (let i = 1; i <= 6; i++) {
+      content += `### Epic E0${i}: Test Epic ${i}\nContent\n`;
+    }
+    const result = shouldShard(content, { maxEpics: 5 });
+    expect(result.shouldShard).toBe(true);
+    expect(result.reason).toContain('epics');
+  });
+
+  it('returns shouldShard:true when lines exceed maxLines', () => {
+    const lines = Array(900).fill('line').join('\n');
+    const result = shouldShard(lines, { maxLines: 800 });
+    expect(result.shouldShard).toBe(true);
+    expect(result.reason).toContain('lines');
+  });
+
+  it('reports epicCount, storyCount, lineCount', () => {
+    const result = shouldShard(SAMPLE_PRD);
+    expect(typeof result.epicCount).toBe('number');
+    expect(typeof result.storyCount).toBe('number');
+    expect(result.lineCount).toBeGreaterThan(0);
+  });
+
+  it('respects custom thresholds', () => {
+    const result = shouldShard(SAMPLE_PRD, { maxEpics: 1 });
+    expect(result.shouldShard).toBe(true);
+  });
+});
+
+// ─── generateShard ───────────────────────────────────────────────────────────
+
+describe('generateShard', () => {
+  it('returns empty string for unknown epic IDs', () => {
+    const result = generateShard(SAMPLE_PRD, ['E99'], 1);
+    expect(result).toBe('');
+  });
+
+  it('generates a shard header with shard index', () => {
+    const result = generateShard(SAMPLE_PRD, ['E01'], 1);
+    expect(result).toContain('PRD Shard 1');
+    expect(result).toContain('E01');
+  });
+
+  it('includes parent document reference', () => {
+    const result = generateShard(SAMPLE_PRD, ['E01'], 1);
+    expect(result).toContain('prd.md');
+  });
+
+  it('includes epic content in shard', () => {
+    const result = generateShard(SAMPLE_PRD, ['E01'], 1);
+    expect(result).toContain('Authentication');
+  });
+
+  it('handles multiple epicIds', () => {
+    const result = generateShard(SAMPLE_PRD, ['E01', 'E02'], 1);
+    expect(result).toContain('E01');
+    expect(result).toContain('E02');
+  });
+});
+
+// ─── generateIndex ───────────────────────────────────────────────────────────
+
+describe('generateIndex', () => {
+  it('generates a markdown index with shard table', () => {
+    const shards: ShardDescriptor[] = [
+      { index: 1, epicIds: ['E01'], filePath: 'specs/prd/prd-001-e01.md' },
+      { index: 2, epicIds: ['E02'], filePath: 'specs/prd/prd-002-e02.md' },
+    ];
+    const result = generateIndex(shards, 'MyProject');
+    expect(result).toContain('PRD Index');
+    expect(result).toContain('MyProject');
+    expect(result).toContain('E01');
+    expect(result).toContain('E02');
+    expect(result).toContain('prd-001-e01.md');
+  });
+
+  it('uses "Project" as default name when not provided', () => {
+    const result = generateIndex([]);
+    expect(result).toContain('Project');
+  });
+
+  it('shows total shard count', () => {
+    const shards: ShardDescriptor[] = [
+      { index: 1, epicIds: ['E01'], filePath: 'a.md' },
+    ];
+    const result = generateIndex(shards);
+    expect(result).toContain('1');
+  });
+});
+
+// ─── pollution-key safety (no JSON state) ───────────────────────────────────
+
+describe('pollution-key safety', () => {
+  it('extractEpics does not crash on __proto__ bytes in content', () => {
+    const content = Buffer.from('{"__proto__":{"evil":1}}\n### Epic E01: Test\nContent\n').toString();
+    expect(() => extractEpics(content)).not.toThrow();
+  });
+
+  it('shouldShard does not crash on constructor key in content', () => {
+    const content = Buffer.from('{"constructor":{"prototype":{}}}\nShort PRD').toString();
+    expect(() => shouldShard(content)).not.toThrow();
+  });
+});

--- a/tests/test-sharder.test.ts
+++ b/tests/test-sharder.test.ts
@@ -1,13 +1,13 @@
 /**
  * tests/test-sharder.test.ts -- vitest suite for src/lib/sharder.ts
  */
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
   extractEpics,
-  shouldShard,
-  generateShard,
   generateIndex,
+  generateShard,
   type ShardDescriptor,
+  shouldShard,
 } from '../src/lib/sharder.js';
 
 // ─── sample PRD content ─────────────────────────────────────────────────────
@@ -43,21 +43,21 @@ describe('extractEpics', () => {
   it('extracts epic IDs and names', () => {
     const epics = extractEpics(SAMPLE_PRD);
     expect(epics.length).toBeGreaterThanOrEqual(2);
-    const ids = epics.map(e => e.id);
+    const ids = epics.map((e) => e.id);
     expect(ids).toContain('E01');
     expect(ids).toContain('E02');
   });
 
   it('counts stories within each epic', () => {
     const epics = extractEpics(SAMPLE_PRD);
-    const e01 = epics.find(e => e.id === 'E01');
+    const e01 = epics.find((e) => e.id === 'E01');
     if (!e01) throw new Error('expected E01');
     expect(e01.storyCount).toBe(2);
   });
 
   it('includes epic content', () => {
     const epics = extractEpics(SAMPLE_PRD);
-    const e01 = epics.find(e => e.id === 'E01');
+    const e01 = epics.find((e) => e.id === 'E01');
     if (!e01) throw new Error('expected E01');
     expect(e01.content).toContain('Authentication');
   });
@@ -156,9 +156,7 @@ describe('generateIndex', () => {
   });
 
   it('shows total shard count', () => {
-    const shards: ShardDescriptor[] = [
-      { index: 1, epicIds: ['E01'], filePath: 'a.md' },
-    ];
+    const shards: ShardDescriptor[] = [{ index: 1, epicIds: ['E01'], filePath: 'a.md' }];
     const result = generateIndex(shards);
     expect(result).toContain('1');
   });
@@ -168,7 +166,9 @@ describe('generateIndex', () => {
 
 describe('pollution-key safety', () => {
   it('extractEpics does not crash on __proto__ bytes in content', () => {
-    const content = Buffer.from('{"__proto__":{"evil":1}}\n### Epic E01: Test\nContent\n').toString();
+    const content = Buffer.from(
+      '{"__proto__":{"evil":1}}\n### Epic E01: Test\nContent\n'
+    ).toString();
     expect(() => extractEpics(content)).not.toThrow();
   });
 

--- a/tests/test-simplicity-gate.test.ts
+++ b/tests/test-simplicity-gate.test.ts
@@ -1,15 +1,16 @@
 /**
  * tests/test-simplicity-gate.test.ts -- vitest suite for src/lib/simplicity-gate.ts
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
-  EXCLUDED_DIRS,
-  countTopLevelDirs,
-  extractPlannedDirs,
   check,
+  countTopLevelDirs,
+  EXCLUDED_DIRS,
+  extractPlannedDirs,
 } from '../src/lib/simplicity-gate.js';
 
 // ─── helpers ────────────────────────────────────────────────────────────────
@@ -150,7 +151,9 @@ describe('check', () => {
 
 describe('pollution-key safety', () => {
   it('countTopLevelDirs does not crash on __proto__ bytes in path', () => {
-    expect(() => countTopLevelDirs(Buffer.from('{"__proto__":{"evil":1}}').toString())).not.toThrow();
+    expect(() =>
+      countTopLevelDirs(Buffer.from('{"__proto__":{"evil":1}}').toString())
+    ).not.toThrow();
   });
 
   it('extractPlannedDirs does not crash on constructor key in content', () => {

--- a/tests/test-simplicity-gate.test.ts
+++ b/tests/test-simplicity-gate.test.ts
@@ -1,0 +1,160 @@
+/**
+ * tests/test-simplicity-gate.test.ts -- vitest suite for src/lib/simplicity-gate.ts
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  EXCLUDED_DIRS,
+  countTopLevelDirs,
+  extractPlannedDirs,
+  check,
+} from '../src/lib/simplicity-gate.js';
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'simplicity-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function mkdir(name: string) {
+  const p = path.join(tmpDir, name);
+  fs.mkdirSync(p, { recursive: true });
+  return p;
+}
+
+// ─── EXCLUDED_DIRS export ────────────────────────────────────────────────────
+
+describe('EXCLUDED_DIRS', () => {
+  it('is a Set containing standard excluded directories', () => {
+    expect(EXCLUDED_DIRS).toBeInstanceOf(Set);
+    expect(EXCLUDED_DIRS.has('node_modules')).toBe(true);
+    expect(EXCLUDED_DIRS.has('.git')).toBe(true);
+    expect(EXCLUDED_DIRS.has('dist')).toBe(true);
+  });
+});
+
+// ─── countTopLevelDirs ───────────────────────────────────────────────────────
+
+describe('countTopLevelDirs', () => {
+  it('returns 0 for non-existent directory', () => {
+    const result = countTopLevelDirs('/nonexistent/dir');
+    expect(result.count).toBe(0);
+    expect(result.directories).toEqual([]);
+  });
+
+  it('counts non-excluded directories', () => {
+    mkdir('src');
+    mkdir('tests');
+    mkdir('node_modules'); // should be excluded
+    const result = countTopLevelDirs(tmpDir);
+    expect(result.count).toBe(2);
+    expect(result.directories).toContain('src');
+    expect(result.directories).toContain('tests');
+    expect(result.directories).not.toContain('node_modules');
+  });
+
+  it('does not count files', () => {
+    mkdir('src');
+    fs.writeFileSync(path.join(tmpDir, 'readme.md'), '# Readme');
+    const result = countTopLevelDirs(tmpDir);
+    expect(result.count).toBe(1);
+  });
+
+  it('excludes all entries in EXCLUDED_DIRS', () => {
+    mkdir('src');
+    mkdir('dist'); // excluded
+    mkdir('.git'); // excluded
+    const result = countTopLevelDirs(tmpDir);
+    expect(result.directories).not.toContain('dist');
+    expect(result.directories).not.toContain('.git');
+    expect(result.count).toBe(1);
+  });
+});
+
+// ─── extractPlannedDirs ──────────────────────────────────────────────────────
+
+describe('extractPlannedDirs', () => {
+  it('returns empty array for content with no structure block', () => {
+    expect(extractPlannedDirs('No structure here')).toEqual([]);
+  });
+});
+
+// ─── check ───────────────────────────────────────────────────────────────────
+
+describe('check', () => {
+  it('passes when no options provided (no dirs to count)', () => {
+    const result = check({});
+    expect(result.passed).toBe(true);
+    expect(result.count).toBe(0);
+  });
+
+  it('passes when directories are within limit', () => {
+    mkdir('src');
+    mkdir('tests');
+    const result = check({ projectDir: tmpDir, maxDirs: 3 });
+    expect(result.passed).toBe(true);
+    expect(result.justificationRequired).toBe(false);
+  });
+
+  it('fails when directories exceed limit', () => {
+    mkdir('src');
+    mkdir('tests');
+    mkdir('docs-extra');
+    mkdir('extra');
+    const result = check({ projectDir: tmpDir, maxDirs: 2 });
+    expect(result.passed).toBe(false);
+    expect(result.justificationRequired).toBe(true);
+    expect(result.message).toContain('FAILED');
+  });
+
+  it('message uses singular "directory" for count of 1', () => {
+    mkdir('src');
+    const result = check({ projectDir: tmpDir, maxDirs: 3 });
+    expect(result.passed).toBe(true);
+    expect(result.message).toContain('1 top-level directory');
+  });
+
+  it('message uses plural "directories" for count of 2', () => {
+    mkdir('src');
+    mkdir('tests');
+    const result = check({ projectDir: tmpDir, maxDirs: 5 });
+    expect(result.passed).toBe(true);
+    expect(result.message).toContain('directories');
+  });
+
+  it('default maxDirs is 3', () => {
+    mkdir('a');
+    mkdir('b');
+    mkdir('c');
+    mkdir('d');
+    const result = check({ projectDir: tmpDir });
+    expect(result.passed).toBe(false);
+  });
+
+  it('uses archContent when provided', () => {
+    const result = check({ archContent: 'No structure block here' });
+    expect(result.count).toBe(0);
+    expect(result.passed).toBe(true);
+  });
+});
+
+// ─── pollution-key safety (no JSON state) ───────────────────────────────────
+
+describe('pollution-key safety', () => {
+  it('countTopLevelDirs does not crash on __proto__ bytes in path', () => {
+    expect(() => countTopLevelDirs(Buffer.from('{"__proto__":{"evil":1}}').toString())).not.toThrow();
+  });
+
+  it('extractPlannedDirs does not crash on constructor key in content', () => {
+    const content = Buffer.from('{"constructor":{"prototype":{}}} No structure').toString();
+    expect(() => extractPlannedDirs(content)).not.toThrow();
+  });
+});

--- a/tests/test-spec-tester.test.ts
+++ b/tests/test-spec-tester.test.ts
@@ -1,23 +1,24 @@
 /**
  * tests/test-spec-tester.test.ts -- vitest suite for src/lib/spec-tester.ts
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
-  VAGUE_ADJECTIVES,
+  checkAmbiguity,
+  checkGuessingLanguage,
+  checkGWTFormat,
+  checkMetricCoverage,
+  checkPassiveVoice,
+  checkTerminologyDrift,
+  GUESSING_WORDS,
+  generateReport,
   METRIC_PATTERNS,
   PASSIVE_PATTERNS,
-  GUESSING_WORDS,
-  checkAmbiguity,
-  checkPassiveVoice,
-  checkMetricCoverage,
-  checkTerminologyDrift,
-  checkGWTFormat,
-  checkGuessingLanguage,
   runAllChecks,
-  generateReport,
+  VAGUE_ADJECTIVES,
 } from '../src/lib/spec-tester.js';
 
 // ─── helpers ────────────────────────────────────────────────────────────────
@@ -74,7 +75,7 @@ describe('checkAmbiguity', () => {
   it('detects vague adjective without metric', () => {
     const result = checkAmbiguity('The system should be fast and scalable.');
     expect(result.count).toBeGreaterThan(0);
-    const words = result.issues.map(i => i.word);
+    const words = result.issues.map((i) => i.word);
     expect(words).toContain('fast');
     expect(words).toContain('scalable');
   });
@@ -82,7 +83,7 @@ describe('checkAmbiguity', () => {
   it('ignores vague adjective when metric follows in same line', () => {
     const result = checkAmbiguity('The system should be fast (under 200ms response time).');
     // "fast" with "200ms" on same line should not be flagged
-    const fastIssues = result.issues.filter(i => i.word === 'fast');
+    const fastIssues = result.issues.filter((i) => i.word === 'fast');
     expect(fastIssues.length).toBe(0);
   });
 

--- a/tests/test-spec-tester.test.ts
+++ b/tests/test-spec-tester.test.ts
@@ -1,0 +1,281 @@
+/**
+ * tests/test-spec-tester.test.ts -- vitest suite for src/lib/spec-tester.ts
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  VAGUE_ADJECTIVES,
+  METRIC_PATTERNS,
+  PASSIVE_PATTERNS,
+  GUESSING_WORDS,
+  checkAmbiguity,
+  checkPassiveVoice,
+  checkMetricCoverage,
+  checkTerminologyDrift,
+  checkGWTFormat,
+  checkGuessingLanguage,
+  runAllChecks,
+  generateReport,
+} from '../src/lib/spec-tester.js';
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'spec-tester-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function write(name: string, content: string) {
+  const p = path.join(tmpDir, name);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, content, 'utf8');
+  return p;
+}
+
+// ─── exports ─────────────────────────────────────────────────────────────────
+
+describe('exports', () => {
+  it('VAGUE_ADJECTIVES is a non-empty array', () => {
+    expect(Array.isArray(VAGUE_ADJECTIVES)).toBe(true);
+    expect(VAGUE_ADJECTIVES.length).toBeGreaterThan(0);
+    expect(VAGUE_ADJECTIVES).toContain('scalable');
+  });
+
+  it('METRIC_PATTERNS is a non-empty array of RegExp', () => {
+    expect(Array.isArray(METRIC_PATTERNS)).toBe(true);
+    expect(METRIC_PATTERNS[0]).toBeInstanceOf(RegExp);
+  });
+
+  it('PASSIVE_PATTERNS is a non-empty array of RegExp', () => {
+    expect(Array.isArray(PASSIVE_PATTERNS)).toBe(true);
+  });
+
+  it('GUESSING_WORDS is a non-empty array', () => {
+    expect(Array.isArray(GUESSING_WORDS)).toBe(true);
+    expect(GUESSING_WORDS).toContain('probably');
+  });
+});
+
+// ─── checkAmbiguity ──────────────────────────────────────────────────────────
+
+describe('checkAmbiguity', () => {
+  it('returns zero issues for content with no vague adjectives', () => {
+    const result = checkAmbiguity('The API returns results in 200ms per request.');
+    expect(result.count).toBe(0);
+  });
+
+  it('detects vague adjective without metric', () => {
+    const result = checkAmbiguity('The system should be fast and scalable.');
+    expect(result.count).toBeGreaterThan(0);
+    const words = result.issues.map(i => i.word);
+    expect(words).toContain('fast');
+    expect(words).toContain('scalable');
+  });
+
+  it('ignores vague adjective when metric follows in same line', () => {
+    const result = checkAmbiguity('The system should be fast (under 200ms response time).');
+    // "fast" with "200ms" on same line should not be flagged
+    const fastIssues = result.issues.filter(i => i.word === 'fast');
+    expect(fastIssues.length).toBe(0);
+  });
+
+  it('skips code blocks', () => {
+    const result = checkAmbiguity('```\nscalable fast\n```');
+    expect(result.count).toBe(0);
+  });
+
+  it('skips headings', () => {
+    const result = checkAmbiguity('# Scalable Architecture\n## Fast System');
+    expect(result.count).toBe(0);
+  });
+});
+
+// ─── checkPassiveVoice ───────────────────────────────────────────────────────
+
+describe('checkPassiveVoice', () => {
+  it('returns zero issues for active voice', () => {
+    const result = checkPassiveVoice('The API validates user credentials.');
+    expect(result.count).toBe(0);
+  });
+
+  it('detects passive voice constructions', () => {
+    const result = checkPassiveVoice('User credentials are validated by the system.');
+    expect(result.count).toBeGreaterThan(0);
+  });
+
+  it('skips code blocks', () => {
+    const result = checkPassiveVoice('```\ndata is processed\n```');
+    expect(result.count).toBe(0);
+  });
+});
+
+// ─── checkMetricCoverage ─────────────────────────────────────────────────────
+
+describe('checkMetricCoverage', () => {
+  it('returns 100% for content with no requirements', () => {
+    const result = checkMetricCoverage('General prose content');
+    expect(result.coverage_pct).toBe(100);
+    expect(result.total_requirements).toBe(0);
+  });
+
+  it('detects requirements without metrics', () => {
+    const content = `
+#### E01-S01: User Login
+The user can log in.
+
+#### E01-S02: Dashboard
+The user sees the dashboard.
+`;
+    const result = checkMetricCoverage(content);
+    expect(result.total_requirements).toBe(2);
+    expect(result.gaps.length).toBeGreaterThan(0);
+  });
+
+  it('counts requirements with MEASURABLE tag as having metrics', () => {
+    const content = `
+#### E01-S01: User Login
+Response time [MEASURABLE].
+`;
+    const result = checkMetricCoverage(content);
+    expect(result.with_metrics).toBe(1);
+    expect(result.gaps).not.toContain('E01-S01');
+  });
+});
+
+// ─── checkGWTFormat ──────────────────────────────────────────────────────────
+
+describe('checkGWTFormat', () => {
+  it('returns zero non-GWT count for content with no AC section', () => {
+    const result = checkGWTFormat('No acceptance criteria here');
+    expect(result.non_gwt_count).toBe(0);
+    expect(result.gwt_count).toBe(0);
+  });
+
+  it('counts GWT-format criteria', () => {
+    const content = `
+## Acceptance Criteria
+- Given the user is logged in
+- When they click logout
+- Then they are redirected to login page
+`;
+    const result = checkGWTFormat(content);
+    expect(result.gwt_count).toBeGreaterThan(0);
+  });
+
+  it('flags non-GWT criteria in AC section', () => {
+    const content = `
+## Acceptance Criteria
+- User can log in
+- System validates credentials
+`;
+    const result = checkGWTFormat(content);
+    expect(result.non_gwt_count).toBeGreaterThan(0);
+    expect(result.issues.length).toBeGreaterThan(0);
+  });
+});
+
+// ─── checkGuessingLanguage ───────────────────────────────────────────────────
+
+describe('checkGuessingLanguage', () => {
+  it('returns zero issues for confident language', () => {
+    const result = checkGuessingLanguage('The API validates credentials and returns a JWT token.');
+    expect(result.count).toBe(0);
+  });
+
+  it('detects guessing language', () => {
+    const result = checkGuessingLanguage('Probably we should use Redis for caching.');
+    expect(result.count).toBeGreaterThan(0);
+    expect(result.issues[0]?.word).toBe('probably');
+  });
+
+  it('detects TBD and TODO', () => {
+    const result = checkGuessingLanguage('The architecture is TBD and implementation is TODO.');
+    expect(result.count).toBeGreaterThan(0);
+  });
+
+  it('skips code blocks', () => {
+    const result = checkGuessingLanguage('```\nTBD TODO\n```');
+    expect(result.count).toBe(0);
+  });
+});
+
+// ─── checkTerminologyDrift ───────────────────────────────────────────────────
+
+describe('checkTerminologyDrift', () => {
+  it('returns empty drifts for non-existent directory', () => {
+    const result = checkTerminologyDrift('/nonexistent/specs');
+    expect(result.count).toBe(0);
+    expect(result.drifts).toEqual([]);
+  });
+
+  it('detects terminology drift across files', () => {
+    write('a.md', 'The user logs in to the system.');
+    write('b.md', 'The customer signs in to the platform.');
+    const result = checkTerminologyDrift(tmpDir);
+    // 'user' and 'customer' are in the same drift group
+    expect(result.count).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ─── runAllChecks ─────────────────────────────────────────────────────────────
+
+describe('runAllChecks', () => {
+  it('returns a score between 0-100', () => {
+    const result = runAllChecks('Some plain text content');
+    expect(result.score).toBeGreaterThanOrEqual(0);
+    expect(result.score).toBeLessThanOrEqual(100);
+  });
+
+  it('returns pass:true for clean content', () => {
+    const result = runAllChecks('The API returns HTTP 200 in under 100ms.');
+    expect(result.pass).toBe(true);
+  });
+
+  it('returns all check sub-results', () => {
+    const result = runAllChecks('content');
+    expect(result.ambiguity).toBeDefined();
+    expect(result.passive_voice).toBeDefined();
+    expect(result.metric_coverage).toBeDefined();
+    expect(result.terminology_drift).toBeDefined();
+    expect(result.gwt_format).toBeDefined();
+    expect(result.guessing_language).toBeDefined();
+  });
+
+  it('passes strict option correctly', () => {
+    const result = runAllChecks('probably scalable', { strict: true });
+    expect(result.pass).toBe(false);
+  });
+});
+
+// ─── generateReport ──────────────────────────────────────────────────────────
+
+describe('generateReport', () => {
+  it('generates a markdown report from a file', () => {
+    const fp = write('spec.md', 'The system should be fast.');
+    const report = generateReport(fp);
+    expect(report).toContain('Spec Quality Report');
+    expect(report).toContain('spec.md');
+    expect(report).toContain('Overall Score');
+  });
+});
+
+// ─── pollution-key safety (no JSON state) ───────────────────────────────────
+
+describe('pollution-key safety', () => {
+  it('checkAmbiguity does not crash on __proto__ bytes in content', () => {
+    const content = Buffer.from('{"__proto__":{"evil":1}} scalable fast').toString();
+    expect(() => checkAmbiguity(content)).not.toThrow();
+  });
+
+  it('checkGuessingLanguage does not crash on constructor key bytes', () => {
+    const content = Buffer.from('{"constructor":{"prototype":{}}} probably TBD').toString();
+    expect(() => checkGuessingLanguage(content)).not.toThrow();
+  });
+});

--- a/tests/test-template-watcher.test.ts
+++ b/tests/test-template-watcher.test.ts
@@ -1,18 +1,19 @@
 /**
  * tests/test-template-watcher.test.ts -- vitest suite for src/lib/template-watcher.ts
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
-  fileHash,
   buildSnapshot,
+  checkForChanges,
+  compareSnapshots,
+  fileHash,
   loadSnapshot,
   saveSnapshot,
-  compareSnapshots,
   templateToSpec,
-  checkForChanges,
 } from '../src/lib/template-watcher.js';
 
 // ─── helpers ────────────────────────────────────────────────────────────────
@@ -182,6 +183,6 @@ describe('checkForChanges', () => {
     checkForChanges(templatesDir, snapshotPath);
     writeTemplate('prd.md', '# PRD updated');
     const result = checkForChanges(templatesDir, snapshotPath);
-    expect(result.warnings.some(w => w.includes('prd.md'))).toBe(true);
+    expect(result.warnings.some((w) => w.includes('prd.md'))).toBe(true);
   });
 });

--- a/tests/test-template-watcher.test.ts
+++ b/tests/test-template-watcher.test.ts
@@ -1,0 +1,187 @@
+/**
+ * tests/test-template-watcher.test.ts -- vitest suite for src/lib/template-watcher.ts
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  fileHash,
+  buildSnapshot,
+  loadSnapshot,
+  saveSnapshot,
+  compareSnapshots,
+  templateToSpec,
+  checkForChanges,
+} from '../src/lib/template-watcher.js';
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+let templatesDir: string;
+let snapshotPath: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'watcher-test-'));
+  templatesDir = path.join(tmpDir, 'templates');
+  fs.mkdirSync(templatesDir);
+  snapshotPath = path.join(tmpDir, 'snapshot.json');
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeTemplate(name: string, content: string) {
+  fs.writeFileSync(path.join(templatesDir, name), content, 'utf8');
+}
+
+// ─── fileHash ────────────────────────────────────────────────────────────────
+
+describe('fileHash', () => {
+  it('returns a hex SHA-256 hash', () => {
+    const fp = path.join(tmpDir, 'test.md');
+    fs.writeFileSync(fp, 'hello world', 'utf8');
+    const hash = fileHash(fp);
+    expect(hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('different content produces different hash', () => {
+    const fp1 = path.join(tmpDir, 'a.md');
+    const fp2 = path.join(tmpDir, 'b.md');
+    fs.writeFileSync(fp1, 'content A', 'utf8');
+    fs.writeFileSync(fp2, 'content B', 'utf8');
+    expect(fileHash(fp1)).not.toBe(fileHash(fp2));
+  });
+});
+
+// ─── buildSnapshot ───────────────────────────────────────────────────────────
+
+describe('buildSnapshot', () => {
+  it('returns empty object for non-existent directory', () => {
+    expect(buildSnapshot('/nonexistent/dir')).toEqual({});
+  });
+
+  it('returns empty object for empty templates directory', () => {
+    expect(buildSnapshot(templatesDir)).toEqual({});
+  });
+
+  it('includes md files with their hashes', () => {
+    writeTemplate('prd.md', '# PRD');
+    const snapshot = buildSnapshot(templatesDir);
+    expect(Object.keys(snapshot)).toContain('prd.md');
+    expect(typeof snapshot['prd.md']).toBe('string');
+  });
+
+  it('skips non-markdown files', () => {
+    fs.writeFileSync(path.join(templatesDir, 'notes.txt'), 'notes');
+    const snapshot = buildSnapshot(templatesDir);
+    expect(Object.keys(snapshot)).not.toContain('notes.txt');
+  });
+});
+
+// ─── loadSnapshot / saveSnapshot ─────────────────────────────────────────────
+
+describe('loadSnapshot / saveSnapshot', () => {
+  it('loadSnapshot returns null when file does not exist', () => {
+    expect(loadSnapshot('/nonexistent/snap.json')).toBeNull();
+  });
+
+  it('round-trips through save/load', () => {
+    const snap = { 'prd.md': 'abc123', 'arch.md': 'def456' };
+    saveSnapshot(snapshotPath, snap);
+    const loaded = loadSnapshot(snapshotPath);
+    expect(loaded).toEqual(snap);
+  });
+
+  it('returns null for malformed JSON', () => {
+    fs.writeFileSync(snapshotPath, 'NOT_JSON', 'utf8');
+    expect(loadSnapshot(snapshotPath)).toBeNull();
+  });
+
+  it('returns null when snapshot contains __proto__ key', () => {
+    fs.writeFileSync(snapshotPath, '{"__proto__":{"evil":1},"prd.md":"abc"}', 'utf8');
+    expect(loadSnapshot(snapshotPath)).toBeNull();
+  });
+
+  it('returns null when snapshot contains constructor key', () => {
+    fs.writeFileSync(snapshotPath, '{"constructor":{"prototype":{}},"prd.md":"abc"}', 'utf8');
+    expect(loadSnapshot(snapshotPath)).toBeNull();
+  });
+});
+
+// ─── compareSnapshots ────────────────────────────────────────────────────────
+
+describe('compareSnapshots', () => {
+  it('detects added files', () => {
+    const prev = { 'a.md': 'hash1' };
+    const curr = { 'a.md': 'hash1', 'b.md': 'hash2' };
+    const changes = compareSnapshots(prev, curr);
+    expect(changes.added).toContain('b.md');
+    expect(changes.modified).toEqual([]);
+    expect(changes.removed).toEqual([]);
+  });
+
+  it('detects modified files', () => {
+    const prev = { 'a.md': 'hash1' };
+    const curr = { 'a.md': 'hash2' };
+    const changes = compareSnapshots(prev, curr);
+    expect(changes.modified).toContain('a.md');
+  });
+
+  it('detects removed files', () => {
+    const prev = { 'a.md': 'hash1', 'b.md': 'hash2' };
+    const curr = { 'a.md': 'hash1' };
+    const changes = compareSnapshots(prev, curr);
+    expect(changes.removed).toContain('b.md');
+  });
+
+  it('returns empty changes for identical snapshots', () => {
+    const snap = { 'a.md': 'hash1' };
+    const changes = compareSnapshots(snap, snap);
+    expect(changes.added).toEqual([]);
+    expect(changes.modified).toEqual([]);
+    expect(changes.removed).toEqual([]);
+  });
+});
+
+// ─── templateToSpec ──────────────────────────────────────────────────────────
+
+describe('templateToSpec', () => {
+  it('maps prd.md to specs/prd.md', () => {
+    expect(templateToSpec('prd.md')).toBe('specs/prd.md');
+  });
+
+  it('maps unknown template to specs/<name>', () => {
+    expect(templateToSpec('custom.md')).toBe('specs/custom.md');
+  });
+});
+
+// ─── checkForChanges ─────────────────────────────────────────────────────────
+
+describe('checkForChanges', () => {
+  it('returns changed:false on first run (creates baseline)', () => {
+    writeTemplate('prd.md', '# PRD');
+    const result = checkForChanges(templatesDir, snapshotPath);
+    expect(result.changed).toBe(false);
+    expect(fs.existsSync(snapshotPath)).toBe(true);
+  });
+
+  it('detects modifications on second run', () => {
+    writeTemplate('prd.md', '# PRD original');
+    checkForChanges(templatesDir, snapshotPath); // first run -- baseline
+    // Modify the template
+    writeTemplate('prd.md', '# PRD updated');
+    const result = checkForChanges(templatesDir, snapshotPath);
+    expect(result.changed).toBe(true);
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it('includes warning text about spec regeneration for modified template', () => {
+    writeTemplate('prd.md', '# PRD original');
+    checkForChanges(templatesDir, snapshotPath);
+    writeTemplate('prd.md', '# PRD updated');
+    const result = checkForChanges(templatesDir, snapshotPath);
+    expect(result.warnings.some(w => w.includes('prd.md'))).toBe(true);
+  });
+});

--- a/tests/test-uat-coverage.test.ts
+++ b/tests/test-uat-coverage.test.ts
@@ -1,17 +1,17 @@
 /**
  * tests/test-uat-coverage.test.ts -- vitest suite for src/lib/uat-coverage.ts
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
-  extractAcceptanceCriteria,
-  scanTestCoverage,
-  matchCriteriaToTests,
-  extractKeywords,
   computeUATCoverage,
+  extractAcceptanceCriteria,
+  extractKeywords,
   generateUATReport,
+  scanTestCoverage,
   walkTestFiles,
 } from '../src/lib/uat-coverage.js';
 
@@ -66,7 +66,7 @@ describe('walkTestFiles', () => {
     write('node_modules/pkg/test.test.js', 'test code');
     write('tests/login.test.ts', 'test code');
     const files = walkTestFiles(tmpDir);
-    expect(files.every(f => !f.includes('node_modules'))).toBe(true);
+    expect(files.every((f) => !f.includes('node_modules'))).toBe(true);
   });
 });
 
@@ -101,14 +101,14 @@ describe('extractAcceptanceCriteria', () => {
 
   it('extracts story IDs from PRD', () => {
     const result = extractAcceptanceCriteria(SAMPLE_PRD);
-    const ids = result.map(s => s.story_id);
+    const ids = result.map((s) => s.story_id);
     expect(ids).toContain('E01-S01');
     expect(ids).toContain('E01-S02');
   });
 
   it('extracts acceptance criteria from AC section', () => {
     const result = extractAcceptanceCriteria(SAMPLE_PRD);
-    const s01 = result.find(s => s.story_id === 'E01-S01');
+    const s01 = result.find((s) => s.story_id === 'E01-S01');
     if (!s01) throw new Error('expected E01-S01');
     expect(s01.criteria.length).toBeGreaterThan(0);
   });
@@ -121,7 +121,7 @@ When they submit credentials
 Then they are redirected
 `;
     const result = extractAcceptanceCriteria(prd);
-    const s01 = result.find(s => s.story_id === 'E02-S01');
+    const s01 = result.find((s) => s.story_id === 'E02-S01');
     if (!s01) throw new Error('expected E02-S01');
     expect(s01.gherkin.length).toBeGreaterThan(0);
   });

--- a/tests/test-uat-coverage.test.ts
+++ b/tests/test-uat-coverage.test.ts
@@ -1,0 +1,216 @@
+/**
+ * tests/test-uat-coverage.test.ts -- vitest suite for src/lib/uat-coverage.ts
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  extractAcceptanceCriteria,
+  scanTestCoverage,
+  matchCriteriaToTests,
+  extractKeywords,
+  computeUATCoverage,
+  generateUATReport,
+  walkTestFiles,
+} from '../src/lib/uat-coverage.js';
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'uat-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function write(name: string, content: string) {
+  const p = path.join(tmpDir, name);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, content, 'utf8');
+  return p;
+}
+
+const SAMPLE_PRD = `
+# PRD
+
+## E01-S01: User Login
+Acceptance Criteria:
+- User can enter email and password
+- System validates credentials
+- User is redirected to dashboard after login
+
+## E01-S02: User Logout
+- User clicks logout button
+- Session is terminated
+`;
+
+// ─── walkTestFiles ───────────────────────────────────────────────────────────
+
+describe('walkTestFiles', () => {
+  it('returns empty array for non-existent directory', () => {
+    expect(walkTestFiles('/nonexistent')).toEqual([]);
+  });
+
+  it('finds test files by pattern', () => {
+    write('tests/login.test.ts', 'test("login", () => {})');
+    write('tests/auth.spec.ts', 'test("auth", () => {})');
+    const files = walkTestFiles(path.join(tmpDir, 'tests'));
+    expect(files.length).toBe(2);
+  });
+
+  it('skips node_modules', () => {
+    write('node_modules/pkg/test.test.js', 'test code');
+    write('tests/login.test.ts', 'test code');
+    const files = walkTestFiles(tmpDir);
+    expect(files.every(f => !f.includes('node_modules'))).toBe(true);
+  });
+});
+
+// ─── extractKeywords ─────────────────────────────────────────────────────────
+
+describe('extractKeywords', () => {
+  it('filters short words and stopwords', () => {
+    const kw = extractKeywords('User can login with email address');
+    expect(kw).not.toContain('with');
+    expect(kw).not.toContain('can');
+  });
+
+  it('returns meaningful content words', () => {
+    const kw = extractKeywords('login credential validation redirect dashboard');
+    expect(kw).toContain('login');
+    expect(kw).toContain('credential');
+  });
+
+  it('returns empty array for stopword-only text', () => {
+    const kw = extractKeywords('is are was were be been');
+    expect(kw.length).toBe(0);
+  });
+});
+
+// ─── extractAcceptanceCriteria ────────────────────────────────────────────────
+
+describe('extractAcceptanceCriteria', () => {
+  it('returns empty array for content with no story IDs', () => {
+    const result = extractAcceptanceCriteria('No stories here');
+    expect(result).toEqual([]);
+  });
+
+  it('extracts story IDs from PRD', () => {
+    const result = extractAcceptanceCriteria(SAMPLE_PRD);
+    const ids = result.map(s => s.story_id);
+    expect(ids).toContain('E01-S01');
+    expect(ids).toContain('E01-S02');
+  });
+
+  it('extracts acceptance criteria from AC section', () => {
+    const result = extractAcceptanceCriteria(SAMPLE_PRD);
+    const s01 = result.find(s => s.story_id === 'E01-S01');
+    if (!s01) throw new Error('expected E01-S01');
+    expect(s01.criteria.length).toBeGreaterThan(0);
+  });
+
+  it('extracts Gherkin steps', () => {
+    const prd = `
+# E02-S01: Feature
+Given the user is on the login page
+When they submit credentials
+Then they are redirected
+`;
+    const result = extractAcceptanceCriteria(prd);
+    const s01 = result.find(s => s.story_id === 'E02-S01');
+    if (!s01) throw new Error('expected E02-S01');
+    expect(s01.gherkin.length).toBeGreaterThan(0);
+  });
+});
+
+// ─── scanTestCoverage ────────────────────────────────────────────────────────
+
+describe('scanTestCoverage', () => {
+  it('returns empty coverage for non-existent test dir', () => {
+    const coverage = scanTestCoverage('/nonexistent', ['E01-S01']);
+    const entry = coverage.get('E01-S01');
+    if (!entry) throw new Error('expected entry');
+    expect(entry.files).toEqual([]);
+  });
+
+  it('finds test files referencing story IDs', () => {
+    write('tests/login.test.ts', 'describe("E01-S01 login", () => { it("works", () => {}) })');
+    const testDir = path.join(tmpDir, 'tests');
+    const coverage = scanTestCoverage(testDir, ['E01-S01']);
+    const entry = coverage.get('E01-S01');
+    if (!entry) throw new Error('expected entry');
+    expect(entry.files.length).toBeGreaterThan(0);
+  });
+});
+
+// ─── computeUATCoverage ──────────────────────────────────────────────────────
+
+describe('computeUATCoverage', () => {
+  it('throws when PRD not found', () => {
+    expect(() => computeUATCoverage('/nonexistent/prd.md', tmpDir)).toThrow('PRD not found');
+  });
+
+  it('returns 100% story coverage when no stories in PRD', () => {
+    const prd = write('prd.md', 'No story IDs here');
+    const result = computeUATCoverage(prd, tmpDir);
+    expect(result.story_coverage_pct).toBe(100);
+    expect(result.total_stories).toBe(0);
+  });
+
+  it('returns pass:true when criteria coverage >= 80%', () => {
+    const prd = write('prd.md', 'No story IDs here');
+    const result = computeUATCoverage(prd, tmpDir);
+    expect(result.pass).toBe(true);
+  });
+
+  it('returns story_details and criteria_details arrays', () => {
+    const prd = write('prd.md', 'E01-S01 story here');
+    const result = computeUATCoverage(prd, tmpDir);
+    expect(Array.isArray(result.story_details)).toBe(true);
+    expect(Array.isArray(result.criteria_details)).toBe(true);
+  });
+
+  it('computes story coverage percentage correctly', () => {
+    const prd = write('prd.md', SAMPLE_PRD);
+    write('tests/login.test.ts', 'test("E01-S01 login works", () => {})');
+    const result = computeUATCoverage(prd, path.join(tmpDir, 'tests'));
+    expect(result.total_stories).toBe(2);
+    expect(result.covered_stories).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ─── generateUATReport ───────────────────────────────────────────────────────
+
+describe('generateUATReport', () => {
+  it('returns markdown report with header', () => {
+    const prd = write('prd.md', SAMPLE_PRD);
+    const report = generateUATReport(prd, tmpDir);
+    expect(report).toContain('UAT Coverage Report');
+    expect(report).toContain('Story Coverage');
+  });
+
+  it('includes story summary table', () => {
+    const prd = write('prd.md', SAMPLE_PRD);
+    const report = generateUATReport(prd, tmpDir);
+    expect(report).toContain('Story Summary');
+    expect(report).toContain('E01-S01');
+  });
+});
+
+// ─── pollution-key safety (no JSON state) ───────────────────────────────────
+
+describe('pollution-key safety', () => {
+  it('extractAcceptanceCriteria does not crash on __proto__ bytes', () => {
+    const content = Buffer.from('{"__proto__":{"evil":1}} E01-S01 story').toString();
+    expect(() => extractAcceptanceCriteria(content)).not.toThrow();
+  });
+
+  it('extractKeywords does not crash on constructor key in text', () => {
+    const text = Buffer.from('{"constructor":{"prototype":{}}} login credential').toString();
+    expect(() => extractKeywords(text)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Ports the final 17 \"orphan\" legacy modules from `bin/lib/` to strict TypeScript (`exactOptionalPropertyTypes` + `noUncheckedIndexedAccess`), completing the M11 strangler migration.

**Modules ported (17 total):**
- `coverage.ts` — test coverage computation (Item 29)
- `freshness-gate.ts` — staleness checks (Item 55)
- `invariants-check.ts` — structural invariants scanner (Item 56)
- `knowledge-graph.ts` — dependency graph builder (Item 58)
- `sharder.ts` — PRD sharding heuristics (Item 68)
- `simplicity-gate.ts` — complexity budget enforcement (Item 81)
- `spec-tester.ts` — spec markdown linting (Item 88)
- `template-watcher.ts` — template sync daemon (Item 89)
- `uat-coverage.ts` — Gherkin/AC coverage alignment (Item 85)
- `boundary-check.ts` — plan boundary validation (Item 74)
- `handoff.ts` — auto-handoff logic (Item 37)
- `init.ts` — interactive init / skill level config (Item 76)
- `lint-runner.ts` — lint-on-save for agents (Item 66)
- `module-loader.ts` — pluggable module system (Item 91)
- `quickstart.ts` — 5-minute quickstart wizard helpers (UX Feature 15)
- `self-evolve.ts` — framework self-improvement hook (Item 100)
- `export.ts` — portable handoff package generator (Item 53)

**Per-module hardening applied:**
- M3: `assertNoPollution()` on all `JSON.parse()` results (rejects `__proto__`/`constructor`/`prototype` keys)
- `defaultState()` fallback on state.json parse failure
- ADR-009: `assertInsideRoot` / `assertUserPath` for all file I/O
- ADR-006: no `process.exit` — throws `JumpstartError` or returns result objects
- `spawnSync(head, tail, { shell: false })` in lint-runner (prevents shell injection)
- Explicit allowlist validation before `Record` key lookup in init.ts (prevents `__proto__` pollution bypass)

**Cluster wiring:** All `legacyRequire<T>(...)` call sites in `src/cli/commands/` replaced with direct ESM imports.

**Tests:** 170 new vitest cases across 8 test files (happy path + rejection + pollution-key paths per module).

**verify-baseline:** 11/12 gates pass (`vitest-full-suite` is a pre-existing pitcrew flakiness failure in parallel mode, passes standalone; `biome-check` now green, up from 10/12 before this PR).

## Test plan

- [ ] `npx vitest run tests/test-export.test.ts` — 23/23 pass
- [ ] `npx vitest run tests/test-module-loader.test.ts` — 24/24 pass
- [ ] `npx vitest run tests/test-boundary-check.test.ts` — 15/15 pass
- [ ] `npx vitest run tests/test-handoff.test.ts` — 28/28 pass
- [ ] `npx vitest run tests/test-init.test.ts` — 21/21 pass
- [ ] `npx vitest run tests/test-lint-runner.test.ts` — 21/21 pass
- [ ] `npx vitest run tests/test-quickstart.test.ts` — 23/23 pass
- [ ] `npx vitest run tests/test-self-evolve.test.ts` — 15/15 pass
- [ ] `npx tsc --noEmit` — clean
- [ ] `npx @biomejs/biome check .` — no errors/warnings
- [ ] `npm run verify-baseline` — 11/12 (pre-existing pitcrew flakiness in parallel run)