### PR TITLE
test: fix parallel-mode vitest race with build coordinator + globalSetup

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -11,6 +11,7 @@
       "src/**/*.ts",
       "scripts/**/*.mjs",
       "tests/**/*.test.ts",
+      "tests/helpers/**/*.ts",
       "tsdown.config.ts",
       "biome.json",
       "tsconfig.json",

--- a/tests/helpers/ensure-dist-built.ts
+++ b/tests/helpers/ensure-dist-built.ts
@@ -1,0 +1,55 @@
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+const REQUIRED_DIST_FILES = [
+  'cli/bin.mjs',
+  'cli/main.mjs',
+  'cli/main.d.mts',
+  'cli/main.mjs.map',
+  'cli/commands/_helpers.mjs',
+  'cli/commands/_helpers.d.mts',
+  'cli/commands/_helpers.mjs.map',
+  'cli/commands/cleanup.mjs',
+  'cli/commands/cleanup.d.mts',
+  'cli/commands/cleanup.mjs.map',
+  'lib/io.mjs',
+  'lib/io.d.mts',
+  'lib/io.mjs.map',
+];
+
+function sleep(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+export function ensureDistBuilt(repoRoot: string): void {
+  const distDir = path.join(repoRoot, 'dist');
+  const hasRequiredFiles = () =>
+    REQUIRED_DIST_FILES.every((relPath) => existsSync(path.join(distDir, relPath)));
+
+  if (hasRequiredFiles()) return;
+
+  const repoHash = createHash('sha1').update(repoRoot).digest('hex');
+  const lockDir = path.join(tmpdir(), `jumpstart-dist-build-${repoHash}.lock`);
+
+  while (true) {
+    try {
+      mkdirSync(lockDir);
+      break;
+    } catch (err) {
+      if (hasRequiredFiles()) return;
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+      sleep(100);
+    }
+  }
+
+  try {
+    if (!hasRequiredFiles()) {
+      execFileSync('npx', ['tsdown'], { cwd: repoRoot, stdio: 'pipe' });
+    }
+  } finally {
+    rmSync(lockDir, { recursive: true, force: true });
+  }
+}

--- a/tests/helpers/global-setup.ts
+++ b/tests/helpers/global-setup.ts
@@ -1,0 +1,19 @@
+/**
+ * Vitest global-setup hook — runs once before any test file is loaded.
+ *
+ * Ensures `dist/` is built so tests that import from `dist/` (either
+ * directly or via re-importing source modules that load dist artifacts
+ * at module-evaluation time, e.g. `tests/test-hooks.test.js` →
+ * `.github/hooks/*.mjs` → `dist/lib/validator.mjs`) don't race the
+ * tsdown invocations from `tests/test-build-smoke.test.ts` and
+ * `tests/test-m9-pitcrew-regressions.test.ts`.
+ *
+ * The helper is mkdir-locked, so multiple vitest workers calling it in
+ * parallel coordinate through a single tsdown invocation.
+ */
+
+import { ensureDistBuilt } from './ensure-dist-built.js';
+
+export default function setup(): void {
+  ensureDistBuilt(process.cwd());
+}

--- a/tests/test-build-smoke.test.ts
+++ b/tests/test-build-smoke.test.ts
@@ -13,10 +13,10 @@
  * @see specs/decisions/adr-001-build-tool.md
  */
 
-import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { beforeAll, describe, expect, it } from 'vitest';
+import { ensureDistBuilt } from './helpers/ensure-dist-built.js';
 
 const repoRoot = process.cwd();
 const distDir = path.join(repoRoot, 'dist');
@@ -27,9 +27,7 @@ function exists(rel: string): boolean {
 
 describe('build smoke (tsdown emit pipeline)', () => {
   beforeAll(() => {
-    // execFileSync (not execSync) avoids shell interpolation — safe per
-    // the codebase's child_process pattern guidance.
-    execFileSync('npx', ['tsdown'], { cwd: repoRoot, stdio: 'pipe' });
+    ensureDistBuilt(repoRoot);
   }, 60_000);
 
   it('emits dist/cli/bin.mjs with shebang preserved', () => {

--- a/tests/test-m9-pitcrew-regressions.test.ts
+++ b/tests/test-m9-pitcrew-regressions.test.ts
@@ -57,6 +57,7 @@ import { mergeTemplatesImpl } from '../src/cli/commands/enterprise.js';
 import { diffImpl } from '../src/cli/commands/handoff.js';
 import { createTestDeps } from '../src/cli/deps.js';
 import { gatherDashboardData } from '../src/lib/dashboard.js';
+import { ensureDistBuilt } from './helpers/ensure-dist-built.js';
 
 const repoRoot = process.cwd();
 const distDir = path.join(repoRoot, 'dist');
@@ -68,9 +69,7 @@ function distExists(rel: string): boolean {
 // Build dist/ once so the bin.ts and cluster-emit checks have something
 // to inspect. The build-smoke test does this too; we share the artifact.
 beforeAll(() => {
-  if (!existsSync(path.join(distDir, 'cli', 'bin.mjs'))) {
-    execFileSync('npx', ['tsdown'], { cwd: repoRoot, stdio: 'pipe' });
-  }
+  ensureDistBuilt(repoRoot);
 }, 60_000);
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,7 @@
     "src/**/*.ts",
     "scripts/**/*.mjs",
     "tests/**/*.test.ts",
+    "tests/helpers/**/*.ts",
     "tsdown.config.ts",
     "vitest.config.mjs"
   ],

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -15,6 +15,11 @@ export default defineConfig({
     root: '.',
     include: ['tests/**/*.test.{js,ts}'],
     exclude: [],
+    // Build dist/ once before any test file loads. Several tests import
+    // from `dist/` at module-evaluation time (e.g., `test-hooks.test.js`
+    // → `.github/hooks/*.mjs` → `dist/lib/validator.mjs`); per-test
+    // `beforeAll` guards run too late for those imports.
+    globalSetup: ['tests/helpers/global-setup.ts'],
     testTimeout: 10000,
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary

Three tests have been racing to build `dist/` since the M11 layout shifted.

`tests/test-build-smoke.test.ts` and `tests/test-m9-pitcrew-regressions.test.ts` both invoked \`npx tsdown\` from their own `beforeAll` hooks. Under vitest's default file-parallelism, the two `tsdown` invocations raced to write `dist/` and one would always fail with half-written artefacts.

A third test surfaced a deeper variant once the helper landed: \`tests/test-hooks.test.js\` imports \`.github/hooks/schema-on-write-validator.mjs\` which imports \`dist/lib/validator.mjs\` at **module-evaluation time**. A per-test `beforeAll` guard runs too late for that path — the import error fires before `beforeAll` ever executes.

## Fix in two layers

### 1. `tests/helpers/ensure-dist-built.ts` — mkdir-locked tsdown coordinator

- Lockdir lives in `os.tmpdir()` keyed on `sha1(repoRoot)` so concurrent vitest workers serialise on a single `npx tsdown` invocation.
- `Atomics.wait` on a `SharedArrayBuffer` gives a real cross-worker sleep without a busy poll.
- Verifies the 13 load-bearing dist artefacts before claiming the build is fresh.

### 2. `tests/helpers/global-setup.ts` + vitest `globalSetup`

- Runs the helper exactly once before any test file is loaded.
- Covers import-time consumers like the hooks test that can't be fixed via `beforeAll`.

The two existing direct callers (`test-build-smoke.test.ts` and `test-m9-pitcrew-regressions.test.ts`) keep the helper invocation as defence-in-depth; both become no-ops once globalSetup has run.

## Build-system housekeeping

`biome.json` and `tsconfig.json` `include` globs extended to match `tests/helpers/**/*.ts` (was `tests/**/*.test.ts` only). Biome now lints 304 files (was 294); tsc covers the helper through both the include glob and the existing import chain.

## Verification

- [x] `npx vitest run` (parallel, no flag) — **3047/3047** pass cleanly
- [x] `npm run verify-baseline` — **12/12 gates green** (was 11/12 due to vitest-full-suite flakily missing dist files in the parallel race)
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check src/ tests/ scripts/` clean

## Why this matters beyond CI

CI was already passing because `.github/workflows/typescript.yml` runs `npm run build` before `npx vitest run --coverage`. The race only bit local development:
- `npm run verify-baseline` runs vitest **before** tsdown, so it always reported 11/12 on a fresh clone
- Contributors saw mysterious "Cannot find module" failures on first `npm test`

Both flake paths are now closed.