### PR TITLE
chore(m11-phase5d): final batch — convert 4 large integration tests

### DIFF
--- a/tests/test-enterprise-differentiators.test.js
+++ b/tests/test-enterprise-differentiators.test.js
@@ -7,9 +7,75 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
-import { createRequire } from 'module';
-
-const require = createRequire(import.meta.url);
+import {
+  evaluate,
+  configureBenchmark,
+  EVAL_DIMENSIONS,
+  generateReport as aiReport,
+} from '../src/lib/ai-evaluation.js';
+import {
+  registerContract,
+  validateCompatibility,
+  trackLineage,
+  generateReport as contractReport,
+  COMPATIBILITY_MODES,
+} from '../src/lib/data-contracts.js';
+import {
+  defineElement,
+  queryOntology,
+  generateReport as ontologyReport,
+  ELEMENT_TYPES,
+} from '../src/lib/domain-ontology.js';
+import { indexProject, searchProject, SEARCHABLE_TYPES } from '../src/lib/enterprise-search.js';
+import {
+  defineTopic,
+  defineEvent,
+  defineSaga,
+  generateReport as eventReport,
+  EVENT_TYPES,
+} from '../src/lib/event-modeling.js';
+import {
+  addNode,
+  addEdge,
+  queryGraph,
+  generateReport as kgReport,
+  NODE_TYPES,
+  EDGE_TYPES,
+} from '../src/lib/knowledge-graph.js';
+import {
+  registerPattern,
+  searchPatterns,
+  listPatterns,
+  PATTERN_CATEGORIES,
+} from '../src/lib/pattern-library.js';
+import {
+  registerTemplate,
+  listTemplates,
+  instantiateTemplate,
+  generateReport as platformReport,
+  TEMPLATE_TYPES,
+} from '../src/lib/platform-engineering.js';
+import {
+  registerAsset,
+  addVersion,
+  approveVersion,
+  listAssets,
+  ASSET_TYPES,
+} from '../src/lib/prompt-governance.js';
+import {
+  generateMonitor,
+  generateAlert,
+  generateRunbook,
+  configureErrorBudget,
+  MONITOR_TYPES,
+  ALERT_SEVERITIES,
+} from '../src/lib/sre-integration.js';
+import {
+  ingestMetric,
+  analyzeMetrics,
+  generateFeedbackReport,
+  METRIC_TYPES,
+} from '../src/lib/telemetry-feedback.js';
 
 function createTempProject() {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jumpstart-enterprise-'));
@@ -22,61 +88,6 @@ function createTempProject() {
 function cleanup(tmpDir) {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 }
-
-// --- Module imports ---
-const {
-  addNode, addEdge, queryGraph, generateReport: kgReport,
-  NODE_TYPES, EDGE_TYPES
-} = require('../bin/lib/knowledge-graph');
-
-const {
-  registerPattern, searchPatterns, listPatterns,
-  PATTERN_CATEGORIES
-} = require('../bin/lib/pattern-library');
-
-const {
-  defineElement, queryOntology, generateReport: ontologyReport,
-  ELEMENT_TYPES
-} = require('../bin/lib/domain-ontology');
-
-const {
-  registerContract, validateCompatibility, trackLineage,
-  generateReport: contractReport, COMPATIBILITY_MODES
-} = require('../bin/lib/data-contracts');
-
-const {
-  defineTopic, defineEvent, defineSaga,
-  generateReport: eventReport, EVENT_TYPES
-} = require('../bin/lib/event-modeling');
-
-const {
-  registerTemplate, listTemplates, instantiateTemplate,
-  generateReport: platformReport, TEMPLATE_TYPES
-} = require('../bin/lib/platform-engineering');
-
-const {
-  evaluate, generateReport: aiReport, configureBenchmark,
-  EVAL_DIMENSIONS
-} = require('../bin/lib/ai-evaluation');
-
-const {
-  registerAsset, addVersion, approveVersion, listAssets,
-  ASSET_TYPES
-} = require('../bin/lib/prompt-governance');
-
-const {
-  generateMonitor, generateAlert, generateRunbook, configureErrorBudget,
-  MONITOR_TYPES, ALERT_SEVERITIES
-} = require('../bin/lib/sre-integration');
-
-const {
-  ingestMetric, analyzeMetrics, generateFeedbackReport,
-  METRIC_TYPES
-} = require('../bin/lib/telemetry-feedback');
-
-const {
-  indexProject, searchProject, SEARCHABLE_TYPES
-} = require('../bin/lib/enterprise-search');
 
 // ============================================================
 // Item 81 — Knowledge Graph

--- a/tests/test-enterprise-governance.test.js
+++ b/tests/test-enterprise-governance.test.js
@@ -28,9 +28,26 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
-import { createRequire } from 'module';
-
-const require = createRequire(import.meta.url);
+import * as aiIntakeLib from '../src/lib/ai-intake.js';
+import * as bcdrPlanningLib from '../src/lib/bcdr-planning.js';
+import * as cabOutputLib from '../src/lib/cab-output.js';
+import * as ciCdIntegrationLib from '../src/lib/ci-cd-integration.js';
+import * as compliancePacksLib from '../src/lib/compliance-packs.js';
+import * as credentialBoundaryLib from '../src/lib/credential-boundary.js';
+import * as dataClassificationLib from '../src/lib/data-classification.js';
+import * as eaReviewPacketLib from '../src/lib/ea-review-packet.js';
+import * as environmentPromotionLib from '../src/lib/environment-promotion.js';
+import * as evidenceCollectorLib from '../src/lib/evidence-collector.js';
+import * as finopsPlannerLib from '../src/lib/finops-planner.js';
+import * as governanceDashboardLib from '../src/lib/governance-dashboard.js';
+import * as modelGovernanceLib from '../src/lib/model-governance.js';
+import * as opsOwnershipLib from '../src/lib/ops-ownership.js';
+import * as raciMatrixLib from '../src/lib/raci-matrix.js';
+import * as releaseReadinessLib from '../src/lib/release-readiness.js';
+import * as riskRegisterLib from '../src/lib/risk-register.js';
+import * as slaSloLib from '../src/lib/sla-slo.js';
+import * as vendorRiskLib from '../src/lib/vendor-risk.js';
+import * as waiverWorkflowLib from '../src/lib/waiver-workflow.js';
 
 function createTempDir() {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jumpstart-gov-'));
@@ -48,7 +65,7 @@ function cleanupTempDir(tmpDir) {
 // ─── Item 21: CI/CD Integration ──────────────────────────────────────────────
 
 describe('CI/CD Integration (Item 21)', () => {
-  const lib = require('../bin/lib/ci-cd-integration');
+  const lib = ciCdIntegrationLib;
 
   it('generates GitHub Actions pipeline', () => {
     const result = lib.generatePipeline('github-actions');
@@ -90,7 +107,7 @@ describe('CI/CD Integration (Item 21)', () => {
 // ─── Item 22: Environment Promotion ──────────────────────────────────────────
 
 describe('Environment Promotion (Item 22)', () => {
-  const lib = require('../bin/lib/environment-promotion');
+  const lib = environmentPromotionLib;
   let tmpDir, stateFile;
 
   beforeEach(() => {
@@ -127,7 +144,7 @@ describe('Environment Promotion (Item 22)', () => {
 // ─── Item 23: RACI Matrix ────────────────────────────────────────────────────
 
 describe('RACI Matrix (Item 23)', () => {
-  const lib = require('../bin/lib/raci-matrix');
+  const lib = raciMatrixLib;
   let tmpDir, stateFile;
 
   beforeEach(() => {
@@ -161,7 +178,7 @@ describe('RACI Matrix (Item 23)', () => {
 // ─── Item 24: Compliance Packs ───────────────────────────────────────────────
 
 describe('Compliance Packs (Item 24)', () => {
-  const lib = require('../bin/lib/compliance-packs');
+  const lib = compliancePacksLib;
   let tmpDir, stateFile;
 
   beforeEach(() => {
@@ -201,7 +218,7 @@ describe('Compliance Packs (Item 24)', () => {
 // ─── Item 25: Evidence Collector ─────────────────────────────────────────────
 
 describe('Evidence Collector (Item 25)', () => {
-  const lib = require('../bin/lib/evidence-collector');
+  const lib = evidenceCollectorLib;
   let tmpDir;
 
   beforeEach(() => { tmpDir = createTempDir(); });
@@ -225,7 +242,7 @@ describe('Evidence Collector (Item 25)', () => {
 // ─── Item 26: Release Readiness ──────────────────────────────────────────────
 
 describe('Release Readiness (Item 26)', () => {
-  const lib = require('../bin/lib/release-readiness');
+  const lib = releaseReadinessLib;
   let tmpDir;
 
   beforeEach(() => { tmpDir = createTempDir(); });
@@ -250,7 +267,7 @@ describe('Release Readiness (Item 26)', () => {
 // ─── Item 27: Waiver Workflow ────────────────────────────────────────────────
 
 describe('Waiver Workflow (Item 27)', () => {
-  const lib = require('../bin/lib/waiver-workflow');
+  const lib = waiverWorkflowLib;
   let tmpDir, stateFile;
 
   beforeEach(() => {
@@ -287,7 +304,7 @@ describe('Waiver Workflow (Item 27)', () => {
 // ─── Item 28: SLA/SLO ───────────────────────────────────────────────────────
 
 describe('SLA/SLO (Item 28)', () => {
-  const lib = require('../bin/lib/sla-slo');
+  const lib = slaSloLib;
   let tmpDir, stateFile;
 
   beforeEach(() => {
@@ -317,7 +334,7 @@ describe('SLA/SLO (Item 28)', () => {
 // ─── Item 29: Risk Register ─────────────────────────────────────────────────
 
 describe('Risk Register (Item 29)', () => {
-  const lib = require('../bin/lib/risk-register');
+  const lib = riskRegisterLib;
   let tmpDir, stateFile;
 
   beforeEach(() => {
@@ -355,7 +372,7 @@ describe('Risk Register (Item 29)', () => {
 // ─── Item 30: Data Classification ───────────────────────────────────────────
 
 describe('Data Classification (Item 30)', () => {
-  const lib = require('../bin/lib/data-classification');
+  const lib = dataClassificationLib;
   let tmpDir, stateFile;
 
   beforeEach(() => {
@@ -385,7 +402,7 @@ describe('Data Classification (Item 30)', () => {
 // ─── Item 31: Credential Boundary ───────────────────────────────────────────
 
 describe('Credential Boundary (Item 31)', () => {
-  const lib = require('../bin/lib/credential-boundary');
+  const lib = credentialBoundaryLib;
   let tmpDir;
 
   beforeEach(() => { tmpDir = createTempDir(); });
@@ -411,7 +428,7 @@ describe('Credential Boundary (Item 31)', () => {
 // ─── Item 32: EA Review Packet ──────────────────────────────────────────────
 
 describe('EA Review Packet (Item 32)', () => {
-  const lib = require('../bin/lib/ea-review-packet');
+  const lib = eaReviewPacketLib;
   let tmpDir;
 
   beforeEach(() => { tmpDir = createTempDir(); });
@@ -434,7 +451,7 @@ describe('EA Review Packet (Item 32)', () => {
 // ─── Item 33: Model Governance ──────────────────────────────────────────────
 
 describe('Model Governance (Item 33)', () => {
-  const lib = require('../bin/lib/model-governance');
+  const lib = modelGovernanceLib;
   let tmpDir, stateFile;
 
   beforeEach(() => {
@@ -459,7 +476,7 @@ describe('Model Governance (Item 33)', () => {
 // ─── Item 34: AI Intake ─────────────────────────────────────────────────────
 
 describe('AI Intake (Item 34)', () => {
-  const lib = require('../bin/lib/ai-intake');
+  const lib = aiIntakeLib;
   let tmpDir, stateFile;
 
   beforeEach(() => {
@@ -485,7 +502,7 @@ describe('AI Intake (Item 34)', () => {
 // ─── Item 35: FinOps Planner ─────────────────────────────────────────────────
 
 describe('FinOps Planner (Item 35)', () => {
-  const lib = require('../bin/lib/finops-planner');
+  const lib = finopsPlannerLib;
   let tmpDir, stateFile;
 
   beforeEach(() => {
@@ -513,7 +530,7 @@ describe('FinOps Planner (Item 35)', () => {
 // ─── Item 36: Vendor Risk ───────────────────────────────────────────────────
 
 describe('Vendor Risk (Item 36)', () => {
-  const lib = require('../bin/lib/vendor-risk');
+  const lib = vendorRiskLib;
   let tmpDir;
 
   beforeEach(() => { tmpDir = createTempDir(); });
@@ -539,7 +556,7 @@ describe('Vendor Risk (Item 36)', () => {
 // ─── Item 37: CAB Output ────────────────────────────────────────────────────
 
 describe('CAB Output (Item 37)', () => {
-  const lib = require('../bin/lib/cab-output');
+  const lib = cabOutputLib;
   let tmpDir;
 
   beforeEach(() => { tmpDir = createTempDir(); });
@@ -556,7 +573,7 @@ describe('CAB Output (Item 37)', () => {
 // ─── Item 38: BCDR Planning ─────────────────────────────────────────────────
 
 describe('BCDR Planning (Item 38)', () => {
-  const lib = require('../bin/lib/bcdr-planning');
+  const lib = bcdrPlanningLib;
   let tmpDir, stateFile;
 
   beforeEach(() => {
@@ -582,7 +599,7 @@ describe('BCDR Planning (Item 38)', () => {
 // ─── Item 39: Ops Ownership ─────────────────────────────────────────────────
 
 describe('Ops Ownership (Item 39)', () => {
-  const lib = require('../bin/lib/ops-ownership');
+  const lib = opsOwnershipLib;
   let tmpDir, stateFile;
 
   beforeEach(() => {
@@ -607,7 +624,7 @@ describe('Ops Ownership (Item 39)', () => {
 // ─── Item 40: Governance Dashboard ──────────────────────────────────────────
 
 describe('Governance Dashboard (Item 40)', () => {
-  const lib = require('../bin/lib/governance-dashboard');
+  const lib = governanceDashboardLib;
   let tmpDir;
 
   beforeEach(() => { tmpDir = createTempDir(); });

--- a/tests/test-platform-features.test.js
+++ b/tests/test-platform-features.test.js
@@ -18,9 +18,16 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { createRequire } from 'module';
-
-const require = createRequire(import.meta.url);
+import * as bidirectionalTraceLib from '../src/lib/bidirectional-trace.js';
+import * as branchWorkflowLib from '../src/lib/branch-workflow.js';
+import * as impactAnalysisLib from '../src/lib/impact-analysis.js';
+import * as multiRepoLib from '../src/lib/multi-repo.js';
+import * as parallelAgentsLib from '../src/lib/parallel-agents.js';
+import * as policyEngineLib from '../src/lib/policy-engine.js';
+import * as prPackageLib from '../src/lib/pr-package.js';
+import * as projectMemoryLib from '../src/lib/project-memory.js';
+import * as repoGraphLib from '../src/lib/repo-graph.js';
+import * as roleApprovalLib from '../src/lib/role-approval.js';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -48,7 +55,7 @@ describe('multi-repo', () => {
   });
   afterEach(() => rmTmpDir(tmp));
 
-  const lib = () => require('../bin/lib/multi-repo');
+  const lib = () => multiRepoLib;
 
   it('initProgram creates a new program', () => {
     const r = lib().initProgram('MyProgram', opts);
@@ -151,7 +158,7 @@ describe('bidirectional-trace', () => {
   });
   afterEach(() => rmTmpDir(tmp));
 
-  const lib = () => require('../bin/lib/bidirectional-trace');
+  const lib = () => bidirectionalTraceLib;
 
   it('scanTraceLinks finds forward and reverse maps', () => {
     const result = lib().scanTraceLinks(tmp);
@@ -220,7 +227,7 @@ describe('impact-analysis', () => {
   });
   afterEach(() => rmTmpDir(tmp));
 
-  const lib = () => require('../bin/lib/impact-analysis');
+  const lib = () => impactAnalysisLib;
 
   it('analyzeImpact returns success for a file target', () => {
     const r = lib().analyzeImpact(tmp, { file: 'src/auth.service.js' });
@@ -284,7 +291,7 @@ describe('repo-graph', () => {
   });
   afterEach(() => rmTmpDir(tmp));
 
-  const lib = () => require('../bin/lib/repo-graph');
+  const lib = () => repoGraphLib;
 
   it('buildRepoGraph returns node and edge counts', () => {
     const graphFile = path.join(tmp, '.jumpstart', 'state', 'repo-graph.json');
@@ -366,7 +373,7 @@ describe('project-memory', () => {
   });
   afterEach(() => rmTmpDir(tmp));
 
-  const lib = () => require('../bin/lib/project-memory');
+  const lib = () => projectMemoryLib;
 
   it('addMemory creates an entry', () => {
     const r = lib().addMemory({ type: 'decision', title: 'Use REST', content: 'We chose REST over gRPC.' }, opts);
@@ -455,7 +462,7 @@ describe('policy-engine', () => {
   });
   afterEach(() => rmTmpDir(tmp));
 
-  const lib = () => require('../bin/lib/policy-engine');
+  const lib = () => policyEngineLib;
 
   it('addPolicy creates a rule', () => {
     const r = lib().addPolicy({
@@ -551,7 +558,7 @@ describe('branch-workflow', () => {
   });
   afterEach(() => rmTmpDir(tmp));
 
-  const lib = () => require('../bin/lib/branch-workflow');
+  const lib = () => branchWorkflowLib;
 
   it('trackBranch creates a branch entry', () => {
     const r = lib().trackBranch(tmp, { branch: 'feature/test', ...opts });
@@ -615,7 +622,7 @@ describe('pr-package', () => {
   });
   afterEach(() => rmTmpDir(tmp));
 
-  const lib = () => require('../bin/lib/pr-package');
+  const lib = () => prPackageLib;
 
   it('createPRPackage creates a markdown file', () => {
     const r = lib().createPRPackage({
@@ -693,7 +700,7 @@ describe('parallel-agents', () => {
   });
   afterEach(() => rmTmpDir(tmp));
 
-  const lib = () => require('../bin/lib/parallel-agents');
+  const lib = () => parallelAgentsLib;
 
   it('scheduleRun creates a run with all default agents', () => {
     const r = lib().scheduleRun([], { root: tmp }, opts);
@@ -781,7 +788,7 @@ describe('role-approval', () => {
   });
   afterEach(() => rmTmpDir(tmp));
 
-  const lib = () => require('../bin/lib/role-approval');
+  const lib = () => roleApprovalLib;
 
   it('assignApprovers creates a workflow', () => {
     const r = lib().assignApprovers('specs/prd.md', [

--- a/tests/test-workflow-adoption.test.js
+++ b/tests/test-workflow-adoption.test.js
@@ -20,9 +20,18 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
-import { createRequire } from 'module';
-
-const require = createRequire(import.meta.url);
+import * as ambiguityHeatmapLib from '../src/lib/ambiguity-heatmap.js';
+import * as artifactComparisonLib from '../src/lib/artifact-comparison.js';
+import * as chatIntegrationLib from '../src/lib/chat-integration.js';
+import * as contextOnboardingLib from '../src/lib/context-onboarding.js';
+import * as designSystemLib from '../src/lib/design-system.js';
+import * as diagramStudioLib from '../src/lib/diagram-studio.js';
+import * as estimationStudioLib from '../src/lib/estimation-studio.js';
+import * as guidedHandoffLib from '../src/lib/guided-handoff.js';
+import * as personaPacksLib from '../src/lib/persona-packs.js';
+import * as promptlessModeLib from '../src/lib/promptless-mode.js';
+import * as transcriptIngestionLib from '../src/lib/transcript-ingestion.js';
+import * as workstreamOwnershipLib from '../src/lib/workstream-ownership.js';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -51,7 +60,7 @@ describe('design-system', () => {
   });
   afterEach(() => cleanupTempDir(tmp));
 
-  const lib = () => require('../bin/lib/design-system');
+  const lib = () => designSystemLib;
 
   it('registerTokens stores tokens for a valid category', () => {
     const tokens = { primary: '#0066cc', secondary: '#ff9900' };
@@ -90,7 +99,7 @@ describe('design-system', () => {
 // ─── 2. Diagram Studio (Item 70) ───────────────────────────────────────────
 
 describe('diagram-studio', () => {
-  const lib = () => require('../bin/lib/diagram-studio');
+  const lib = () => diagramStudioLib;
 
   it('generateDiagram returns a template for a known type', () => {
     const r = lib().generateDiagram('sequence');
@@ -140,7 +149,7 @@ describe('ambiguity-heatmap', () => {
   beforeEach(() => { tmp = createTempDir(); });
   afterEach(() => cleanupTempDir(tmp));
 
-  const lib = () => require('../bin/lib/ambiguity-heatmap');
+  const lib = () => ambiguityHeatmapLib;
 
   it('scanAmbiguity finds vague language', () => {
     const text = 'The system should be robust and scalable.\nIt must handle large scale traffic.';
@@ -187,7 +196,7 @@ describe('estimation-studio', () => {
   });
   afterEach(() => cleanupTempDir(tmp));
 
-  const lib = () => require('../bin/lib/estimation-studio');
+  const lib = () => estimationStudioLib;
 
   it('estimateFeature creates an estimate with ROM cost', () => {
     const r = lib().estimateFeature('Login Page', 'M', opts);
@@ -223,7 +232,7 @@ describe('estimation-studio', () => {
 // ─── 5. Guided Handoff (Item 73) ───────────────────────────────────────────
 
 describe('guided-handoff', () => {
-  const lib = () => require('../bin/lib/guided-handoff');
+  const lib = () => guidedHandoffLib;
 
   it('generateHandoff creates a handoff package with missing items', () => {
     const r = lib().generateHandoff('product-to-engineering', '/tmp');
@@ -269,7 +278,7 @@ describe('transcript-ingestion', () => {
   });
   afterEach(() => cleanupTempDir(tmp));
 
-  const lib = () => require('../bin/lib/transcript-ingestion');
+  const lib = () => transcriptIngestionLib;
 
   it('ingestTranscript extracts actions and decisions', () => {
     const text = [
@@ -320,7 +329,7 @@ describe('chat-integration', () => {
   });
   afterEach(() => cleanupTempDir(tmp));
 
-  const lib = () => require('../bin/lib/chat-integration');
+  const lib = () => chatIntegrationLib;
 
   it('configure sets up a platform integration', () => {
     const r = lib().configure('slack', { channel: '#dev', ...opts });
@@ -362,7 +371,7 @@ describe('context-onboarding', () => {
   beforeEach(() => { tmp = createTempDir(); });
   afterEach(() => cleanupTempDir(tmp));
 
-  const lib = () => require('../bin/lib/context-onboarding');
+  const lib = () => contextOnboardingLib;
 
   it('generateOnboarding creates an onboarding package', () => {
     fs.writeFileSync(path.join(tmp, 'specs', 'decisions', 'adr-001.md'), '# ADR-001');
@@ -411,7 +420,7 @@ describe('promptless-mode', () => {
   });
   afterEach(() => cleanupTempDir(tmp));
 
-  const lib = () => require('../bin/lib/promptless-mode');
+  const lib = () => promptlessModeLib;
 
   it('startWizard creates a session with steps', () => {
     const r = lib().startWizard('new-project', opts);
@@ -457,7 +466,7 @@ describe('artifact-comparison', () => {
   beforeEach(() => { tmp = createTempDir(); });
   afterEach(() => cleanupTempDir(tmp));
 
-  const lib = () => require('../bin/lib/artifact-comparison');
+  const lib = () => artifactComparisonLib;
 
   it('compareArtifacts detects added and removed sections', () => {
     const a = '# Overview\nFirst version.\n# Scope\nSmall scope.';
@@ -509,7 +518,7 @@ describe('workstream-ownership', () => {
   });
   afterEach(() => cleanupTempDir(tmp));
 
-  const lib = () => require('../bin/lib/workstream-ownership');
+  const lib = () => workstreamOwnershipLib;
 
   it('defineWorkstream creates a named workstream', () => {
     const r = lib().defineWorkstream('Auth Service', { team: 'Platform', owner: 'alice', ...opts });
@@ -550,7 +559,7 @@ describe('workstream-ownership', () => {
 // ─── 12. Persona Packs (Item 80) ───────────────────────────────────────────
 
 describe('persona-packs', () => {
-  const lib = () => require('../bin/lib/persona-packs');
+  const lib = () => personaPacksLib;
 
   it('listPersonas returns all enterprise personas', () => {
     const r = lib().listPersonas();


### PR DESCRIPTION
## Summary
- Final batch of #53 phase 5d. Cuts 53 \`bin/lib/*\` references across 4 large integration tests
- 4 files changed, +153 / -109
- 232 individual test cases verified across the conversions (40 + 51 + 93 + 48)

## Files converted
- \`test-enterprise-differentiators.test.js\` — 11 refs (knowledge-graph, pattern-library, domain-ontology, data-contracts, event-modeling, platform-engineering, ai-evaluation, prompt-governance, sre-integration, telemetry-feedback, enterprise-search)
- \`test-enterprise-governance.test.js\` — 20 refs (Items 21-40 governance modules)
- \`test-platform-features.test.js\` — 10 refs (Items 1-10 platform modules)
- \`test-workflow-adoption.test.js\` — 12 refs (Items 69-80 workflow modules)

## Status

\`bin/lib/*\` test-suite refs after this lands:
- 0 in \`.test.ts\` files
- 1 in \`.test.js\` (test-install-integration, deferred — port divergence)
- 2 in pitcrew regression tests (intentional — pin \`legacyRequire\` security helpers)

Phase 5e (final bin/lib delete) unblocked once #58 (Phase 5c) lands.

## Test plan
- [x] \`npm run verify-baseline\` → 12/12 gates green
- [x] All 232 converted tests pass
- [ ] CI green on PR

Refs #53