### PR TITLE
chore: drop deprecated tsconfig `baseUrl`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,9 +33,8 @@
     "noEmit": true,
     "incremental": true,
 
-    "baseUrl": ".",
     "paths": {
-      "@lib/*": ["src/lib/*"]
+      "@lib/*": ["./src/lib/*"]
     }
   },
   "include": [


### PR DESCRIPTION
## Summary

VS Code surfaced a TS deprecation warning on `tsconfig.json:36`:

> Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.

`baseUrl` is no longer required for `paths` resolution in TS 5+: paths resolve relative to the tsconfig file's directory by default. Dropped `baseUrl: "."` and rewrote the `@lib/*` glob to be explicitly tsconfig-relative (`./src/lib/*`) so resolution stays unambiguous after the option is removed.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `tsdown` build emits 744 files (unchanged)
- [x] Full vitest suite **3047/3047** pass (sequential)
- [x] No actual runtime imports use `@lib/*` today (only two example lines inside a JSDoc comment in `src/lib/config-loader.ts`); the alias stays in place since downstream consumers may rely on it via the `exports` map