### PR TITLE
chore: drop stale $schema ref from .github/hooks/autonav.json

### DIFF
--- a/.github/hooks/autonav.json
+++ b/.github/hooks/autonav.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://code.visualstudio.com/schemas/copilot-hooks.json",
   "description": "AutoNav (JumpStart) VS Code workspace hooks for lifecycle guardrails, traceability, schema validation, and session analytics.",
   "hooks": {
     "SessionStart": [


### PR DESCRIPTION
## Summary
- The referenced URL \`https://code.visualstudio.com/schemas/copilot-hooks.json\` returns **404** — it was never published (or has been removed since the ref was added)
- VS Code surfaced this as a hint-level diagnostic on every editor session
- Removing the field has zero functional impact (the file is consumed by the AutoNav agent runtime, not VS Code's JSON schema engine)

## Test plan
- [x] \`node -e "JSON.parse(require('node:fs').readFileSync('.github/hooks/autonav.json','utf8'))"\` — parses cleanly
- [x] \`curl -sI https://code.visualstudio.com/schemas/copilot-hooks.json\` → 404 (confirms the URL is dead)
- [x] \`npx tsc --noEmit\` → 0 errors
- [x] \`npm run lint\` (biome) → 0 errors, 0 warnings
- [ ] CI green on PR