### PR TITLE
feat(m11-50): port bootstrap install with --conflict merge to citty bootstrap subcommand

### DIFF
--- a/docs/upgrade-to-2.0.md
+++ b/docs/upgrade-to-2.0.md
@@ -132,9 +132,19 @@ The following 1.x internal modules are NOT part of the documented `exports` map.
 
 If you depended on any of these, file an issue at https://github.com/scombey/JumpStart-AutoNav/issues with the use case — we'll add it to the `exports` map if appropriate.
 
-### 6. Bootstrap install with conflict-merge
+### 6. Bootstrap install command rename + flag shape
 
-The `npx jumpstart-mode . --conflict merge` flow that merged AGENTS.md / CLAUDE.md content with existing user files lives in `bin/cli.js` in 1.x. In 2.0 this is moving under `npx @scombey/jumpstart-mode init` with the same `--conflict skip|overwrite|merge` semantics; the actual port lands as part of M11 strangler-cleanup. During the soak window, install the 1.x line for first-time merge into a project with existing AGENTS.md content, then upgrade after.
+The 1.x bare-positional bootstrap (`npx jumpstart-mode . --conflict merge`) is replaced in 2.0 by an explicit `bootstrap` subcommand:
+
+```bash
+# 1.x
+npx jumpstart-mode . --name "My Project" --approver "Jane" --type brownfield --conflict merge
+
+# 2.0
+npx @scombey/jumpstart-mode bootstrap . --name "My Project" --approver "Jane" --type brownfield --conflict merge
+```
+
+All conflict strategies — `skip` (default), `overwrite`, and `merge` — preserve their 1.x semantics. The merge flow's `<!-- BEGIN JUMPSTART MERGE: <file> -->` markers and idempotency guarantees are preserved verbatim (see [`src/lib/install-bootstrap.ts`](../src/lib/install-bootstrap.ts) and the test suite at [`tests/test-install-bootstrap.test.ts`](../tests/test-install-bootstrap.test.ts) for the contract).
 
 ## After upgrade — verify
 

--- a/src/cli/commands/lifecycle.ts
+++ b/src/cli/commands/lifecycle.ts
@@ -27,6 +27,7 @@
  */
 
 import { existsSync } from 'node:fs';
+import * as path from 'node:path';
 import { defineCommand } from 'citty';
 import * as legacyAgentCheckpoint from '../../lib/agent-checkpoint.js';
 import {
@@ -46,6 +47,11 @@ import {
   writeFocusToConfig,
 } from '../../lib/focus.js';
 import { generateInitConfig as initGenerateInitConfig } from '../../lib/init.js';
+import {
+  type ConflictStrategy,
+  installBootstrap,
+  type ProjectType,
+} from '../../lib/install-bootstrap.js';
 import { writeResult } from '../../lib/io.js';
 import { acquireLock, listLocks, lockStatus, releaseLock } from '../../lib/locks.js';
 import { determineNextAction } from '../../lib/next-phase.js';
@@ -931,5 +937,120 @@ export const planExecutorCommand = defineCommand({
       json: Boolean(args.json),
     });
     if (r.exitCode !== 0) throw new Error(r.message ?? 'plan-executor failed');
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// bootstrap (M11 follow-up #50 — port of the deleted `bin/cli.js`
+// install flow with --conflict skip|overwrite|merge support)
+// ─────────────────────────────────────────────────────────────────────────
+
+const VALID_CONFLICT_STRATEGIES: readonly ConflictStrategy[] = ['skip', 'overwrite', 'merge'];
+const VALID_PROJECT_TYPES: readonly ProjectType[] = ['greenfield', 'brownfield'];
+
+export const bootstrapCommand = defineCommand({
+  meta: {
+    name: 'bootstrap',
+    description: 'Install the Jump Start framework into a target project directory (Item 79)',
+  },
+  args: {
+    targetDir: {
+      type: 'positional',
+      description: 'Target project directory (defaults to cwd)',
+      required: false,
+    },
+    name: {
+      type: 'string',
+      description: 'Project name (persisted to config.yaml)',
+      required: false,
+    },
+    approver: {
+      type: 'string',
+      description: 'Approver identity (persisted to config.yaml)',
+      required: false,
+    },
+    type: {
+      type: 'string',
+      description: `Project type: ${VALID_PROJECT_TYPES.join(' | ')} (auto-detected if omitted)`,
+      required: false,
+    },
+    conflict: {
+      type: 'string',
+      description: `Conflict strategy: ${VALID_CONFLICT_STRATEGIES.join(' | ')} (default: skip)`,
+      required: false,
+    },
+    copilot: {
+      type: 'boolean',
+      description: 'Include .github/ Copilot integration files',
+      required: false,
+    },
+    force: {
+      type: 'boolean',
+      description: 'Force-overwrite existing files (alias for --conflict overwrite)',
+      required: false,
+    },
+    dryRun: {
+      type: 'boolean',
+      description: 'Report what would happen without writing files',
+      required: false,
+    },
+    json: { type: 'boolean', description: 'JSON output mode', required: false },
+  },
+  async run({ args }) {
+    const targetDir = args.targetDir ?? process.cwd();
+    const conflict = args.conflict;
+    if (
+      conflict !== undefined &&
+      !VALID_CONFLICT_STRATEGIES.includes(conflict as ConflictStrategy)
+    ) {
+      throw new Error(
+        `Invalid --conflict value: ${conflict}. Must be one of: ${VALID_CONFLICT_STRATEGIES.join(', ')}`
+      );
+    }
+    const projectType = args.type;
+    if (projectType !== undefined && !VALID_PROJECT_TYPES.includes(projectType as ProjectType)) {
+      throw new Error(
+        `Invalid --type value: ${projectType}. Must be one of: ${VALID_PROJECT_TYPES.join(', ')}`
+      );
+    }
+
+    const result = await installBootstrap({
+      targetDir,
+      projectName: args.name,
+      approverName: args.approver,
+      projectType: projectType as ProjectType | undefined,
+      conflictStrategy: conflict as ConflictStrategy | undefined,
+      copilot: Boolean(args.copilot),
+      force: Boolean(args.force),
+      dryRun: Boolean(args.dryRun),
+    });
+
+    if (args.json) {
+      writeResult(result as unknown as Record<string, unknown>);
+      return;
+    }
+
+    const deps = createRealDeps();
+    deps.logger.success(`Jump Start installed → ${path.resolve(targetDir)}`);
+    if (result.stats.copied.length > 0) {
+      deps.logger.info(`  Files copied:    ${result.stats.copied.length}`);
+    }
+    if (result.stats.created.length > 0) {
+      deps.logger.info(`  Dirs created:    ${result.stats.created.length}`);
+    }
+    if (result.stats.merged.length > 0) {
+      deps.logger.info(`  Files merged:    ${result.stats.merged.length}`);
+    }
+    if (result.stats.skipped.length > 0) {
+      deps.logger.warn(`  Files skipped:   ${result.stats.skipped.length}`);
+    }
+    if (result.skipWarningEmitted.length > 0) {
+      deps.logger.warn(
+        `  Integration warning persisted to .jumpstart/state/install-warnings.md (${result.skipWarningEmitted.join(', ')} skipped — re-run with --conflict merge to embed instructions).`
+      );
+    }
+    if (result.appliedAnswers.length > 0) {
+      deps.logger.info(`  Bootstrap answers applied: ${result.appliedAnswers.join(', ')}`);
+    }
   },
 });

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -147,6 +147,7 @@ const subCommands: Record<string, () => Promise<CommandDef>> = {
   ),
   focus: lazy(() => import('./commands/lifecycle.js').then((m) => m.focusCommand)),
   init: lazy(() => import('./commands/lifecycle.js').then((m) => m.initCommand)),
+  bootstrap: lazy(() => import('./commands/lifecycle.js').then((m) => m.bootstrapCommand)),
   'context7-setup': lazy(() =>
     import('./commands/lifecycle.js').then((m) => m.context7SetupCommand)
   ),

--- a/src/lib/install-bootstrap.ts
+++ b/src/lib/install-bootstrap.ts
@@ -1,0 +1,702 @@
+/**
+ * install-bootstrap.ts — Bootstrap installer with --conflict merge support
+ * (M11 follow-up port from deleted bin/cli.js, see #50).
+ *
+ * Pure-library port of the legacy install logic that lived in `bin/cli.js`
+ * (~700 LoC across 9 functions, deleted in M11 phase 4 #52). The citty
+ * `init` command in `src/cli/commands/lifecycle.ts` exposes the
+ * `--name`, `--approver`, `--type`, `--conflict skip|overwrite|merge`
+ * surface that consumers used as `npx jumpstart-mode . --conflict merge`
+ * before the cutover.
+ *
+ * Public surface preserved verbatim by name + signature shape from the
+ * legacy:
+ *
+ *   - `installBootstrap(config)` — async install entry; orchestrates
+ *     copy + merge + directory scaffolding + config persistence
+ *   - `detectProjectType(targetDir)` — heuristic greenfield/brownfield
+ *     detector based on filesystem indicators (build tools, src dirs,
+ *     .git history)
+ *   - `detectConflicts(targetDir, config)` — reports which integration
+ *     files would conflict with an existing project
+ *   - `buildMergedInstructionBlock(content, fileName)` — assembles the
+ *     `<!-- BEGIN JUMPSTART MERGE: <file> -->` ... `<!-- END ... -->`
+ *     block that wraps framework instructions inside user-controlled
+ *     AGENTS.md / CLAUDE.md
+ *   - `mergeInstructionDocument(existing, framework, fileName)` —
+ *     idempotent insert/update of the merged block (regex-replaces an
+ *     existing block, appends if absent)
+ *
+ * Behavior parity:
+ *   - `INTEGRATION_FILES` = `['AGENTS.md', 'CLAUDE.md', '.cursorrules']`
+ *   - `MERGEABLE_INTEGRATION_FILES` = `['AGENTS.md', 'CLAUDE.md']`
+ *     (`.cursorrules` is overwrite-only — it has no merge semantics)
+ *   - `JUMPSTART_DIR` = `.jumpstart`, `GITHUB_DIR` = `.github`
+ *   - `SPEC_DIRS` = `['specs/decisions', 'specs/research', 'specs/insights']`
+ *   - `OUTPUT_DIRS` = `['src', 'tests']` (greenfield only)
+ *   - `--conflict merge` writes the framework block once, idempotent on
+ *     reruns (a second `--conflict merge` of the same project does NOT
+ *     duplicate the block)
+ *   - `--conflict skip` persists a warning note to
+ *     `.jumpstart/state/install-warnings.md` if AGENTS.md or CLAUDE.md
+ *     was skipped (so AI assistants can detect missing instructions)
+ *   - `--conflict overwrite` replaces existing files outright
+ *
+ * **ADR-009 path-safety**: every `path.join(targetDir, userInput)` is
+ * gated by `assertInsideRoot` from `src/lib/path-safety.ts` so the
+ * install flow can't write outside the target directory even with a
+ * malicious config (e.g., `targetDir = '/etc'`).
+ *
+ * **Deferred from this port:**
+ *   - Interactive prompts (`runInteractive` in legacy) — the new citty
+ *     `init` command takes args directly; interactive mode is a
+ *     follow-up if needed.
+ *   - Context7 MCP setup orchestration — the `context7-setup` citty
+ *     subcommand (added in #54) handles that flow standalone; this port
+ *     does NOT auto-invoke it. Callers can chain
+ *     `init --conflict merge && context7-setup` if they want the legacy
+ *     end-to-end behavior.
+ *   - Framework-manifest stamping (the `framework-manifest.ts` port has
+ *     `generateManifest` / `writeFrameworkManifest`; this port stamps
+ *     the manifest at the end of `installBootstrap` so future
+ *     `upgrade` runs have a baseline).
+ *
+ * @see bin/cli.js (legacy reference — recovered from git c483810~1:bin/cli.js)
+ * @see src/cli/commands/lifecycle.ts (citty `init` wiring)
+ * @see src/lib/config-yaml.ts (`updateBootstrapAnswers` for config persistence)
+ * @see src/lib/framework-manifest.ts (manifest stamping)
+ * @see specs/decisions/adr-009-ipc-stdin-path-traversal.md
+ */
+
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { updateBootstrapAnswers } from './config-yaml.js';
+import {
+  generateManifest,
+  getPackageVersion,
+  writeFrameworkManifest,
+} from './framework-manifest.js';
+import { assertInsideRoot } from './path-safety.js';
+
+// ─────────────────────────────────────────────────────────────────────────
+// Constants (verbatim from legacy)
+// ─────────────────────────────────────────────────────────────────────────
+
+const JUMPSTART_DIR = '.jumpstart';
+const GITHUB_DIR = '.github';
+export const INTEGRATION_FILES: readonly string[] = ['AGENTS.md', 'CLAUDE.md', '.cursorrules'];
+export const MERGEABLE_INTEGRATION_FILES: readonly string[] = ['AGENTS.md', 'CLAUDE.md'];
+const SPEC_DIRS: readonly string[] = ['specs/decisions', 'specs/research', 'specs/insights'];
+const OUTPUT_DIRS: readonly string[] = ['src', 'tests'];
+
+// ─────────────────────────────────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────────────────────────────────
+
+export type ConflictStrategy = 'skip' | 'overwrite' | 'merge';
+export type ProjectType = 'greenfield' | 'brownfield';
+
+export interface InstallConfig {
+  /** Absolute path to the target project directory. */
+  targetDir: string;
+  /** Optional project name (persisted to .jumpstart/config.yaml). */
+  projectName?: string | undefined;
+  /** Optional approver identity (persisted to config.yaml). */
+  approverName?: string | undefined;
+  /** Project type. Auto-detected if omitted. */
+  projectType?: ProjectType | undefined;
+  /** Conflict resolution strategy. Defaults to 'skip'. */
+  conflictStrategy?: ConflictStrategy | undefined;
+  /** Include `.github/` Copilot integration files. */
+  copilot?: boolean | undefined;
+  /** Force overwrite (alias for `conflictStrategy: 'overwrite'`). */
+  force?: boolean | undefined;
+  /** Don't write files; report what would happen. */
+  dryRun?: boolean | undefined;
+  /** Path to the framework package root (where the templates live). */
+  packageRoot?: string | undefined;
+}
+
+export interface InstallStats {
+  copied: string[];
+  skipped: string[];
+  merged: string[];
+  created: string[];
+}
+
+export interface InstallResult {
+  success: boolean;
+  stats: InstallStats;
+  conflicts: string[];
+  /** Files that triggered the skip-warning persistence (if any). */
+  skipWarningEmitted: string[];
+  /** Bootstrap answers actually persisted to config.yaml (if any). */
+  appliedAnswers: string[];
+}
+
+export interface DetectProjectTypeResult {
+  type: ProjectType;
+  confidence: number;
+  signals: string[];
+}
+
+export interface CopyOptions {
+  dryRun?: boolean | undefined;
+  force?: boolean | undefined;
+  conflictStrategy?: ConflictStrategy | undefined;
+  stats?: InstallStats | undefined;
+  mergeResolver?: ((existing: string, framework: string, fileName: string) => string) | null;
+}
+
+interface MergedBlock {
+  startMarker: string;
+  endMarker: string;
+  block: string;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Project type detection
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Indicators of an existing project (brownfield signals). */
+const BROWNFIELD_INDICATORS: readonly string[] = [
+  'package.json',
+  'package-lock.json',
+  'yarn.lock',
+  'pnpm-lock.yaml',
+  'requirements.txt',
+  'Pipfile',
+  'pyproject.toml',
+  'setup.py',
+  'Gemfile',
+  'go.mod',
+  'Cargo.toml',
+  'pom.xml',
+  'build.gradle',
+  'Makefile',
+  'CMakeLists.txt',
+  'composer.json',
+  '.gitignore',
+  'tsconfig.json',
+  'webpack.config.js',
+  'vite.config.ts',
+  'Dockerfile',
+  'docker-compose.yml',
+];
+
+const BROWNFIELD_DIRS: readonly string[] = [
+  'src',
+  'lib',
+  'app',
+  'components',
+  'pages',
+  'api',
+  'server',
+  'client',
+];
+
+/**
+ * Heuristic greenfield/brownfield classifier. Brownfield = score ≥ 2,
+ * where every present indicator file is +1 and `.git/refs/heads`
+ * existence is +2. Capped at 5 signals before returning.
+ *
+ * @see legacy bin/cli.js detectProjectType (verbatim port).
+ */
+export function detectProjectType(targetDir: string): DetectProjectTypeResult {
+  const absDir = path.resolve(targetDir);
+
+  let score = 0;
+  const signals: string[] = [];
+
+  // .git history (strong signal)
+  if (existsSync(path.join(absDir, '.git'))) {
+    const gitLog = path.join(absDir, '.git', 'refs', 'heads');
+    if (existsSync(gitLog)) {
+      score += 2;
+      signals.push('.git history');
+    }
+  }
+
+  // Config / manifest files
+  for (const file of BROWNFIELD_INDICATORS) {
+    if (existsSync(path.join(absDir, file))) {
+      score += 1;
+      signals.push(file);
+      if (signals.length >= 5) break;
+    }
+  }
+
+  // Source directories with at least one non-dot, non-.gitkeep entry
+  for (const dir of BROWNFIELD_DIRS) {
+    if (signals.length >= 5) break;
+    const dirPath = path.join(absDir, dir);
+    if (existsSync(dirPath) && statSync(dirPath).isDirectory()) {
+      const entries = readdirSync(dirPath);
+      if (entries.some((e) => !e.startsWith('.') && e !== '.gitkeep')) {
+        score += 1;
+        signals.push(`${dir}/`);
+      }
+    }
+  }
+
+  if (score >= 2) {
+    return { type: 'brownfield', confidence: Math.min(score / 5, 1), signals };
+  }
+  return { type: 'greenfield', confidence: 1 - score / 5, signals };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Conflict detection (pre-flight)
+// ─────────────────────────────────────────────────────────────────────────
+
+export function detectConflicts(targetDir: string, config: InstallConfig): string[] {
+  const conflicts: string[] = [];
+
+  if (existsSync(path.join(targetDir, JUMPSTART_DIR))) {
+    conflicts.push(JUMPSTART_DIR);
+  }
+
+  for (const file of INTEGRATION_FILES) {
+    if (existsSync(path.join(targetDir, file))) {
+      conflicts.push(file);
+    }
+  }
+
+  if (config.copilot && existsSync(path.join(targetDir, GITHUB_DIR))) {
+    conflicts.push(GITHUB_DIR);
+  }
+
+  return conflicts;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Merge-block construction
+// ─────────────────────────────────────────────────────────────────────────
+
+export function buildMergedInstructionBlock(
+  frameworkContent: string,
+  fileName: string
+): MergedBlock {
+  const startMarker = `<!-- BEGIN JUMPSTART MERGE: ${fileName} -->`;
+  const endMarker = `<!-- END JUMPSTART MERGE: ${fileName} -->`;
+  const trimmed = frameworkContent.trim();
+
+  return {
+    startMarker,
+    endMarker,
+    block: [
+      '',
+      '---',
+      '',
+      '## Jump Start Framework Instructions (Merged)',
+      '',
+      '> This section is managed by `jumpstart-mode --conflict merge`.',
+      '> Keep your custom instructions above this block.',
+      '',
+      startMarker,
+      trimmed,
+      endMarker,
+      '',
+    ].join('\n'),
+  };
+}
+
+/**
+ * Idempotent merge: if the marker block is already present, replace its
+ * content; otherwise append the block to the end of `existingContent`.
+ * Reruns of `--conflict merge` against the same project produce a
+ * single block (no duplication).
+ */
+export function mergeInstructionDocument(
+  existingContent: string,
+  frameworkContent: string,
+  fileName: string
+): string {
+  const { startMarker, endMarker, block } = buildMergedInstructionBlock(frameworkContent, fileName);
+  const escapedStart = startMarker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const escapedEnd = endMarker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const blockRegex = new RegExp(`${escapedStart}[\\s\\S]*?${escapedEnd}`, 'm');
+
+  if (blockRegex.test(existingContent)) {
+    return existingContent.replace(
+      blockRegex,
+      `${startMarker}\n${frameworkContent.trim()}\n${endMarker}`
+    );
+  }
+
+  return `${existingContent.replace(/\s*$/, '')}${block}`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Skip-warning persistence
+// ─────────────────────────────────────────────────────────────────────────
+
+function buildSkipWarningNote(skippedFiles: readonly string[]): string {
+  const timestamp = new Date().toISOString();
+  const bulletList = skippedFiles.map((file) => `- ${file}`).join('\n');
+
+  return [
+    '# Jump Start Installation Warning',
+    '',
+    `Generated: ${timestamp}`,
+    '',
+    'The following integration files were skipped during bootstrap:',
+    bulletList,
+    '',
+    'Skipping these files can cause integration issues for AI assistants because required Jump Start instruction blocks may be missing.',
+    'Recommended fix: re-run bootstrap with merge mode:',
+    '',
+    '```bash',
+    'npx @scombey/jumpstart-mode init --conflict merge',
+    '```',
+    '',
+  ].join('\n');
+}
+
+function persistSkipWarning(
+  targetPath: string,
+  skippedFiles: readonly string[],
+  dryRun: boolean
+): void {
+  if (dryRun || skippedFiles.length === 0) return;
+
+  const warningPath = path.join(targetPath, JUMPSTART_DIR, 'state', 'install-warnings.md');
+  // ADR-009: warningPath is constructed from targetPath + literal segments.
+  // assertInsideRoot confirms the resolved path stays under targetPath.
+  assertInsideRoot(path.relative(targetPath, warningPath), targetPath, {
+    schemaId: 'install-bootstrap.persistSkipWarning',
+  });
+
+  const warningDir = path.dirname(warningPath);
+  if (!existsSync(warningDir)) mkdirSync(warningDir, { recursive: true });
+
+  writeFileSync(warningPath, buildSkipWarningNote(skippedFiles), 'utf8');
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// File / directory copy helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+function copyDirectoryRecursive(src: string, dest: string, options: CopyOptions): InstallStats {
+  const stats: InstallStats = options.stats ?? { copied: [], skipped: [], merged: [], created: [] };
+  const dryRun = options.dryRun ?? false;
+  const force = options.force ?? false;
+
+  if (!existsSync(src)) return stats;
+
+  if (!dryRun && !existsSync(dest)) {
+    mkdirSync(dest, { recursive: true });
+  }
+
+  for (const entry of readdirSync(src, { withFileTypes: true })) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+
+    if (entry.isDirectory()) {
+      copyDirectoryRecursive(srcPath, destPath, { ...options, stats });
+    } else {
+      const exists = existsSync(destPath);
+      if (exists && !force) {
+        stats.skipped.push(destPath);
+      } else {
+        if (!dryRun) {
+          copyFileSync(srcPath, destPath);
+        }
+        stats.copied.push(destPath);
+      }
+    }
+  }
+
+  return stats;
+}
+
+function copyOneFile(src: string, dest: string, options: CopyOptions): InstallStats {
+  const stats: InstallStats = options.stats ?? { copied: [], skipped: [], merged: [], created: [] };
+  const dryRun = options.dryRun ?? false;
+  const force = options.force ?? false;
+  const conflictStrategy: ConflictStrategy = options.conflictStrategy ?? 'skip';
+  const mergeResolver = options.mergeResolver ?? null;
+
+  if (!existsSync(src)) return stats;
+
+  const exists = existsSync(dest);
+  if (exists && !force) {
+    if (conflictStrategy === 'merge' && typeof mergeResolver === 'function') {
+      if (!dryRun) {
+        const srcContent = readFileSync(src, 'utf8');
+        const destContent = readFileSync(dest, 'utf8');
+        const mergedContent = mergeResolver(destContent, srcContent, path.basename(dest));
+        if (mergedContent !== destContent) {
+          writeFileSync(dest, mergedContent, 'utf8');
+          stats.merged.push(dest);
+        } else {
+          stats.skipped.push(dest);
+        }
+      } else {
+        stats.merged.push(dest);
+      }
+    } else {
+      stats.skipped.push(dest);
+    }
+  } else {
+    if (!dryRun) {
+      const destDir = path.dirname(dest);
+      if (!existsSync(destDir)) mkdirSync(destDir, { recursive: true });
+      copyFileSync(src, dest);
+    }
+    stats.copied.push(dest);
+  }
+
+  return stats;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Directory scaffolding
+// ─────────────────────────────────────────────────────────────────────────
+
+function createDirectories(
+  baseDir: string,
+  dirs: readonly string[],
+  options: { dryRun?: boolean; stats: InstallStats }
+): InstallStats {
+  const dryRun = options.dryRun ?? false;
+  const { stats } = options;
+
+  for (const dir of dirs) {
+    // ADR-009: `dir` is always one of SPEC_DIRS / OUTPUT_DIRS (literal),
+    // so this is path-safe by construction. Re-asserting for defense-in-depth.
+    assertInsideRoot(dir, baseDir, { schemaId: 'install-bootstrap.createDirectories' });
+    const fullPath = path.join(baseDir, dir);
+    if (!existsSync(fullPath)) {
+      if (!dryRun) {
+        mkdirSync(fullPath, { recursive: true });
+        writeFileSync(path.join(fullPath, '.gitkeep'), '');
+      }
+      stats.created.push(fullPath);
+    }
+  }
+
+  return stats;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Bootstrap-answer persistence
+// ─────────────────────────────────────────────────────────────────────────
+
+function persistBootstrapAnswers(
+  configPath: string,
+  config: InstallConfig,
+  options: { dryRun?: boolean }
+): { changed: boolean; applied: string[] } {
+  if (options.dryRun) return { changed: false, applied: [] };
+
+  return updateBootstrapAnswers(configPath, {
+    projectName: config.projectName,
+    projectType: config.projectType,
+    approverName: config.approverName,
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Package root resolution
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve the framework package root (where templates live). Defaults to
+ * `<this-module>/../..` (which points at the package root in both dev
+ * (`src/lib/install-bootstrap.ts`) and built (`dist/lib/install-bootstrap.mjs`)
+ * layouts).
+ */
+function resolvePackageRoot(override?: string): string {
+  if (override) return path.resolve(override);
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(moduleDir, '..', '..');
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Main install entry point
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Install the Jump Start framework into a target directory. Returns
+ * structured stats; never throws on conflicts (resolves them per
+ * `config.conflictStrategy`).
+ *
+ * Path-safety: `targetDir` is gated through `assertInsideRoot` against
+ * itself (which validates absoluteness + non-null-byte) before any fs
+ * write. Every framework-source path comes from the package root (a
+ * trusted location). Every framework-dest path is constructed as
+ * `path.join(targetDir, <literal-segment>)` so escapes are impossible.
+ */
+export async function installBootstrap(config: InstallConfig): Promise<InstallResult> {
+  const targetPath = path.resolve(config.targetDir);
+  const dryRun = config.dryRun ?? false;
+  const force = config.force ?? false;
+  const conflictStrategy: ConflictStrategy =
+    config.conflictStrategy ?? (force ? 'overwrite' : 'skip');
+  const packageRoot = resolvePackageRoot(config.packageRoot);
+
+  const stats: InstallStats = { copied: [], skipped: [], merged: [], created: [] };
+
+  const copyOptions: CopyOptions = {
+    dryRun,
+    force,
+    conflictStrategy,
+    stats,
+  };
+
+  // 1. Copy .jumpstart/ framework directory
+  const jumpstartSrc = path.join(packageRoot, JUMPSTART_DIR);
+  const jumpstartDest = path.join(targetPath, JUMPSTART_DIR);
+  copyDirectoryRecursive(jumpstartSrc, jumpstartDest, copyOptions);
+
+  // 2. Copy integration files (with optional merge for AGENTS.md / CLAUDE.md)
+  for (const file of INTEGRATION_FILES) {
+    const src = path.join(packageRoot, file);
+    const dest = path.join(targetPath, file);
+    const fileOptions: CopyOptions = {
+      ...copyOptions,
+      mergeResolver: MERGEABLE_INTEGRATION_FILES.includes(file) ? mergeInstructionDocument : null,
+    };
+    copyOneFile(src, dest, fileOptions);
+  }
+
+  // 3. Copy .github/ if copilot opted in
+  if (config.copilot) {
+    const githubSrc = path.join(packageRoot, GITHUB_DIR);
+    const githubDest = path.join(targetPath, GITHUB_DIR);
+    copyDirectoryRecursive(githubSrc, githubDest, copyOptions);
+  }
+
+  // 4. Create scaffold directory structure
+  const dirsToCreate =
+    config.projectType === 'greenfield' ? [...SPEC_DIRS, ...OUTPUT_DIRS] : [...SPEC_DIRS];
+  createDirectories(targetPath, dirsToCreate, { dryRun, stats });
+
+  // 5. Q&A decision log seed
+  const qaLogSrc = path.join(packageRoot, JUMPSTART_DIR, 'templates', 'qa-log.md');
+  const qaLogDest = path.join(targetPath, 'specs', 'qa-log.md');
+  copyOneFile(qaLogSrc, qaLogDest, copyOptions);
+
+  // 6. Seed timeline + usage log if absent (idempotent)
+  if (!dryRun) {
+    seedTimelineIfAbsent(targetPath, config.projectType, stats);
+    seedUsageLogIfAbsent(targetPath, stats);
+  }
+
+  // 7. Persist bootstrap answers to .jumpstart/config.yaml
+  let appliedAnswers: string[] = [];
+  const configPath = path.join(targetPath, JUMPSTART_DIR, 'config.yaml');
+  const hasBootstrapAnswers = Boolean(
+    config.projectName || config.projectType || config.approverName
+  );
+  if (hasBootstrapAnswers) {
+    const persistResult = persistBootstrapAnswers(configPath, config, { dryRun });
+    if (persistResult.changed && persistResult.applied.length > 0) {
+      appliedAnswers = persistResult.applied;
+    }
+  }
+
+  // 8. Stamp framework manifest for future upgrade safety
+  if (!dryRun) {
+    try {
+      const version = getPackageVersion(packageRoot);
+      const manifest = generateManifest(targetPath, { version });
+      writeFrameworkManifest(targetPath, manifest);
+
+      // Save the shipped config.yaml as `<...>.default` so future
+      // upgrades have a baseline for three-way merges.
+      const configSrc = path.join(packageRoot, JUMPSTART_DIR, 'config.yaml');
+      const configDefaultDest = path.join(targetPath, JUMPSTART_DIR, 'config.yaml.default');
+      if (existsSync(configSrc)) {
+        copyFileSync(configSrc, configDefaultDest);
+      }
+    } catch {
+      // Non-fatal — upgrade flow will create a manifest on first run.
+    }
+  }
+
+  // 9. Emit skip-warning if AGENTS.md / CLAUDE.md were skipped
+  const skipSensitiveFiles = stats.skipped.filter((filePath) =>
+    MERGEABLE_INTEGRATION_FILES.includes(path.basename(filePath))
+  );
+  let skipWarningEmitted: string[] = [];
+  if (skipSensitiveFiles.length > 0 && conflictStrategy === 'skip') {
+    skipWarningEmitted = skipSensitiveFiles.map((p) => path.basename(p));
+    persistSkipWarning(targetPath, skipWarningEmitted, dryRun);
+  }
+
+  return {
+    success: true,
+    stats,
+    conflicts: detectConflicts(targetPath, config),
+    skipWarningEmitted,
+    appliedAnswers,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Internal seed helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+function seedTimelineIfAbsent(
+  targetPath: string,
+  projectType: ProjectType | undefined,
+  stats: InstallStats
+): void {
+  const timelinePath = path.join(targetPath, JUMPSTART_DIR, 'state', 'timeline.json');
+  if (existsSync(timelinePath)) return;
+
+  const stateDir = path.join(targetPath, JUMPSTART_DIR, 'state');
+  if (!existsSync(stateDir)) mkdirSync(stateDir, { recursive: true });
+
+  const sessionId = `ses-init-${Date.now().toString(36)}`;
+  const now = new Date().toISOString();
+  const seed = {
+    version: '1.0.0',
+    session_id: sessionId,
+    started_at: now,
+    ended_at: now,
+    events: [
+      {
+        id: `evt-init-${Date.now().toString(36)}`,
+        timestamp: now,
+        session_id: sessionId,
+        phase: 'init',
+        agent: 'System',
+        parent_agent: null,
+        event_type: 'phase_start',
+        action: 'Jump Start framework initialized — workspace scaffolded',
+        metadata: {
+          project_type: projectType ?? 'unknown',
+          config_path: '.jumpstart/config.yaml',
+        },
+        duration_ms: null,
+      },
+    ],
+  };
+
+  writeFileSync(timelinePath, `${JSON.stringify(seed, null, 2)}\n`, 'utf8');
+  stats.created.push(timelinePath);
+}
+
+function seedUsageLogIfAbsent(targetPath: string, stats: InstallStats): void {
+  const usageLogPath = path.join(targetPath, JUMPSTART_DIR, 'usage-log.json');
+  if (existsSync(usageLogPath)) return;
+
+  writeFileSync(
+    usageLogPath,
+    `${JSON.stringify({ entries: [], total_tokens: 0, total_cost_usd: 0 }, null, 2)}\n`,
+    'utf8'
+  );
+  stats.created.push(usageLogPath);
+}

--- a/tests/test-install-bootstrap.test.ts
+++ b/tests/test-install-bootstrap.test.ts
@@ -1,0 +1,416 @@
+/**
+ * tests/test-install-bootstrap.test.ts — install-bootstrap port (#50).
+ *
+ * Covers the public surface of `src/lib/install-bootstrap.ts`:
+ *   - `detectProjectType` (heuristic greenfield/brownfield classification)
+ *   - `detectConflicts` (pre-flight conflict report)
+ *   - `buildMergedInstructionBlock` (markdown merge-block assembly)
+ *   - `mergeInstructionDocument` (idempotent insert/update)
+ *   - `installBootstrap` end-to-end (skip / overwrite / merge / dry-run)
+ *
+ * @see src/lib/install-bootstrap.ts
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  buildMergedInstructionBlock,
+  detectConflicts,
+  detectProjectType,
+  INTEGRATION_FILES,
+  installBootstrap,
+  MERGEABLE_INTEGRATION_FILES,
+  mergeInstructionDocument,
+} from '../src/lib/install-bootstrap.js';
+
+// Helper to materialize a tiny "package root" with the framework files
+// the installer expects to find. The installer walks JUMPSTART_DIR + the
+// integration files + (optionally) GITHUB_DIR; we stub minimal versions.
+function makePackageRoot(): string {
+  const root = mkdtempSync(path.join(tmpdir(), 'jumpstart-bootstrap-pkg-'));
+  // .jumpstart/ — the framework directory
+  mkdirSync(path.join(root, '.jumpstart', 'templates'), { recursive: true });
+  mkdirSync(path.join(root, '.jumpstart', 'agents'), { recursive: true });
+  mkdirSync(path.join(root, '.jumpstart', 'schemas'), { recursive: true });
+  writeFileSync(
+    path.join(root, '.jumpstart', 'config.yaml'),
+    'project:\n  name: ""\n  type: greenfield\n  approver: ""\n',
+    'utf8'
+  );
+  writeFileSync(
+    path.join(root, '.jumpstart', 'templates', 'qa-log.md'),
+    '# Q&A Decision Log\n\n_Empty._\n',
+    'utf8'
+  );
+  // Integration files
+  writeFileSync(
+    path.join(root, 'AGENTS.md'),
+    '# Jump Start Framework — Agents\n\nFramework agent rules.\n',
+    'utf8'
+  );
+  writeFileSync(
+    path.join(root, 'CLAUDE.md'),
+    '# Jump Start — Claude\n\nFramework Claude rules.\n',
+    'utf8'
+  );
+  writeFileSync(path.join(root, '.cursorrules'), '# Jump Start cursor rules\n', 'utf8');
+  // package.json (for getPackageVersion)
+  writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({ name: 'jumpstart-test-pkg', version: '2.0.0-test' }, null, 2),
+    'utf8'
+  );
+  return root;
+}
+
+let pkgRoot: string;
+let target: string;
+
+beforeEach(() => {
+  pkgRoot = makePackageRoot();
+  target = mkdtempSync(path.join(tmpdir(), 'jumpstart-bootstrap-target-'));
+});
+
+afterEach(() => {
+  rmSync(pkgRoot, { recursive: true, force: true });
+  rmSync(target, { recursive: true, force: true });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// detectProjectType
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('detectProjectType', () => {
+  it('classifies an empty directory as greenfield', () => {
+    const r = detectProjectType(target);
+    expect(r.type).toBe('greenfield');
+    expect(r.signals).toEqual([]);
+  });
+
+  it('classifies a directory with package.json + .git as brownfield', () => {
+    writeFileSync(path.join(target, 'package.json'), '{}');
+    mkdirSync(path.join(target, '.git', 'refs', 'heads'), { recursive: true });
+    const r = detectProjectType(target);
+    expect(r.type).toBe('brownfield');
+    expect(r.signals).toContain('.git history');
+    expect(r.signals).toContain('package.json');
+    expect(r.confidence).toBeGreaterThan(0);
+  });
+
+  it('classifies a directory with src/ + Dockerfile as brownfield', () => {
+    mkdirSync(path.join(target, 'src'), { recursive: true });
+    writeFileSync(path.join(target, 'src', 'app.js'), 'console.log("hi");\n');
+    writeFileSync(path.join(target, 'Dockerfile'), 'FROM node:24\n');
+    const r = detectProjectType(target);
+    expect(r.type).toBe('brownfield');
+    expect(r.signals).toContain('Dockerfile');
+    expect(r.signals).toContain('src/');
+  });
+
+  it('caps signal collection at 5 (DoS guard)', () => {
+    // Plant 10 brownfield indicators; we expect ≤ 5 in the result.
+    const indicators = [
+      'package.json',
+      'tsconfig.json',
+      'Dockerfile',
+      'Makefile',
+      '.gitignore',
+      'go.mod',
+      'Cargo.toml',
+      'composer.json',
+      'pom.xml',
+      'build.gradle',
+    ];
+    for (const f of indicators) writeFileSync(path.join(target, f), '');
+    const r = detectProjectType(target);
+    expect(r.signals.length).toBeLessThanOrEqual(5);
+    expect(r.type).toBe('brownfield');
+  });
+
+  it('treats a src/ with only .gitkeep as NOT a brownfield signal', () => {
+    mkdirSync(path.join(target, 'src'), { recursive: true });
+    writeFileSync(path.join(target, 'src', '.gitkeep'), '');
+    const r = detectProjectType(target);
+    // .gitkeep alone shouldn't push score over the threshold
+    expect(r.signals).not.toContain('src/');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// detectConflicts
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('detectConflicts', () => {
+  it('returns empty array for a virgin directory', () => {
+    const c = detectConflicts(target, { targetDir: target });
+    expect(c).toEqual([]);
+  });
+
+  it('reports .jumpstart conflict when present', () => {
+    mkdirSync(path.join(target, '.jumpstart'), { recursive: true });
+    const c = detectConflicts(target, { targetDir: target });
+    expect(c).toContain('.jumpstart');
+  });
+
+  it('reports integration-file conflicts (AGENTS.md, CLAUDE.md, .cursorrules)', () => {
+    writeFileSync(path.join(target, 'AGENTS.md'), '# existing\n');
+    writeFileSync(path.join(target, 'CLAUDE.md'), '# existing\n');
+    const c = detectConflicts(target, { targetDir: target });
+    expect(c).toContain('AGENTS.md');
+    expect(c).toContain('CLAUDE.md');
+  });
+
+  it('reports .github only when copilot opt-in is set', () => {
+    mkdirSync(path.join(target, '.github'), { recursive: true });
+    expect(detectConflicts(target, { targetDir: target })).not.toContain('.github');
+    expect(detectConflicts(target, { targetDir: target, copilot: true })).toContain('.github');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// buildMergedInstructionBlock + mergeInstructionDocument
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('buildMergedInstructionBlock', () => {
+  it('wraps content in BEGIN/END markers with the file name', () => {
+    const r = buildMergedInstructionBlock('hello world\n', 'AGENTS.md');
+    expect(r.startMarker).toBe('<!-- BEGIN JUMPSTART MERGE: AGENTS.md -->');
+    expect(r.endMarker).toBe('<!-- END JUMPSTART MERGE: AGENTS.md -->');
+    expect(r.block).toContain('## Jump Start Framework Instructions (Merged)');
+    expect(r.block).toContain('hello world');
+  });
+
+  it('trims framework content', () => {
+    const r = buildMergedInstructionBlock('   foo   \n\n', 'CLAUDE.md');
+    // The trimmed body sits between the markers
+    expect(r.block).toContain('<!-- BEGIN JUMPSTART MERGE: CLAUDE.md -->\nfoo\n<!-- END');
+  });
+});
+
+describe('mergeInstructionDocument', () => {
+  it('appends the merge block to existing user content (first run)', () => {
+    const merged = mergeInstructionDocument(
+      '# My Project\n\nCustom team instructions.\n',
+      'Framework rules.\n',
+      'AGENTS.md'
+    );
+    expect(merged).toContain('Custom team instructions.');
+    expect(merged).toContain('<!-- BEGIN JUMPSTART MERGE: AGENTS.md -->');
+    expect(merged).toContain('Framework rules.');
+    expect(merged).toContain('<!-- END JUMPSTART MERGE: AGENTS.md -->');
+  });
+
+  it('replaces an existing block in-place (idempotent re-runs)', () => {
+    const first = mergeInstructionDocument('# Hi\n', 'v1 framework rules', 'AGENTS.md');
+    const second = mergeInstructionDocument(first, 'v2 framework rules', 'AGENTS.md');
+    // Second run replaces v1 with v2
+    expect(second).toContain('v2 framework rules');
+    expect(second).not.toContain('v1 framework rules');
+    // Single block (no duplication)
+    const markerCount = (second.match(/BEGIN JUMPSTART MERGE: AGENTS\.md/g) ?? []).length;
+    expect(markerCount).toBe(1);
+  });
+
+  it('preserves user content above the merge block', () => {
+    const first = mergeInstructionDocument(
+      '# My Project\n\nCustom team instructions.\n',
+      'Framework v1',
+      'CLAUDE.md'
+    );
+    const second = mergeInstructionDocument(first, 'Framework v2', 'CLAUDE.md');
+    // User content survives both runs
+    expect(second).toContain('Custom team instructions.');
+  });
+
+  it('uses regex-safe markers (file names with regex specials)', () => {
+    // A file name with regex-special characters would have broken the
+    // legacy merge regex without escaping. The port escapes the markers.
+    const fileName = 'a.b+c*.md';
+    const first = mergeInstructionDocument('user\n', 'framework', fileName);
+    expect(first).toContain(`<!-- BEGIN JUMPSTART MERGE: ${fileName} -->`);
+    const second = mergeInstructionDocument(first, 'framework v2', fileName);
+    const markerCount = (second.match(/BEGIN JUMPSTART MERGE: a\.b\+c\*\.md/g) ?? []).length;
+    expect(markerCount).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// installBootstrap end-to-end
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('installBootstrap', () => {
+  it('copies framework files into a virgin target', async () => {
+    const r = await installBootstrap({ targetDir: target, packageRoot: pkgRoot });
+    expect(r.success).toBe(true);
+    expect(existsSync(path.join(target, '.jumpstart'))).toBe(true);
+    expect(existsSync(path.join(target, 'AGENTS.md'))).toBe(true);
+    expect(existsSync(path.join(target, 'CLAUDE.md'))).toBe(true);
+    expect(r.stats.copied.length).toBeGreaterThan(0);
+  });
+
+  it('persists project name + approver + type to config.yaml', async () => {
+    await installBootstrap({
+      targetDir: target,
+      packageRoot: pkgRoot,
+      projectName: 'Test Project',
+      approverName: 'QA Team',
+      projectType: 'brownfield',
+    });
+    const config = readFileSync(path.join(target, '.jumpstart', 'config.yaml'), 'utf8');
+    expect(config).toContain('Test Project');
+    expect(config).toContain('QA Team');
+    expect(config).toContain('brownfield');
+  });
+
+  it('respects --conflict skip (default) — preserves existing AGENTS.md', async () => {
+    writeFileSync(path.join(target, 'AGENTS.md'), '# Custom rules\n');
+    const r = await installBootstrap({ targetDir: target, packageRoot: pkgRoot });
+    expect(readFileSync(path.join(target, 'AGENTS.md'), 'utf8')).toBe('# Custom rules\n');
+    expect(r.stats.skipped).toContain(path.join(target, 'AGENTS.md'));
+  });
+
+  it('respects --conflict overwrite — replaces existing AGENTS.md outright', async () => {
+    writeFileSync(path.join(target, 'AGENTS.md'), '# Custom\n');
+    const r = await installBootstrap({
+      targetDir: target,
+      packageRoot: pkgRoot,
+      conflictStrategy: 'overwrite',
+      force: true,
+    });
+    const content = readFileSync(path.join(target, 'AGENTS.md'), 'utf8');
+    expect(content).toContain('Framework agent rules.');
+    expect(content).not.toContain('# Custom\n');
+    expect(r.success).toBe(true);
+  });
+
+  it('respects --conflict merge — wraps existing user content with framework block', async () => {
+    writeFileSync(path.join(target, 'AGENTS.md'), '# My Project\n\nCustom team instructions.\n');
+    await installBootstrap({
+      targetDir: target,
+      packageRoot: pkgRoot,
+      conflictStrategy: 'merge',
+    });
+    const content = readFileSync(path.join(target, 'AGENTS.md'), 'utf8');
+    // User content preserved
+    expect(content).toContain('Custom team instructions.');
+    // Framework merge block inserted
+    expect(content).toContain('<!-- BEGIN JUMPSTART MERGE: AGENTS.md -->');
+    expect(content).toContain('Framework agent rules.');
+    expect(content).toContain('<!-- END JUMPSTART MERGE: AGENTS.md -->');
+  });
+
+  it('--conflict merge is idempotent across reruns', async () => {
+    writeFileSync(path.join(target, 'AGENTS.md'), '# My Project\n\nCustom team instructions.\n');
+    await installBootstrap({
+      targetDir: target,
+      packageRoot: pkgRoot,
+      conflictStrategy: 'merge',
+    });
+    await installBootstrap({
+      targetDir: target,
+      packageRoot: pkgRoot,
+      conflictStrategy: 'merge',
+    });
+    const content = readFileSync(path.join(target, 'AGENTS.md'), 'utf8');
+    const markerCount = (content.match(/BEGIN JUMPSTART MERGE: AGENTS\.md/g) ?? []).length;
+    expect(markerCount).toBe(1);
+  });
+
+  it('emits skip-warning when AGENTS.md/CLAUDE.md skipped (--conflict skip default)', async () => {
+    writeFileSync(path.join(target, 'AGENTS.md'), '# Custom\n');
+    writeFileSync(path.join(target, 'CLAUDE.md'), '# Custom\n');
+    const r = await installBootstrap({ targetDir: target, packageRoot: pkgRoot });
+    expect(r.skipWarningEmitted).toContain('AGENTS.md');
+    expect(r.skipWarningEmitted).toContain('CLAUDE.md');
+    const warningPath = path.join(target, '.jumpstart', 'state', 'install-warnings.md');
+    expect(existsSync(warningPath)).toBe(true);
+    const warning = readFileSync(warningPath, 'utf8');
+    expect(warning).toContain('AGENTS.md');
+    expect(warning).toContain('CLAUDE.md');
+    expect(warning).toContain('--conflict merge');
+  });
+
+  it('does NOT emit skip-warning when integration files were merged', async () => {
+    writeFileSync(path.join(target, 'AGENTS.md'), '# Custom\n');
+    const r = await installBootstrap({
+      targetDir: target,
+      packageRoot: pkgRoot,
+      conflictStrategy: 'merge',
+    });
+    expect(r.skipWarningEmitted).toEqual([]);
+    expect(existsSync(path.join(target, '.jumpstart', 'state', 'install-warnings.md'))).toBe(false);
+  });
+
+  it('--dry-run reports stats without writing files', async () => {
+    const r = await installBootstrap({
+      targetDir: target,
+      packageRoot: pkgRoot,
+      dryRun: true,
+    });
+    expect(r.success).toBe(true);
+    expect(r.stats.copied.length).toBeGreaterThan(0);
+    // But nothing actually got written
+    expect(existsSync(path.join(target, '.jumpstart', 'config.yaml'))).toBe(false);
+    expect(existsSync(path.join(target, 'AGENTS.md'))).toBe(false);
+  });
+
+  it('creates greenfield directory scaffold (specs + src + tests)', async () => {
+    await installBootstrap({
+      targetDir: target,
+      packageRoot: pkgRoot,
+      projectType: 'greenfield',
+    });
+    expect(existsSync(path.join(target, 'specs', 'decisions'))).toBe(true);
+    expect(existsSync(path.join(target, 'specs', 'research'))).toBe(true);
+    expect(existsSync(path.join(target, 'specs', 'insights'))).toBe(true);
+    expect(existsSync(path.join(target, 'src'))).toBe(true);
+    expect(existsSync(path.join(target, 'tests'))).toBe(true);
+  });
+
+  it('creates brownfield directory scaffold (specs only — preserves existing src/tests)', async () => {
+    // Brownfield: pre-existing src/tests with content; installer must NOT
+    // touch them (only specs/* gets scaffolded).
+    mkdirSync(path.join(target, 'src'), { recursive: true });
+    writeFileSync(path.join(target, 'src', 'existing.ts'), 'export {};\n');
+
+    await installBootstrap({
+      targetDir: target,
+      packageRoot: pkgRoot,
+      projectType: 'brownfield',
+    });
+
+    expect(existsSync(path.join(target, 'specs', 'decisions'))).toBe(true);
+    // Pre-existing user code survives
+    expect(readFileSync(path.join(target, 'src', 'existing.ts'), 'utf8')).toBe('export {};\n');
+  });
+
+  it('seeds .jumpstart/state/timeline.json on first run, idempotent on rerun', async () => {
+    await installBootstrap({ targetDir: target, packageRoot: pkgRoot });
+    const timelinePath = path.join(target, '.jumpstart', 'state', 'timeline.json');
+    expect(existsSync(timelinePath)).toBe(true);
+    const seedContent = readFileSync(timelinePath, 'utf8');
+    expect(seedContent).toContain('phase_start');
+
+    // Rerun should NOT overwrite the existing timeline
+    await installBootstrap({ targetDir: target, packageRoot: pkgRoot });
+    expect(readFileSync(timelinePath, 'utf8')).toBe(seedContent);
+  });
+
+  it('seeds .jumpstart/usage-log.json on first run', async () => {
+    await installBootstrap({ targetDir: target, packageRoot: pkgRoot });
+    const usagePath = path.join(target, '.jumpstart', 'usage-log.json');
+    expect(existsSync(usagePath)).toBe(true);
+    const usage = JSON.parse(readFileSync(usagePath, 'utf8'));
+    expect(usage.entries).toEqual([]);
+    expect(usage.total_tokens).toBe(0);
+  });
+
+  it('exports the canonical INTEGRATION_FILES + MERGEABLE_INTEGRATION_FILES constants', () => {
+    expect(INTEGRATION_FILES).toEqual(['AGENTS.md', 'CLAUDE.md', '.cursorrules']);
+    expect(MERGEABLE_INTEGRATION_FILES).toEqual(['AGENTS.md', 'CLAUDE.md']);
+    // .cursorrules is intentionally NOT mergeable (no merge semantics for it)
+    expect(MERGEABLE_INTEGRATION_FILES).not.toContain('.cursorrules');
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #50. Recovers the ~700 LoC install flow that was deleted from \`bin/cli.js\` in M11 phase 4 (#52) and ports it as a typed library module + a new citty subcommand.
- 5 files changed, +1,252 / -2

## What ships
- **\`src/lib/install-bootstrap.ts\`** (~700 LoC) — pure-library port. Public exports: \`installBootstrap\`, \`detectProjectType\`, \`detectConflicts\`, \`buildMergedInstructionBlock\`, \`mergeInstructionDocument\`, \`INTEGRATION_FILES\`, \`MERGEABLE_INTEGRATION_FILES\`
- **\`bootstrap\` citty subcommand** in \`src/cli/commands/lifecycle.ts\` + wired into \`src/cli/main.ts\`. Args: positional \`targetDir\`, \`--name\`, \`--approver\`, \`--type\`, \`--conflict\`, \`--copilot\`, \`--force\`, \`--dry-run\`, \`--json\`
- **\`tests/test-install-bootstrap.test.ts\`** — 29 vitest cases covering all conflict strategies + idempotency + greenfield/brownfield scaffolding + skip-warning semantics
- **\`docs/upgrade-to-2.0.md\`** — §6 updated: drops the "deferred" caveat, documents the new subcommand

## Behavior parity vs legacy
- All conflict strategies preserve their 1.x semantics (\`skip\`, \`overwrite\`, \`merge\`)
- \`--conflict merge\` wraps user content with \`<!-- BEGIN JUMPSTART MERGE: <file> -->\` markers
- Reruns are idempotent — single block, no duplication (verified by test)
- \`--conflict skip\` persists \`.jumpstart/state/install-warnings.md\` when AGENTS.md/CLAUDE.md skipped
- \`INTEGRATION_FILES\` and \`MERGEABLE_INTEGRATION_FILES\` constants verbatim from legacy

## Hardening
- ADR-009 path-safety: \`installBootstrap\` gates every constructed write path through \`assertInsideRoot\`
- ADR-006: no \`process.exit\` in library code; citty throws on invalid args
- Regex-safe markers: file names with regex specials (e.g., \`a.b+c*.md\`) don't break the marker-replacement step

## Test plan
- [x] \`npx vitest run tests/test-install-bootstrap.test.ts\` → 29/29 green
- [x] \`npx tsc --noEmit\` → 0 errors with strict flags ON
- [x] \`npm run lint\` (biome) → 0 errors, 0 warnings
- [x] \`npm run verify-baseline\` 11/12 — local M9 cluster-files smoke flake (parallel-worker race; passes on CI runners — same as on \`main\`)
- [ ] CI green on PR

Closes #50