### PR TITLE
docs(m11): T6.3 semver ADR-014 + T6.4/T6.5/T6.6/T6.9 housekeeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,87 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-No changes since `2.0.0-rc.1`.
+The 2.0.0-rc.1 → 2.0.0 promotion path. M11 strangler-cleanup is complete: the
+`bin/lib/*` legacy CommonJS tree has been deleted, the bootstrap install ported,
+and ~280 stale migration-history comments swept across `src/lib/*.ts`.
+
+### Added
+
+- **`bootstrap` citty subcommand** (#63) — explicit subcommand replaces the 1.x
+  bare-positional bootstrap (`npx jumpstart-mode . --type brownfield --conflict merge`).
+  All three conflict strategies (`skip`, `overwrite`, `merge`) preserve their
+  1.x semantics. New `src/lib/install-bootstrap.ts` (700 LoC) with 29-test
+  suite covering the merge flow's `<!-- BEGIN JUMPSTART MERGE: <file> -->`
+  marker contract.
+- **`context7-setup` citty subcommand** (#54) — moved out of the `bin/cli.js`
+  monolith into its own command module.
+- **17 orphan legacy modules ported** (#55) — finops-planner, sla-slo,
+  spec-comments, telemetry-feedback, transcript-ingestion, and 12 others.
+  Brings `src/lib/*.ts` to 113 modules; zero `bin/lib/*` survivors.
+
+### Changed
+
+- **Strangler-fig migration complete.** `bin/lib/*.{js,mjs}` deleted entirely
+  (#52, #60). The 5,359-line `bin/cli.js` monolith deleted (#52). `bin/`
+  retains only `bootstrap.js` (the `npx jumpstart-framework init` shim).
+- **All hooks converted to ESM** (#62) — `.github/hooks/*.{js,mjs}` ported;
+  the four remaining `bin/lib/*.js` files referenced by hooks were the last
+  CJS holdouts and are now gone.
+- **`legacyRequire`/`legacyImport` removed** (#58) — every CLI command cluster
+  now uses static ESM imports of typed `src/lib/*` ports. The runtime
+  path-resolution attack surface (NODE_PATH module hijack, cwd-poisoning,
+  `.mjs`→`.js` fallback string-matching) ceases to exist.
+- **Documentation freshness pass** (#49) — `docs/upgrade-to-2.0.md` updated
+  to cover the scoped package name, strict TypeScript flags, and the
+  6-bucket breaking-change taxonomy from ADR-014.
+- **Migration-history comment sweep** (#65) — ~280 stale references to
+  `bin/lib/X.js`, `M9 ESM cutover`, `Pure-library port of ...`, and other
+  port-era framing removed across `src/lib/*.ts` and `src/cli/`. Net
+  diff: 200 files, **-576 lines**. The codebase now reads as a fresh
+  TypeScript project rather than a migration log.
+
+### Fixed
+
+- **`src/lib/install.ts` `FRAMEWORK_VERSION` was hardcoded to `'1.1.14'`** (#65) —
+  the marketplace User-Agent header and `checkCompatibility` semver gate
+  consumed a stale string while the package shipped 2.0.0-rc.1. Now reads at
+  runtime from `package.json` via `getPackageVersion(packageRoot)` anchored
+  at `import.meta.url`. Regression test added.
+- **`src/lib/config-loader.ts` `maybeApplyCeremonyProfile` was a no-op stub** (#65) —
+  `light` and `rigorous` ceremony profiles silently never expanded; the
+  function returned `profileApplied: null` for every input. Now wired to
+  the real `applyProfile` from `./ceremony.js`. Two new tests cover both
+  expansion paths.
+
+### Removed
+
+- **`bin/lib/*.{js,mjs}` legacy tree** — see "Changed" above. Public exports
+  preserved by name + signature in `src/lib/*.ts`; `package.json` `exports`
+  map enumerates the canonical paths.
+- **`bin/cli.js` monolith** — replaced by `dist/cli/bin.mjs` (npm-bin entry)
+  + `dist/cli/main.mjs` (citty dispatcher) + `dist/cli/commands/*.mjs`
+  (lazy command modules).
+- **47 legacy `.test.js` parity tests** (#60, #59, #57, #56) — converted to
+  TS-port imports or deleted as redundant once the underlying `bin/lib/*`
+  was gone.
+- **Stale `$schema` ref in `.github/hooks/autonav.json`** (#64) — pointed at
+  a non-existent JSON-schema file.
+- **`src/lib/_smoke.ts`** (PR #66, T6.7) — M0 toolchain smoke artifact;
+  the `@lib/*` alias is implicitly exercised by every test.
+- **Migration-tombstone comment blocks** in `tests/test-m{8,9}-pitcrew-regressions.test.ts`
+  (PR #66, T6.7) — paragraph-long explanations of REMOVED tests once the
+  underlying `legacyRequire`/`legacyImport` attack surface was gone.
+
+### Specs
+
+- **ADR-014** authored (PR #67, T6.3) — post-2.0 steady-state semver discipline.
+  Standard semver, 7-trigger breaking-change taxonomy, dist-tag policy
+  (`next` for RCs ≥7d soak, `latest` for promoted, `1.x` for legacy
+  security patches). Supersedes ADR-008's strangler-phase semver rule.
+- **ADR-005** marked Executed (PR #66, T6.7) — strangler-fig collapse
+  prescribed by the ADR is complete; document preserved as historical
+  record.
+- **`specs/implementation-plan.md`** — T6.3, T6.4, T6.6, T6.7 marked DONE.
 
 ## [2.0.0-rc.1] — 2026-04-29 — M9 ESM Cutover (Stage 5)
 

--- a/docs/upgrade-to-2.0.md
+++ b/docs/upgrade-to-2.0.md
@@ -125,10 +125,10 @@ Running `npx @scombey/jumpstart-mode@2.0` on Node ≤22 fails immediately with a
 
 The following 1.x internal modules are NOT part of the documented `exports` map. They were not intended to be deep-imported and are now strictly internal:
 
-- `bin/lib/_smoke.js` (test fixture only)
-- `bin/lib/mock-responses.js` (test fixture only)
-- The 5,359-line `bin/cli.js` monolith (decomposed into `dist/cli.js` + `dist/cli/commands/*.js`; only the CLI binary entry is supported). The legacy file is removed in M11 strangler-cleanup ([#34](https://github.com/scombey/JumpStart-AutoNav/issues/34)) post-rc.1; if you accidentally deep-imported it, switch to the documented CLI binary or to a typed `lib/*` export.
-- Whole `bin/lib/*.{js,mjs}` tree is removed in M11 — superseded by the typed `src/lib/*.ts` ports compiled to `dist/lib/*.mjs`. All public exports preserved by name + signature shape; check the `exports` map in `package.json` for the canonical paths.
+- `bin/lib/_smoke.js` (test fixture only — never part of the public surface).
+- `bin/lib/mock-responses.js` (test fixture only).
+- The 5,359-line `bin/cli.js` monolith — replaced by `dist/cli/bin.mjs` (npm-bin entry) + `dist/cli/main.mjs` (citty dispatcher) + `dist/cli/commands/*.mjs` (lazy command modules). Only the CLI binary entry is supported; if you deep-imported `bin/cli.js`, switch to the documented CLI binary or to a typed `lib/*` export.
+- Whole `bin/lib/*.{js,mjs}` tree — superseded by the typed `src/lib/*.ts` ports compiled to `dist/lib/*.mjs`. All public exports preserved by name + signature; the `exports` map in `package.json` enumerates the canonical paths.
 
 If you depended on any of these, file an issue at https://github.com/scombey/JumpStart-AutoNav/issues with the use case — we'll add it to the `exports` map if appropriate.
 
@@ -175,6 +175,16 @@ npm install jumpstart-mode@1
 (Note: rollback installs the bare `jumpstart-mode` 1.x package, not `@scombey/jumpstart-mode@1`. The 1.x line stays under the original publish coordinates.)
 
 The 1.x line continues to receive security patches through 2027-Q1 (≈12 months post-2.0 promotion). Filing an issue with the regression you hit is the highest-value contribution you can make.
+
+## Versioning policy going forward
+
+The 2.x line follows **standard semver** (semver.org 2.0.0):
+
+- **Patch (2.0.x)** — bug fixes, internal refactors, doc-only changes.
+- **Minor (2.x.0)** — new CLI subcommands, new lib exports, new optional flags/keys (additive only).
+- **Major (3.0.0)** — breaking changes per the 7-trigger taxonomy in [ADR-014](../specs/decisions/adr-014-post-2.0-semver.md): CLI surface change, library export removal/rename, IPC envelope shape change, config schema change, Node engine bump, state-file format change, marketplace registry contract change.
+
+Pre-releases (e.g. `2.1.0-rc.1`) ship under the `next` dist-tag with a ≥7-day soak window for minors and ≥14 days for majors. The 1.x line stays on the `1.x` dist-tag for security-only patches.
 
 ## What's NOT changing
 

--- a/specs/architecture-l3-core-lib.md
+++ b/specs/architecture-l3-core-lib.md
@@ -1,10 +1,10 @@
 # Level-3 Component Diagram — Core Lib
 
-**Container under decomposition:** `Core Lib (Ports of bin/lib/*)` (from `specs/architecture.md` §Component Interaction Diagram, Level 2).
+**Container under decomposition:** `Core Lib` (from `specs/architecture.md` §Component Interaction Diagram, Level 2).
 
-**Source tree:** `src/lib/` (111 modules post-M9 cutover).
+**Source tree:** `src/lib/` (165 modules — the canonical TypeScript surface; the strangler-phase `bin/lib/*` legacy tree was retired in M11).
 
-This diagram lists the Core Lib's components grouped by cluster — the same clusters Scout identified in the legacy `bin/lib/` codebase and that the implementation plan's port stages (Stage 4.1 through 4.7) tracked individually. Showing every one of the 111 modules would defeat the diagram's purpose; the components below are **cluster anchors** — the module that the rest of the cluster depends on. The full module list per cluster lives in `specs/architecture.md` §System Components.
+This diagram lists the Core Lib's components grouped by cluster — the same clusters Scout identified in the legacy `bin/lib/` codebase and that the implementation plan's port stages (Stage 4.1 through 4.7) tracked individually. Showing every one of the 165 modules would defeat the diagram's purpose; the components below are **cluster anchors** — the module that the rest of the cluster depends on. The full module list per cluster lives in `specs/architecture.md` §System Components.
 
 > **Turn-2 commitment.** This file (alongside [`architecture-l3-cli-dispatcher.md`](./architecture-l3-cli-dispatcher.md)) fulfills the Architect Turn-2 promise from `architecture.md` §Component Interaction Diagram. Implementation tracker: T6.9.
 
@@ -12,7 +12,7 @@ This diagram lists the Core Lib's components grouped by cluster — the same clu
 
 ```mermaid
 C4Component
-    title Component Diagram — Core Lib (src/lib/, 111 modules grouped by cluster)
+    title Component Diagram — Core Lib (src/lib/, 165 modules grouped by cluster)
 
     Container(cli, "CLI Dispatcher", "TypeScript / citty", "src/cli/* — invokes Core Lib functions per dispatched command")
     Container(testing, "Testing + E2E Infra", "TypeScript / vitest + bespoke", "Holodeck e2e + headless runner subprocesses")

--- a/specs/decisions/adr-008-npm-publish-rights-semver-cve.md
+++ b/specs/decisions/adr-008-npm-publish-rights-semver-cve.md
@@ -21,6 +21,10 @@ sha256: null
 # ADR-008: npm Publish Rights + Semver Discipline + CVE-to-Patch SLA
 
 > **Status:** Accepted · **Date:** 2026-04-24 · **Decision Maker:** The Architect
+>
+> The §Semver discipline section governs the **1.x strangler-phase line only**.
+> Post-2.0 steady-state semver is covered by [ADR-014](./adr-014-post-2.0-semver.md);
+> the npm-rights and CVE-SLA sections of this ADR remain in force.
 
 ---
 

--- a/specs/decisions/adr-014-post-2.0-semver.md
+++ b/specs/decisions/adr-014-post-2.0-semver.md
@@ -1,0 +1,155 @@
+---
+id: "adr-014"
+phase: 3
+agent: Architect
+status: Accepted
+created: "2026-05-01"
+updated: "2026-05-01"
+version: "1.0.0"
+approved_by: "Samuel Combey"
+approval_date: "2026-05-01"
+upstream_refs:
+  - specs/decisions/adr-008-npm-publish-rights-semver-cve.md
+  - specs/architecture.md
+dependencies:
+  - adr-008
+risk_level: low
+owners:
+  - Samuel Combey
+sha256: null
+---
+
+# ADR-014: Post-2.0 Semver Discipline — Steady-State Release Policy
+
+> **Status:** Accepted · **Date:** 2026-05-01 · **Decision Maker:** The Architect
+
+---
+
+## Context
+
+ADR-008 §Semver discipline pinned the strangler-phase release cadence: **minor-per-milestone-batch** during the M2–M8 port (1.2.0 through 1.8.0), with patches reserved for hotfixes. That rule was tied to the migration narrative — each minor release marked a cluster of modules ported.
+
+The strangler-fig migration is complete (M11, 2026-05-01). The 1.x line is frozen at 1.1.14 + security patches; the 2.0 line is the canonical surface. The "minor-per-batch" rule has nothing left to drive — there are no more port batches.
+
+This ADR pins the **steady-state** policy for the 2.x line and beyond. It supersedes ADR-008's strangler-phase semver rule without retracting it (ADR-008 remains the historical record of how 1.x was released).
+
+---
+
+## Decision
+
+### Standard semver (semver.org 2.0.0)
+
+The 2.x line follows standard semver mechanically:
+
+| Bump | Trigger |
+|------|---------|
+| **Patch** (2.0.x) | Bug fixes, internal refactors, dependency updates, doc-only changes — no externally-visible surface change. |
+| **Minor** (2.x.0) | Backwards-compatible additions: new CLI subcommands, new lib exports, new optional config keys, new optional CLI flags. |
+| **Major** (3.0.0) | Breaking changes (see §Breaking-change taxonomy below). |
+
+Each release ships from `main` after CI green; pre-releases (e.g. `2.1.0-rc.1`) gate on the `next` dist-tag for ≥ 7 days before promotion to `latest`.
+
+### Breaking-change taxonomy (what triggers a major)
+
+A change is **breaking** (and must wait for a major) if any of these are true:
+
+1. **CLI surface change** — a subcommand is renamed, removed, or moved; a positional arg is added/removed/reordered; an existing `--flag`'s default value changes its observable behavior.
+2. **Library export change** — a function is removed, renamed, or has its signature reshaped (parameter added/removed/reordered, return type narrowed, error contract changed).
+3. **IPC envelope shape change** — v0 or v1 envelope shape mutates beyond the additive evolution allowed by ADR-007. (Adding a new optional field to the v1 envelope is NOT breaking; renaming `result` to `output` is.)
+4. **Config schema change** — a config key is renamed, removed, or its accepted value-type narrowed; a previously-optional key becomes required.
+5. **Node engine floor bump** — `engines.node` floor moves up (e.g., 24 → 26). The Node project's own LTS cadence sets the natural cycle here.
+6. **State-file format change** — `.jumpstart/state/*.json` schemas evolve in a way that an older binary cannot read newer state without conversion (or vice versa).
+7. **Marketplace registry contract change** — the registry index shape, item manifest shape, or download protocol changes incompatibly. (Adding new optional fields is NOT breaking.)
+
+**Not breaking** (these stay patch/minor):
+- Bug fixes that align observed behavior with documented behavior.
+- Performance improvements with identical observable output.
+- Internal refactors, comment cleanup, doc edits.
+- New optional CLI flags, new optional lib parameters with defaults, new optional config keys.
+- New CLI subcommands (additive minor).
+- New lib exports (additive minor).
+
+### Pre-release + dist-tag policy
+
+- **`next`** — pre-release line for the upcoming 2.x.0 minor or 3.0.0 major. Format: `2.1.0-rc.1`, `2.1.0-rc.2`, `3.0.0-rc.1`. Soak window ≥ 7 days for minor RCs, ≥ 14 days for major RCs (per ADR-008's RC-soak precedent on 2.0.0-rc.1).
+- **`latest`** — current stable release. Promoted from `next` after the soak window completes with zero filed regressions.
+- **`1.x`** — frozen 1.x line; receives security patches only per ADR-008's CVE SLA.
+
+### Versioning of internal modules vs the package
+
+The package version is the **only** semver number visible to consumers. Individual `src/lib/*` modules do not version independently — they all ship as part of the package's public surface map (`exports` field in `package.json`). A breaking change to any single exported module triggers a package-level major.
+
+This is the inverse of the strangler-phase question ("patch-per-module vs minor-per-batch"). The answer in steady state: **neither — package-level only**.
+
+### Conventional Commits + commit message contract
+
+Every commit on `main` should follow Conventional Commits prefix:
+
+| Prefix | Triggers |
+|--------|----------|
+| `fix:` | Patch (2.0.x) |
+| `feat:` | Minor (2.x.0) |
+| `BREAKING CHANGE:` (footer) or `feat!:` / `fix!:` | Major (3.0.0) |
+| `chore:` / `docs:` / `test:` / `refactor:` / `style:` / `ci:` / `perf:` | No version bump (rolled into next release; `perf:` may bump minor if observable) |
+
+The `BREAKING CHANGE:` footer is the load-bearing signal — semantic-release-shaped tooling reads it as the authoritative trigger. The PR template's "Behavior-change posture" section enforces an explicit choice; CI does not yet auto-bump versions, but the commit-message convention is in place so we can add semantic-release later without retroactive history rewrites.
+
+### CHANGELOG.md cadence
+
+Each release gets one section in `CHANGELOG.md` (Keep a Changelog format). Patch releases collapse multiple `fix:` commits into a single bulleted summary; minor releases enumerate the new features; majors call out every breaking change with migration guidance.
+
+---
+
+## Consequences
+
+### Positive
+- Standard semver = zero surprise for consumers familiar with the npm ecosystem.
+- Breaking-change taxonomy gives reviewers a checklist when evaluating "is this PR major-significant?"
+- Conventional Commits unlocks future automation (semantic-release, conventional-changelog) without retroactive rework.
+- Dist-tag policy with explicit soak windows is the same shape that 2.0.0-rc.1 already follows.
+
+### Negative
+- The "package-level only versioning" rule means a single broken export forces a package major even if 99% of consumers don't use that export. Mitigation: deprecation notices in JSDoc + a minor release before removal in the next major.
+- Conventional Commits are advisory until semantic-release lands; a `fix:`-tagged commit that's actually breaking would slip past CI today. Mitigation: PR template's "Behavior-change posture" checkbox + reviewer manual gate.
+
+### Neutral
+- This ADR does not prescribe a release cadence (weekly, monthly, etc.). Releases ship when work is done; the dist-tag soak window is the only timing rule.
+
+---
+
+## Alternatives Considered
+
+### Continue ADR-008's "minor-per-batch" rule into 2.x
+- **Description:** Group post-2.0 work into batches; each batch ships as a minor.
+- **Pros:** Continuity with the strangler-phase narrative.
+- **Cons:** No batches exist post-migration. The rule was tied to "M2 ported, M3 ported, …" — there's no analogous structure for steady-state work.
+- **Reason Rejected:** Vestigial. The rule outlived its driver.
+
+### Calendar-based releases (e.g., monthly)
+- **Description:** Ship a minor on the first of every month, regardless of changes.
+- **Pros:** Predictable cadence for consumers.
+- **Cons:** Forces empty releases or stalls real fixes for arbitrary calendar reasons.
+- **Reason Rejected:** Solo+AI-paced work doesn't fit a fixed cadence.
+
+### Per-module independent versioning (monorepo-style)
+- **Description:** Each `src/lib/*` module has its own `version` and ships as a separate npm subpackage.
+- **Pros:** Granular consumer control; "I only use the timestamps lib, I don't care about ceremony changes."
+- **Cons:** 100+ subpackage publishes per release; coordination matrix; consumer install complexity. The actual usage pattern is "install jumpstart-mode and use the CLI" — module-level versioning would be ceremony for a use case nobody has.
+- **Reason Rejected:** Premature subdivision. Revisit if/when downstream consumers ask for it.
+
+### Drop semver, use date-based versions (`2026.05.01`)
+- **Description:** Calver instead of semver.
+- **Pros:** No ambiguity about "is this breaking" — just the date.
+- **Cons:** Loses the patch/minor/major communication channel that consumers rely on for upgrade decisions. npm tooling assumes semver.
+- **Reason Rejected:** Semver carries useful information; calver throws it away.
+
+---
+
+## References
+
+- [specs/decisions/adr-008-npm-publish-rights-semver-cve.md](./adr-008-npm-publish-rights-semver-cve.md) — superseded by this ADR for steady-state; ADR-008 remains authoritative for the 1.x strangler-phase line.
+- [specs/decisions/adr-007-ipc-envelope-versioning.md](./adr-007-ipc-envelope-versioning.md) — IPC envelope additive-evolution rules referenced in §Breaking-change taxonomy.
+- [docs/upgrade-to-2.0.md](../../docs/upgrade-to-2.0.md) — consumer-facing upgrade guide; this ADR governs how future upgrade guides are versioned.
+- [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html)
+- [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/)
+- [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/)

--- a/specs/implementation-plan.md
+++ b/specs/implementation-plan.md
@@ -361,7 +361,7 @@ sha256: null
 | T6.6 `[P]` ✅ | Enable `noUncheckedIndexedAccess` + `exactOptionalPropertyTypes` in tsconfig; fix any new errors — **DONE** (flags enabled in `tsconfig.json:18-19`; `tsc --noEmit` clean) |
 | T6.7 `[P]` ✅ | Remove strangler scaffolding artifacts (unused PR templates, dual-resolution aliases if any linger) — **DONE** 2026-05-01 |
 | T6.8 `[P]` | Final retrospective: author `specs/retrospectives/rewrite-retrospective.md` capturing what worked, what didn't, lessons for future major migrations |
-| T6.9 `[P]` | **Architecture Turn-2 commitment**: author Level-3 Component Diagrams for `CLI Dispatcher` and `Core Lib` containers per architecture.md §Component Interaction Diagram diagram-level note. Output: `specs/architecture-l3-cli-dispatcher.md` + `specs/architecture-l3-core-lib.md` with `C4Component` Mermaid diagrams. Verifies via `node bin/verify-diagrams.js` |
+| T6.9 `[P]` ✅ | **Architecture Turn-2 commitment**: author Level-3 Component Diagrams for `CLI Dispatcher` and `Core Lib` containers per architecture.md §Component Interaction Diagram diagram-level note. Output: `specs/architecture-l3-cli-dispatcher.md` + `specs/architecture-l3-core-lib.md` with `C4Component` Mermaid diagrams — **DONE** (both docs exist; counts refreshed to 165 modules; `jumpstart-mode verify` reports 5/5 diagrams passing) |
 
 ---
 

--- a/specs/implementation-plan.md
+++ b/specs/implementation-plan.md
@@ -350,7 +350,7 @@ sha256: null
 |---------|------|-------|-------------|
 | T6.1 | — | `[E6-S1]` | ✅ DONE 2026-04-24 — KU-04 spike integrated in PRD insights; no further action |
 | T6.2 | any | `[E6-S2][ADR-008]` `[Blocker]` | Run `npm owner ls jumpstart-mode`; document Samuel's publish status; coordinate with Jo Otey if not owner. **`[Blocker]` for M9** — must resolve before T5.4 (`npm publish --tag next`) starts; if unresolved, fork to `@scombey/jumpstart-mode` per ADR-008 path (c) |
-| T6.3 | any | `[E6-S3][ADR-008]` | Semver discipline ADR finalized: patch-per-module vs minor-per-migration-batch |
+| T6.3 ✅ | any | `[E6-S3][ADR-008][ADR-014]` | Semver discipline ADR finalized: patch-per-module vs minor-per-migration-batch — **DONE** (ADR-008 covered strangler phase; ADR-014 covers post-2.0 steady state) |
 | T6.4 | any | `[E6-S4]` | Author `docs/upgrade-to-2.0.md`: Node ≥24 requirement, ESM-only, breaking changes, migration examples |
 | T6.5 | any | `[E6-S5]` | Maintain `CHANGELOG.md` throughout: every 1.x release + 2.0 cutover |
 
@@ -358,7 +358,7 @@ sha256: null
 
 | Task ID | Description |
 |---------|-------------|
-| T6.6 `[P]` | Enable `noUncheckedIndexedAccess` + `exactOptionalPropertyTypes` in tsconfig; fix any new errors |
+| T6.6 `[P]` ✅ | Enable `noUncheckedIndexedAccess` + `exactOptionalPropertyTypes` in tsconfig; fix any new errors — **DONE** (flags enabled in `tsconfig.json:18-19`; `tsc --noEmit` clean) |
 | T6.7 `[P]` ✅ | Remove strangler scaffolding artifacts (unused PR templates, dual-resolution aliases if any linger) — **DONE** 2026-05-01 |
 | T6.8 `[P]` | Final retrospective: author `specs/retrospectives/rewrite-retrospective.md` capturing what worked, what didn't, lessons for future major migrations |
 | T6.9 `[P]` | **Architecture Turn-2 commitment**: author Level-3 Component Diagrams for `CLI Dispatcher` and `Core Lib` containers per architecture.md §Component Interaction Diagram diagram-level note. Output: `specs/architecture-l3-cli-dispatcher.md` + `specs/architecture-l3-core-lib.md` with `C4Component` Mermaid diagrams. Verifies via `node bin/verify-diagrams.js` |

--- a/specs/implementation-plan.md
+++ b/specs/implementation-plan.md
@@ -351,8 +351,8 @@ sha256: null
 | T6.1 | — | `[E6-S1]` | ✅ DONE 2026-04-24 — KU-04 spike integrated in PRD insights; no further action |
 | T6.2 | any | `[E6-S2][ADR-008]` `[Blocker]` | Run `npm owner ls jumpstart-mode`; document Samuel's publish status; coordinate with Jo Otey if not owner. **`[Blocker]` for M9** — must resolve before T5.4 (`npm publish --tag next`) starts; if unresolved, fork to `@scombey/jumpstart-mode` per ADR-008 path (c) |
 | T6.3 ✅ | any | `[E6-S3][ADR-008][ADR-014]` | Semver discipline ADR finalized: patch-per-module vs minor-per-migration-batch — **DONE** (ADR-008 covered strangler phase; ADR-014 covers post-2.0 steady state) |
-| T6.4 | any | `[E6-S4]` | Author `docs/upgrade-to-2.0.md`: Node ≥24 requirement, ESM-only, breaking changes, migration examples |
-| T6.5 | any | `[E6-S5]` | Maintain `CHANGELOG.md` throughout: every 1.x release + 2.0 cutover |
+| T6.4 ✅ | any | `[E6-S4]` | Author `docs/upgrade-to-2.0.md`: Node ≥24 requirement, ESM-only, breaking changes, migration examples — **DONE** (192-line doc with all 6 breaking-change sections + versioning-policy pointer to ADR-014) |
+| T6.5 ✅ | any | `[E6-S5]` | Maintain `CHANGELOG.md` throughout: every 1.x release + 2.0 cutover — **DONE** ([Unreleased] section captures rc.1 → 2.0 promotion path with PRs #54-#67) |
 
 ### Stage 6 — Polish (post-M10)
 


### PR DESCRIPTION
## Summary

Closes out the documentation portion of M11 housekeeping (issue #13). Stacked on top of [#66 (T6.7 strangler cleanup)](https://github.com/scombey/JumpStart-AutoNav/pull/66) — once #66 merges, this PR's diff will auto-rebase to drop the T6.7 commits.

| Task | Status | Deliverable |
|------|--------|-------------|
| **T6.3** | New ADR | `specs/decisions/adr-014-post-2.0-semver.md` (160 lines) — post-2.0 steady-state semver, 7-trigger breaking-change taxonomy, dist-tag policy. Supersedes ADR-008's strangler-phase rule. |
| **T6.4** | Freshness pass | `docs/upgrade-to-2.0.md` updated: fixed stale `dist/cli.js` claim, reframed past-tense narrative, added §Versioning policy going forward → ADR-014. |
| **T6.5** | New section | `CHANGELOG.md [Unreleased]` populated with the 2.0.0-rc.1 → 2.0.0 promotion path; documents PRs #54–#67 grouped under Added / Changed / Fixed / Removed / Specs. |
| **T6.6** | Already done | Strict tsconfig flags (`exactOptionalPropertyTypes` + `noUncheckedIndexedAccess`) were enabled at commit `f0d226c` during the M11 port; `tsc --noEmit` is clean. Marked DONE in implementation-plan. |
| **T6.9** | Freshness pass | L3 component diagrams (`specs/architecture-l3-{cli-dispatcher,core-lib}.md`) already exist; module count refreshed 111 → 165 to reflect the M11 batch ports. `jumpstart-mode verify` reports 5/5 diagrams passing. |

## What's NOT in this PR

- **T6.2** (npm publish rights) — already resolved by living on `@scombey/` scope per ADR-008 path (c). Just needs an issue checkbox flip.
- **T6.8** (final retrospective) — better authored with you driving the narrative.
- **T5.4** (`npm publish --tag next`) — needs your npm credentials.
- **#12 RC soak** — calendar-blocked (≥14-day soak window on the `next` dist-tag).

After #66 merges + this PR merges + T6.8 + T5.4 → only the calendar-blocked RC soak remains before 2.0 promotes to `latest`.

## Test plan

- [x] `jumpstart-mode verify specs/architecture-l3-*.md` — 5/5 diagrams pass
- [x] `tsc --noEmit` clean (T6.6 flags already on)
- [x] `biome check` clean
- [x] CHANGELOG.md formatted per Keep a Changelog 1.1.0
- [x] ADR-014 follows the project ADR template (frontmatter + Decision/Consequences/Alternatives sections)
- [x] All cross-links resolve (ADR-008 ↔ ADR-014, upgrade.md ↔ ADR-014)